### PR TITLE
Add dynamic terror info panel

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -37,6 +37,8 @@ namespace ToNRoundCounter
 
         // 情報表示パネル
         public InfoPanel InfoPanel { get; private set; }
+        private TerrorInfoPanel terrorInfoPanel;
+        private JObject terrorInfoData;
 
         // 統計情報表示およびラウンドログ表示は SplitContainer で実装（縦に並べる）
         private SplitContainer splitContainerMain;
@@ -208,6 +210,7 @@ namespace ToNRoundCounter
             roundMapNames = new Dictionary<string, string>();
             terrorMapNames = new Dictionary<string, Dictionary<string, string>>();
             roundLogHistory = new List<Tuple<RoundData, string>>();
+            LoadTerrorInfo();
             AppSettings.Load();
             InitializeComponents();
             this.Load += MainForm_Load;
@@ -287,6 +290,13 @@ namespace ToNRoundCounter
             this.Controls.Add(InfoPanel);
             currentY += InfoPanel.Height + margin;
 
+            terrorInfoPanel = new TerrorInfoPanel();
+            terrorInfoPanel.Location = new Point(margin, currentY);
+            terrorInfoPanel.Width = contentWidth;
+            terrorInfoPanel.Height = 0;
+            this.Controls.Add(terrorInfoPanel);
+            currentY += terrorInfoPanel.Height + margin;
+
             // SplitContainer（統計情報表示欄とラウンドログを縦に並べる）
             splitContainerMain = new SplitContainer();
             splitContainerMain.Orientation = Orientation.Horizontal;
@@ -348,6 +358,9 @@ namespace ToNRoundCounter
             InfoPanel.Location = new Point(margin, currentY);
             InfoPanel.Width = contentWidth;
             currentY += InfoPanel.Height + margin;
+            terrorInfoPanel.Location = new Point(margin, currentY);
+            terrorInfoPanel.Width = contentWidth;
+            currentY += terrorInfoPanel.Height + margin;
             splitContainerMain.Location = new Point(margin, currentY);
             splitContainerMain.Width = contentWidth;
             splitContainerMain.Height = this.ClientSize.Height - currentY - margin;
@@ -1340,6 +1353,33 @@ namespace ToNRoundCounter
             InfoPanel.ItemValue.Text = "";
         }
 
+        private void LoadTerrorInfo()
+        {
+            string path = "./terrosInfo.json";
+            if (File.Exists(path))
+            {
+                try
+                {
+                    string json = File.ReadAllText(path, Encoding.UTF8);
+                    terrorInfoData = JObject.Parse(json);
+                }
+                catch
+                {
+                    terrorInfoData = null;
+                }
+            }
+        }
+
+        private void UpdateTerrorInfoPanel(List<string> names)
+        {
+            if (terrorInfoPanel == null)
+                return;
+
+            terrorInfoPanel.UpdateInfo(names, terrorInfoData);
+            // Re-layout controls when height changes
+            MainForm_Resize(this, EventArgs.Empty);
+        }
+
         private Color AdjustColorForVisibility(Color color)
         {
             if (color.GetBrightness() > 0.8f)
@@ -1425,6 +1465,11 @@ namespace ToNRoundCounter
                 {
                     terrorColors[joinedNames] = color;
                 }
+                UpdateTerrorInfoPanel(names);
+            }
+            else
+            {
+                UpdateTerrorInfoPanel(null);
             }
         }
 

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -100,6 +100,9 @@
     <Compile Include="UI\InfoPanel.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="UI\TerrorInfoPanel.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="UI\LogPanel.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/UI/TerrorInfoPanel.cs
+++ b/UI/TerrorInfoPanel.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using Newtonsoft.Json.Linq;
+
+namespace ToNRoundCounter.UI
+{
+    public class TerrorInfoPanel : Panel
+    {
+        private TableLayoutPanel table;
+
+        public TerrorInfoPanel()
+        {
+            this.BorderStyle = BorderStyle.FixedSingle;
+            this.BackColor = Color.DarkGray;
+            this.AutoSize = true;
+            this.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            this.Visible = false;
+
+            table = new TableLayoutPanel();
+            table.AutoSize = true;
+            table.Dock = DockStyle.Fill;
+            table.CellBorderStyle = TableLayoutPanelCellBorderStyle.Single;
+            this.Controls.Add(table);
+        }
+
+        public void UpdateInfo(List<string> names, JObject data)
+        {
+            table.Controls.Clear();
+            table.ColumnStyles.Clear();
+
+            if (names == null || names.Count == 0)
+            {
+                this.Visible = false;
+                return;
+            }
+
+            this.Visible = true;
+
+            int count = Math.Min(3, names.Count);
+            table.ColumnCount = count;
+            for (int i = 0; i < count; i++)
+            {
+                table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f / count));
+            }
+
+            int col = 0;
+            foreach (string name in names.Take(3))
+            {
+                var panel = CreateCell(name, data?[name] as JArray);
+                table.Controls.Add(panel, col, 0);
+                col++;
+            }
+        }
+
+        private Control CreateCell(string name, JArray infoArray)
+        {
+            var cell = new TableLayoutPanel();
+            cell.AutoSize = true;
+            cell.Dock = DockStyle.Fill;
+            cell.ColumnCount = 2;
+            cell.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
+            cell.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
+
+            var title = new Label
+            {
+                Text = name,
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleCenter,
+                ForeColor = Color.White,
+                AutoSize = true
+            };
+            cell.RowCount = 1;
+            cell.Controls.Add(title, 0, 0);
+            cell.SetColumnSpan(title, 2);
+
+            if (infoArray != null)
+            {
+                int row = 1;
+                foreach (JObject obj in infoArray.OfType<JObject>())
+                {
+                    var prop = obj.Properties().FirstOrDefault();
+                    if (prop == null) continue;
+
+                    cell.RowCount = row + 1;
+                    var keyLabel = new Label
+                    {
+                        Text = prop.Name,
+                        Dock = DockStyle.Fill,
+                        TextAlign = ContentAlignment.MiddleRight,
+                        ForeColor = Color.White,
+                        AutoSize = true
+                    };
+                    var valLabel = new Label
+                    {
+                        Text = prop.Value.ToString(),
+                        Dock = DockStyle.Fill,
+                        TextAlign = ContentAlignment.MiddleLeft,
+                        ForeColor = Color.White,
+                        AutoSize = true
+                    };
+                    cell.Controls.Add(keyLabel, 0, row);
+                    cell.Controls.Add(valLabel, 1, row);
+                    row++;
+                }
+            }
+
+            return cell;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- load `terrosInfo.json` on startup
- add `TerrorInfoPanel` with dynamic table layout
- update panel with info for up to three terrors when they appear

## Testing
- `apt-get update`
- `apt-get install -y mono-devel`
- `mono nuget.exe restore ToNRoundCounter.sln`
- `xbuild /t:Build /p:Configuration=Release ToNRoundCounter.sln`

------
https://chatgpt.com/codex/tasks/task_e_6879f64b92cc832984fc8105a1f45b03