### PR TITLE
Include updater in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         run: nuget restore ToNRoundCounter.sln
       - name: Build
         run: msbuild ToNRoundCounter.sln /p:Configuration=Release /p:Platform=x64
+      - name: Include updater
+        run: Copy-Item -Path .\Updater\bin\Release\net48\* -Destination .\bin\x64\Release\ -Recurse -Force
       - name: Include shared assets
         run: |
           Expand-Archive -Path share_assets.zip -DestinationPath share_assets


### PR DESCRIPTION
## Summary
- build the Updater project and copy its output into the release directory

## Testing
- `dotnet build Updater/Updater.csproj -c Release`
- `dotnet build ToNRoundCounter.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a872840f2483298799cab989c72812