### PR TITLE
Resolve Color type ambiguity

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -20,7 +20,7 @@ using ToNRoundCounter.Models;
 using ToNRoundCounter.Properties;
 using ToNRoundCounter.UI;
 using ToNRoundCounter.Utils;
-using System.Windows.Media;
+using MediaPlayer = System.Windows.Media.MediaPlayer;
 
 namespace ToNRoundCounter
 {


### PR DESCRIPTION
## Summary
- Alias `System.Windows.Media.MediaPlayer` so that `Color` unambiguously refers to `System.Drawing.Color`

## Testing
- `mcs -unsafe -r:System.Windows.Forms.dll -r:System.Drawing.dll -r:PresentationCore.dll MainForm.cs` *(fails: Metadata file `System.Windows.Forms.dll` could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a862bdcbf08329a386673e11b2eb10