### PR TITLE
feat: add detailed auto suicide configuration

### DIFF
--- a/Models/AutoSuicidePreset.cs
+++ b/Models/AutoSuicidePreset.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace ToNRoundCounter.Models
+{
+    public class AutoSuicidePreset
+    {
+        public List<string> RoundTypes { get; set; } = new List<string>();
+        public List<string> DetailCustom { get; set; } = new List<string>();
+        public bool Fuzzy { get; set; } = false;
+    }
+}

--- a/Models/AutoSuicideRule.cs
+++ b/Models/AutoSuicideRule.cs
@@ -1,0 +1,88 @@
+using System;
+
+namespace ToNRoundCounter.Models
+{
+    public class AutoSuicideRule
+    {
+        public string Round { get; set; }
+        public bool RoundNegate { get; set; }
+        public string Terror { get; set; }
+        public bool TerrorNegate { get; set; }
+        public bool Value { get; set; }
+
+        public static bool TryParse(string line, out AutoSuicideRule rule)
+        {
+            rule = null;
+            if (string.IsNullOrWhiteSpace(line)) return false;
+            var parts = line.Split(':');
+            string round = null;
+            bool roundNeg = false;
+            string terror = null;
+            bool terrorNeg = false;
+            bool value;
+            if (parts.Length == 1)
+            {
+                if (parts[0] == "1" || parts[0] == "0")
+                {
+                    value = parts[0] == "1";
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else if (parts.Length == 3)
+            {
+                if (!string.IsNullOrWhiteSpace(parts[0]))
+                {
+                    roundNeg = parts[0].StartsWith("!");
+                    round = roundNeg ? parts[0].Substring(1) : parts[0];
+                }
+                if (!string.IsNullOrWhiteSpace(parts[1]))
+                {
+                    terrorNeg = parts[1].StartsWith("!");
+                    terror = terrorNeg ? parts[1].Substring(1) : parts[1];
+                }
+                if (parts[2] == "1" || parts[2] == "0")
+                {
+                    value = parts[2] == "1";
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+            rule = new AutoSuicideRule { Round = round, RoundNegate = roundNeg, Terror = terror, TerrorNegate = terrorNeg, Value = value };
+            return true;
+        }
+
+        public bool Matches(string round, string terror, Func<string, string, bool> comparer)
+        {
+            bool roundMatch = Round == null || (round != null && (RoundNegate ? !comparer(round, Round) : comparer(round, Round)));
+            bool terrorMatch = Terror == null || (terror != null && (TerrorNegate ? !comparer(terror, Terror) : comparer(terror, Terror)));
+            return roundMatch && terrorMatch;
+        }
+
+        public bool Covers(AutoSuicideRule other)
+        {
+            bool roundCovers = (Round == null && !RoundNegate) || (other.Round != null && Round == other.Round && RoundNegate == other.RoundNegate);
+            bool terrorCovers = (Terror == null && !TerrorNegate) || (other.Terror != null && Terror == other.Terror && TerrorNegate == other.TerrorNegate);
+            return roundCovers && terrorCovers;
+        }
+
+        public override string ToString()
+        {
+            if (Round == null && Terror == null)
+            {
+                return Value ? "1" : "0";
+            }
+            string r = Round == null ? "" : (RoundNegate ? "!" + Round : Round);
+            string t = Terror == null ? "" : (TerrorNegate ? "!" + Terror : Terror);
+            return $"{r}:{t}:{(Value ? 1 : 0)}";
+        }
+    }
+}

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -90,6 +90,8 @@
     <Compile Include="Models\RoundAggregate.cs" />
     <Compile Include="Models\RoundData.cs" />
     <Compile Include="Models\TerrorAggregate.cs" />
+    <Compile Include="Models\AutoSuicideRule.cs" />
+    <Compile Include="Models\AutoSuicidePreset.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UI\FilterPanel.cs">

--- a/Utils/AppSettings.cs
+++ b/Utils/AppSettings.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.IO;
 using Newtonsoft.Json;
 using ToNRoundCounter.Utils;
+using ToNRoundCounter.Models;
 
 namespace ToNRoundCounter
 {
@@ -31,7 +32,9 @@ namespace ToNRoundCounter
         public static bool Filter_SurvivalRate { get; set; } = true;
 
         public static List<string> AutoSuicideRoundTypes { get; set; } = new List<string>();
-        public static Dictionary<string, List<string>> AutoSuicidePresets { get; set; } = new Dictionary<string, List<string>>();
+        public static Dictionary<string, AutoSuicidePreset> AutoSuicidePresets { get; set; } = new Dictionary<string, AutoSuicidePreset>();
+        public static List<string> AutoSuicideDetailCustom { get; set; } = new List<string>();
+        public static bool AutoSuicideFuzzyMatch { get; set; } = false;
 
         public static List<string> RoundTypeStats { get; set; } = new List<string>()
         {
@@ -72,7 +75,9 @@ namespace ToNRoundCounter
                         };
                         AutoSuicideEnabled = bool.TryParse(settings.AutoSuicideEnabled.ToString(), out bool autoSuicideEnabled) ? autoSuicideEnabled : false;
                         AutoSuicideRoundTypes = settings.AutoSuicideRoundTypes ?? new List<string>();
-                        AutoSuicidePresets = settings.AutoSuicidePresets ?? new Dictionary<string, List<string>>();
+                        AutoSuicidePresets = settings.AutoSuicidePresets ?? new Dictionary<string, AutoSuicidePreset>();
+                        AutoSuicideDetailCustom = settings.AutoSuicideDetailCustom ?? new List<string>();
+                        AutoSuicideFuzzyMatch = bool.TryParse(settings.AutoSuicideFuzzyMatch.ToString(), out bool autoSuicideFuzzy) ? autoSuicideFuzzy : false;
                         apikey = !string.IsNullOrEmpty(settings.apikey) ? settings.apikey : string.Empty; // APIキーの読み込み
                         EventLogger.LogEvent("AppSettings", "Settings loaded successfully from " + settingsFile);
 
@@ -111,6 +116,8 @@ namespace ToNRoundCounter
                 AutoSuicideEnabled = AutoSuicideEnabled,
                 AutoSuicideRoundTypes = AutoSuicideRoundTypes,
                 AutoSuicidePresets = AutoSuicidePresets,
+                AutoSuicideDetailCustom = AutoSuicideDetailCustom,
+                AutoSuicideFuzzyMatch = AutoSuicideFuzzyMatch,
                 apikey = apikey // APIキーの保存
             };
             string json = JsonConvert.SerializeObject(settings, Formatting.Indented);
@@ -139,7 +146,9 @@ namespace ToNRoundCounter
         public List<string> RoundTypeStats { get; set; }
         public bool AutoSuicideEnabled { get; internal set; }
         public List<string> AutoSuicideRoundTypes { get; internal set; }
-        public Dictionary<string, List<string>> AutoSuicidePresets { get; set; }
+        public Dictionary<string, AutoSuicidePreset> AutoSuicidePresets { get; set; }
+        public List<string> AutoSuicideDetailCustom { get; set; }
+        public bool AutoSuicideFuzzyMatch { get; set; }
 
         public string apikey { get; set; }
     }


### PR DESCRIPTION
## Summary
- add rule-based auto-suicide settings with optional fuzzy matching
- store custom rule text and fuzzy toggle in settings and presets
- evaluate auto-suicide using prioritized rules over round and terror names
- allow `!` prefix on round or terror to invert matching
- support importing and exporting presets and restore detailed settings on startup

## Testing
- `dotnet build` *(fails: reference assemblies for .NETFramework,Version=v4.8 were not found)*
- `xbuild ToNRoundCounter.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd955fb9f88329a612c530f0e99a3d