### PR TITLE
Add Levenshtein typo-tolerant matcher

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -2032,15 +2032,80 @@ namespace ToNRoundCounter
                 }
             }
             catch (Exception ex)
+        {
+            // エラー内容を標準出力に表示
+            Console.Error.WriteLine(ex.Message);
+            if (ex.InnerException != null)
             {
-                // エラー内容を標準出力に表示
-                Console.Error.WriteLine(ex.Message);
-                if (ex.InnerException != null)
-                {
-                    Console.Error.WriteLine(ex.InnerException.Message);
-                }
-                throw;
+                Console.Error.WriteLine(ex.InnerException.Message);
             }
+            throw;
+        }
+        }
+
+        private class TypoMatchResult
+        {
+            public bool result;
+            public bool typomatch;
+        }
+
+        private TypoMatchResult MatchWithTypoTolerance(string text, string target)
+        {
+            if (text == null || target == null)
+            {
+                return new TypoMatchResult { result = false, typomatch = false };
+            }
+
+            if (text.Equals(target))
+            {
+                return new TypoMatchResult { result = true, typomatch = false };
+            }
+
+            int allowedDistance = (int)Math.Floor(target.Length * 0.25);
+            int distance = LevenshteinDistance(text, target);
+
+            if (distance <= allowedDistance)
+            {
+                return new TypoMatchResult { result = true, typomatch = true };
+            }
+
+            return new TypoMatchResult { result = false, typomatch = false };
+        }
+
+        private int LevenshteinDistance(string source, string target)
+        {
+            if (string.IsNullOrEmpty(source))
+            {
+                return target?.Length ?? 0;
+            }
+            if (string.IsNullOrEmpty(target))
+            {
+                return source.Length;
+            }
+
+            int[,] d = new int[source.Length + 1, target.Length + 1];
+
+            for (int i = 0; i <= source.Length; i++)
+            {
+                d[i, 0] = i;
+            }
+            for (int j = 0; j <= target.Length; j++)
+            {
+                d[0, j] = j;
+            }
+
+            for (int i = 1; i <= source.Length; i++)
+            {
+                for (int j = 1; j <= target.Length; j++)
+                {
+                    int cost = (source[i - 1] == target[j - 1]) ? 0 : 1;
+                    d[i, j] = Math.Min(
+                        Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1),
+                        d[i - 1, j - 1] + cost);
+                }
+            }
+
+            return d[source.Length, target.Length];
         }
     }
 }


### PR DESCRIPTION
## Summary
- add helper to match strings within 25% Levenshtein distance
- expose typo info with `result`/`typomatch` flags

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd909a4c308329a7e2c6966d018089