### PR TITLE
Fix SettingsPanel spacing for display group

### DIFF
--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -499,7 +499,7 @@ namespace ToNRoundCounter.UI
             AutoSuicideUseDetailCheckBox_CheckedChanged(null, EventArgs.Empty);
             AutoSuicideCheckBox_CheckedChanged(null, EventArgs.Empty);
 
-            currentY = Math.Max(grpOsc.Bottom, grpAutoSuicide.Bottom) + margin;
+            currentY = Math.Max(grpOsc.Bottom, grpAutoSuicide.Bottom);
 
             // 表示設定グループ
             GroupBox grpDisplay = new GroupBox();


### PR DESCRIPTION
## Summary
- place the Display Settings group directly beneath OSC Settings so no extra gap appears

## Testing
- `xbuild ToNRoundCounter.sln` *(fails: Feature `default literal` cannot be used; Updater project XML namespace missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be3407a2c48329a85f25a2b6bcb9af