### PR TITLE
Add option to use detailed auto-suicide settings

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -399,6 +399,7 @@ namespace ToNRoundCounter
                     settingsForm.SettingsPanel.RoundTypeStatsListBox.SetItemChecked(i, AppSettings.RoundTypeStats.Contains(item));
                 }
                 settingsForm.SettingsPanel.autoSuicideCheckBox.Checked = AppSettings.AutoSuicideEnabled;
+                settingsForm.SettingsPanel.autoSuicideUseDetailCheckBox.Checked = AppSettings.AutoSuicideUseDetail;
                 for (int i = 0; i < settingsForm.SettingsPanel.autoSuicideRoundListBox.Items.Count; i++)
                 {
                     string item = settingsForm.SettingsPanel.autoSuicideRoundListBox.Items[i].ToString();
@@ -435,6 +436,7 @@ namespace ToNRoundCounter
                         AppSettings.RoundTypeStats.Add(item.ToString());
                     }
                     AppSettings.AutoSuicideEnabled = settingsForm.SettingsPanel.autoSuicideCheckBox.Checked;
+                    AppSettings.AutoSuicideUseDetail = settingsForm.SettingsPanel.autoSuicideUseDetailCheckBox.Checked;
                     AppSettings.AutoSuicideRoundTypes.Clear();
                     foreach (object item in settingsForm.SettingsPanel.autoSuicideRoundListBox.CheckedItems)
                     {

--- a/Models/AutoSuicideRule.cs
+++ b/Models/AutoSuicideRule.cs
@@ -60,6 +60,64 @@ namespace ToNRoundCounter.Models
             return true;
         }
 
+        public static bool TryParseDetailed(string line, out AutoSuicideRule rule, out string error)
+        {
+            rule = null;
+            error = null;
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                error = "空行です";
+                return false;
+            }
+            var parts = line.Split(':');
+            string round = null;
+            bool roundNeg = false;
+            string terror = null;
+            bool terrorNeg = false;
+            int value;
+            if (parts.Length == 1)
+            {
+                if (parts[0] == "1" || parts[0] == "0" || parts[0] == "2")
+                {
+                    value = int.Parse(parts[0]);
+                }
+                else
+                {
+                    error = $"値 '{parts[0]}' が不正です。0,1,2のみ使用できます";
+                    return false;
+                }
+            }
+            else if (parts.Length == 3)
+            {
+                if (!string.IsNullOrWhiteSpace(parts[0]))
+                {
+                    roundNeg = parts[0].StartsWith("!");
+                    round = roundNeg ? parts[0].Substring(1) : parts[0];
+                }
+                if (!string.IsNullOrWhiteSpace(parts[1]))
+                {
+                    terrorNeg = parts[1].StartsWith("!");
+                    terror = terrorNeg ? parts[1].Substring(1) : parts[1];
+                }
+                if (parts[2] == "1" || parts[2] == "0" || parts[2] == "2")
+                {
+                    value = int.Parse(parts[2]);
+                }
+                else
+                {
+                    error = $"値 '{parts[2]}' が不正です。0,1,2のみ使用できます";
+                    return false;
+                }
+            }
+            else
+            {
+                error = "形式が不正です。'ラウンド:テラー:値' または '値' の形式で記述してください";
+                return false;
+            }
+            rule = new AutoSuicideRule { Round = round, RoundNegate = roundNeg, Terror = terror, TerrorNegate = terrorNeg, Value = value };
+            return true;
+        }
+
         public bool Matches(string round, string terror, Func<string, string, bool> comparer)
         {
             bool roundMatch = Round == null || (round != null && (RoundNegate ? !comparer(round, Round) : comparer(round, Round)));

--- a/Utils/AppSettings.cs
+++ b/Utils/AppSettings.cs
@@ -35,6 +35,7 @@ namespace ToNRoundCounter
         public static Dictionary<string, AutoSuicidePreset> AutoSuicidePresets { get; set; } = new Dictionary<string, AutoSuicidePreset>();
         public static List<string> AutoSuicideDetailCustom { get; set; } = new List<string>();
         public static bool AutoSuicideFuzzyMatch { get; set; } = false;
+        public static bool AutoSuicideUseDetail { get; set; } = false;
 
         public static List<string> RoundTypeStats { get; set; } = new List<string>()
         {
@@ -78,6 +79,7 @@ namespace ToNRoundCounter
                         AutoSuicidePresets = settings.AutoSuicidePresets ?? new Dictionary<string, AutoSuicidePreset>();
                         AutoSuicideDetailCustom = settings.AutoSuicideDetailCustom ?? new List<string>();
                         AutoSuicideFuzzyMatch = bool.TryParse(settings.AutoSuicideFuzzyMatch.ToString(), out bool autoSuicideFuzzy) ? autoSuicideFuzzy : false;
+                        AutoSuicideUseDetail = bool.TryParse(settings.AutoSuicideUseDetail.ToString(), out bool autoSuicideUseDetail) ? autoSuicideUseDetail : false;
                         apikey = !string.IsNullOrEmpty(settings.apikey) ? settings.apikey : string.Empty; // APIキーの読み込み
                         EventLogger.LogEvent("AppSettings", "Settings loaded successfully from " + settingsFile);
 
@@ -118,6 +120,7 @@ namespace ToNRoundCounter
                 AutoSuicidePresets = AutoSuicidePresets,
                 AutoSuicideDetailCustom = AutoSuicideDetailCustom,
                 AutoSuicideFuzzyMatch = AutoSuicideFuzzyMatch,
+                AutoSuicideUseDetail = AutoSuicideUseDetail,
                 apikey = apikey // APIキーの保存
             };
             string json = JsonConvert.SerializeObject(settings, Formatting.Indented);
@@ -149,6 +152,7 @@ namespace ToNRoundCounter
         public Dictionary<string, AutoSuicidePreset> AutoSuicidePresets { get; set; }
         public List<string> AutoSuicideDetailCustom { get; set; }
         public bool AutoSuicideFuzzyMatch { get; set; }
+        public bool AutoSuicideUseDetail { get; set; }
 
         public string apikey { get; set; }
     }


### PR DESCRIPTION
## Summary
- add checkbox to enable detailed auto-suicide rules and disable round selection list when used
- persist AutoSuicideUseDetail setting in app settings
- hook settings UI to respect detailed mode and handle custom rules
- validate current detailed rules on confirmation and report syntax errors
- split auto-generated and custom rules on save so detailed edits persist

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `xbuild ToNRoundCounter.sln` *(fails: Feature `default literal` cannot be used because it is not part of the C# 7.0 language specification)*

------
https://chatgpt.com/codex/tasks/task_e_68be17b95b7483298c46ce5a1b0b60ff