### PR TITLE
Avoid redundant auto-suicide detail output

### DIFF
--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -394,7 +394,10 @@ namespace ToNRoundCounter.UI
                 {
                     var roundName = rw.Round;
                     var baseValue = rw.Value;
-                    var exceptions = detailRules.Where(d => d.Round == roundName && (d.Value != baseValue || d.TerrorNegate)).ToList();
+                    var relatedDetails = detailRules.Where(d => d.Round == roundName).ToList();
+                    var exceptions = relatedDetails.Where(d => d.Value != baseValue || d.TerrorNegate).ToList();
+                    var sameActionDetails = relatedDetails.Except(exceptions).ToList();
+
                     if (!exceptions.Any())
                     {
                         simpleRounds.Add(Tuple.Create(roundName, baseValue));
@@ -420,6 +423,9 @@ namespace ToNRoundCounter.UI
                                 processedDetail.Add(t);
                         }
                     }
+
+                    foreach (var d in sameActionDetails)
+                        processedDetail.Add(d);
                 }
 
                 foreach (var g in simpleRounds.GroupBy(r => r.Item2))


### PR DESCRIPTION
## Summary
- prevent nested detail rules with same action as their round wildcard from being displayed twice in settings confirmation

## Testing
- `dotnet build` *(fails: reference assemblies for .NETFramework,Version=v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c153cad7a4832985a2dbf0ab4404bc