### PR TITLE
Prevent auto round lines when loading presets in detail mode

### DIFF
--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -168,6 +168,7 @@ namespace ToNRoundCounter.UI
             };
             autoSuicideDetailTextBox = new TextBox();
             autoSuicideDetailTextBox.Multiline = true;
+            autoSuicideDetailTextBox.AcceptsReturn = true;
             autoSuicideDetailTextBox.ScrollBars = ScrollBars.Vertical;
             autoSuicideDetailTextBox.Size = autoSuicideRoundListBox.Size;
             autoSuicideDetailTextBox.Location = autoSuicideRoundListBox.Location;
@@ -232,9 +233,12 @@ namespace ToNRoundCounter.UI
                         autoSuicideRoundListBox.SetItemChecked(i, preset.RoundTypes.Contains(item));
                     }
                     autoSuicideFuzzyCheckBox.Checked = preset.Fuzzy;
-                    var autoLinesLocal = GenerateAutoSuicideLines();
-                    autoSuicideAutoRuleCount = autoLinesLocal.Length;
-                    autoSuicideDetailTextBox.Text = string.Join(Environment.NewLine, autoLinesLocal.Concat(preset.DetailCustom));
+                    autoSuicideAutoRuleCount = 0;
+                    autoSuicideDetailTextBox.Text = string.Join(Environment.NewLine, preset.DetailCustom);
+                    if (!autoSuicideUseDetailCheckBox.Checked)
+                    {
+                        UpdateAutoSuicideDetailAutoLines();
+                    }
                 }
             };
             grpAutoSuicide.Controls.Add(autoSuicidePresetLoadButton);


### PR DESCRIPTION
## Summary
- Avoid adding auto-generated round lines when a preset is loaded while detailed rules are enabled
- Allow multiline editing in the detailed settings text area without cancelling changes

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c130f21e888329bc28f603ce0a5567