### PR TITLE
Add standalone updater process

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -481,36 +480,20 @@ namespace ToNRoundCounter
                             var bytes = await client.GetByteArrayAsync(url);
                             File.WriteAllBytes(zipPath, bytes);
 
-                            try
+                            var updaterExe = Path.Combine(Directory.GetCurrentDirectory(), "Updater.exe");
+                            if (File.Exists(updaterExe))
                             {
-                                using (var archive = ZipFile.OpenRead(zipPath))
+                                Process.Start(new ProcessStartInfo(updaterExe)
                                 {
-                                    foreach (var entry in archive.Entries)
-                                    {
-                                        var destinationPath = Path.Combine(Directory.GetCurrentDirectory(), entry.FullName);
-                                        if (string.IsNullOrEmpty(entry.Name))
-                                        {
-                                            Directory.CreateDirectory(destinationPath);
-                                        }
-                                        else
-                                        {
-                                            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
-                                            entry.ExtractToFile(destinationPath, true);
-                                        }
-                                    }
-                                }
+                                    Arguments = $"\"{zipPath}\" \"{Application.ExecutablePath}\"",
+                                    UseShellExecute = false
+                                });
+                                Application.Exit();
                             }
-                            catch (IOException)
+                            else
                             {
-                                // ignore extraction errors
+                                MessageBox.Show("Updater.exe が見つかりません。", "アップデート", MessageBoxButtons.OK, MessageBoxIcon.Error);
                             }
-                            finally
-                            {
-                                try { File.Delete(zipPath); } catch { }
-                            }
-
-                            Process.Start(new ProcessStartInfo(Application.ExecutablePath) { UseShellExecute = true });
-                            Application.Exit();
                         }
                     }
                 }

--- a/ToNRoundCounter.sln
+++ b/ToNRoundCounter.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.12.35707.178
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToNRoundCounter", "ToNRoundCounter.csproj", "{2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Updater", "Updater\Updater.csproj", "{0415BFC3-4703-4E15-955C-37F872DD5E41}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,16 +14,24 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Debug|x64.ActiveCfg = Debug|x64
-		{2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Debug|x64.Build.0 = Debug|x64
-		{2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Release|x64.ActiveCfg = Release|x64
-		{2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Release|x64.Build.0 = Release|x64
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Debug|x64.ActiveCfg = Debug|x64
+                {2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Debug|x64.Build.0 = Debug|x64
+                {2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Release|Any CPU.Build.0 = Release|Any CPU
+                {2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Release|x64.ActiveCfg = Release|x64
+                {2EE5DF69-2E18-419D-8EFD-6AC05156C6DB}.Release|x64.Build.0 = Release|x64
+                {0415BFC3-4703-4E15-955C-37F872DD5E41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0415BFC3-4703-4E15-955C-37F872DD5E41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0415BFC3-4703-4E15-955C-37F872DD5E41}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {0415BFC3-4703-4E15-955C-37F872DD5E41}.Debug|x64.Build.0 = Debug|Any CPU
+                {0415BFC3-4703-4E15-955C-37F872DD5E41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0415BFC3-4703-4E15-955C-37F872DD5E41}.Release|Any CPU.Build.0 = Release|Any CPU
+                {0415BFC3-4703-4E15-955C-37F872DD5E41}.Release|x64.ActiveCfg = Release|Any CPU
+                {0415BFC3-4703-4E15-955C-37F872DD5E41}.Release|x64.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Updater/Program.cs
+++ b/Updater/Program.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+
+namespace Updater
+{
+    internal static class Program
+    {
+        static int Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: Updater <zipPath> <targetExe>");
+                return 1;
+            }
+
+            string zipPath = args[0];
+            string targetExe = args[1];
+            string targetDir = Path.GetDirectoryName(targetExe) ?? ".";
+
+            // wait for the target file to be unlocked
+            for (int i = 0; i < 30 && IsFileLocked(targetExe); i++)
+            {
+                Thread.Sleep(1000);
+            }
+
+            try
+            {
+                using (var archive = ZipFile.OpenRead(zipPath))
+                {
+                    foreach (var entry in archive.Entries)
+                    {
+                        var destinationPath = Path.Combine(targetDir, entry.FullName);
+                        if (string.IsNullOrEmpty(entry.Name))
+                        {
+                            Directory.CreateDirectory(destinationPath);
+                        }
+                        else
+                        {
+                            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
+                            entry.ExtractToFile(destinationPath, true);
+                        }
+                    }
+                }
+                File.Delete(zipPath);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Update failed: " + ex.Message);
+                return 1;
+            }
+
+            Process.Start(new ProcessStartInfo(targetExe) { UseShellExecute = true });
+            return 0;
+        }
+
+        private static bool IsFileLocked(string path)
+        {
+            try
+            {
+                using (File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+                {
+                    return false;
+                }
+            }
+            catch
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/Updater/Updater.csproj
+++ b/Updater/Updater.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add separate Updater console app to replace in-use files and restart main program
- invoke Updater.exe from `CheckForUpdatesAsync` instead of extracting in-process

## Testing
- `dotnet build ToNRoundCounter.sln` *(fails: reference assemblies for .NETFramework,Version=v4.8 not found)*
- `dotnet build Updater/Updater.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a870db80a4832999b7db804a97fc79