### PR TITLE
Fix SettingsForm constructor initialization

### DIFF
--- a/UI/SettingsForm.cs
+++ b/UI/SettingsForm.cs
@@ -16,9 +16,10 @@ namespace ToNRoundCounter.UI
 
         public SettingsPanel SettingsPanel { get { return settingsPanel; } }
 
-        public SettingsForm()
-            _settings = settings;
+        public SettingsForm(IAppSettings settings)
         {
+            _settings = settings;
+
             this.Text = LanguageManager.Translate("設定");
             this.Size = new Size(1150, 900);
             this.StartPosition = FormStartPosition.CenterParent;


### PR DESCRIPTION
## Summary
- correct SettingsForm constructor to accept settings dependency and initialize form properties

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c179e3ded88329ba01e7fe6c427b5b