### PR TITLE
Use default gray for light theme and refine round prediction

### DIFF
--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -457,6 +457,24 @@ namespace ToNRoundCounter.UI
                     }
                 }
 
+                var negRoundGroups = rulesCheck.Where(r => r.Round != null && r.Terror == null && r.RoundNegate)
+                                               .GroupBy(r => r.Value);
+                foreach (var g in negRoundGroups)
+                {
+                    var rounds = g.Select(r => r.Round).ToList();
+                    bool useBullet = ShouldBullet(rounds);
+                    if (useBullet)
+                    {
+                        sb.AppendLine($"全てのラウンドで以下のラウンド以外が出現した時、{GetActionText(g.Key)}");
+                        foreach (var r in rounds)
+                            sb.AppendLine($"・{r}");
+                    }
+                    else
+                    {
+                        sb.AppendLine($"全てのラウンドで{string.Join(",", rounds)}以外が出現した時、{GetActionText(g.Key)}");
+                    }
+                }
+
                 var remainingDetail = detailRules.Where(d => !processedDetail.Contains(d))
                                                 .GroupBy(d => d.Round);
                 foreach (var rg in remainingDetail)

--- a/UI/Theme.cs
+++ b/UI/Theme.cs
@@ -26,9 +26,9 @@ namespace ToNRoundCounter.UI
 
         public static readonly ThemeColors Light = new ThemeColors
         {
-            Background = Color.White,
+            Background = SystemColors.Control,
             Foreground = Color.Black,
-            PanelBackground = Color.Gainsboro
+            PanelBackground = SystemColors.Control
         };
 
         public static ThemeColors Current { get; private set; } = Light;


### PR DESCRIPTION
## Summary
- tone down light theme by using the OS default gray for background and panels
- rewrite next round prediction logic to support variable normal/special cycles and special overrides
- trigger special round after instance owner changes
- display negated round rules in auto-suicide settings confirmation

## Testing
- `dotnet test` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c184d4f3388329a810611b5474ef1e