### PR TITLE
Add async interfaces and enable nullable context

### DIFF
--- a/Domain/UnboundRoundDefinitions.cs
+++ b/Domain/UnboundRoundDefinitions.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace ToNRoundCounter.Domain
 {
     /// <summary>

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -91,6 +91,9 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="System.Threading.Channels, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Threading.Channels.8.0.0\lib\net462\System.Threading.Channels.dll</HintPath>
     </Reference>

--- a/packages.config
+++ b/packages.config
@@ -5,6 +5,7 @@
   <package id="Serilog" version="4.0.0" targetFramework="net48" />
   <package id="Serilog.Sinks.Console" version="6.0.0" targetFramework="net48" />
   <package id="Serilog.Sinks.File" version="5.0.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="8.0.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />


### PR DESCRIPTION
## Summary
- add Microsoft.Bcl.AsyncInterfaces to provide IAsyncEnumerable support
- enable nullable reference type annotations in UnboundRoundDefinitions

## Testing
- `dotnet test` *(fails: reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c17e7fd1988329b2f293e694c66e09