### PR TITLE
Fix zip extraction for updates on .NET Framework

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -483,7 +483,22 @@ namespace ToNRoundCounter
 
                             try
                             {
-                                ZipFile.ExtractToDirectory(zipPath, Directory.GetCurrentDirectory(), true);
+                                using (var archive = ZipFile.OpenRead(zipPath))
+                                {
+                                    foreach (var entry in archive.Entries)
+                                    {
+                                        var destinationPath = Path.Combine(Directory.GetCurrentDirectory(), entry.FullName);
+                                        if (string.IsNullOrEmpty(entry.Name))
+                                        {
+                                            Directory.CreateDirectory(destinationPath);
+                                        }
+                                        else
+                                        {
+                                            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
+                                            entry.ExtractToFile(destinationPath, true);
+                                        }
+                                    }
+                                }
                             }
                             catch (IOException)
                             {


### PR DESCRIPTION
## Summary
- replace unsupported ZipFile.ExtractToDirectory overload with manual ZipArchive extraction to allow overwriting existing files

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a86a403a24832981b39727fc96bd68