### PR TITLE
Handle additional WebSocket events

### DIFF
--- a/Application/StateService.cs
+++ b/Application/StateService.cs
@@ -15,6 +15,7 @@ namespace ToNRoundCounter.Application
         public Dictionary<string, string> RoundMapNames { get; } = new Dictionary<string, string>();
         public TerrorMapNameCollection TerrorMapNames { get; } = new TerrorMapNameCollection();
         public List<Tuple<Round, string>> RoundLogHistory { get; } = new List<Tuple<Round, string>>();
+        public Dictionary<string, object> Stats { get; } = new Dictionary<string, object>();
         public int RoundCycle { get; private set; } = 0;
 
         public void UpdateCurrentRound(Round round)
@@ -61,6 +62,12 @@ namespace ToNRoundCounter.Application
             StateChanged?.Invoke();
         }
 
+        public void UpdateStat(string name, object value)
+        {
+            Stats[name] = value;
+            StateChanged?.Invoke();
+        }
+
         public void Reset()
         {
             CurrentRound = null;
@@ -70,6 +77,7 @@ namespace ToNRoundCounter.Application
             TerrorMapNames.Clear();
             RoundLogHistory.Clear();
             RoundCycle = 0;
+            Stats.Clear();
             StateChanged?.Invoke();
         }
     }

--- a/Domain/Round.cs
+++ b/Domain/Round.cs
@@ -23,6 +23,7 @@ namespace ToNRoundCounter.Domain
         public string MapName { get; set; }
         public List<string> ItemNames { get; set; }
         public int Damage { get; set; }
+        public int PageCount { get; set; }
         public int InstancePlayersCount { get; internal set; }
     }
 }

--- a/ToNRoundCounter.Tests/StateServiceTests.cs
+++ b/ToNRoundCounter.Tests/StateServiceTests.cs
@@ -24,5 +24,16 @@ namespace ToNRoundCounter.Tests
             Assert.Equal(1, terrorAgg.Survival);
             Assert.Equal(1, terrorAgg.Death);
         }
+
+        [Fact]
+        public void UpdateStat_StoresValue()
+        {
+            var service = new StateService();
+            service.UpdateStat("Survivals", 5);
+            Assert.True(service.Stats.ContainsKey("Survivals"));
+            Assert.Equal(5, service.Stats["Survivals"]);
+            service.Reset();
+            Assert.Empty(service.Stats);
+        }
     }
 }

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -679,6 +679,61 @@ namespace ToNRoundCounter.UI
                         }
                     }
                 }
+                else if (eventType == "STATS")
+                {
+                    string statName = json.Value<string>("Name") ?? string.Empty;
+                    JToken valueToken = json["Value"];
+                    if (!string.IsNullOrEmpty(statName) && valueToken != null)
+                    {
+                        stateService.UpdateStat(statName, valueToken.ToObject<object>());
+                    }
+                }
+                else if (eventType == "ALIVE")
+                {
+                    bool isAlive = json.Value<bool?>("Value") ?? true;
+                    if (stateService.CurrentRound != null)
+                    {
+                        if (!isAlive && !stateService.CurrentRound.IsDeath)
+                        {
+                            stateService.CurrentRound.IsDeath = true;
+                            FinalizeCurrentRound("☠");
+                        }
+                        else if (isAlive)
+                        {
+                            stateService.CurrentRound.IsDeath = false;
+                        }
+                    }
+                }
+                else if (eventType == "REBORN")
+                {
+                    bool reborn = json.Value<bool?>("Value") ?? false;
+                    if (stateService.CurrentRound != null && reborn)
+                    {
+                        stateService.CurrentRound.IsDeath = false;
+                    }
+                }
+                else if (eventType == "PAGE_COUNT")
+                {
+                    int pages = json.Value<int>("Value");
+                    if (stateService.CurrentRound != null)
+                    {
+                        stateService.CurrentRound.PageCount = pages;
+                    }
+                }
+                else if (eventType == "PLAYER_JOIN")
+                {
+                    if (stateService.CurrentRound != null)
+                    {
+                        stateService.CurrentRound.InstancePlayersCount++;
+                    }
+                }
+                else if (eventType == "PLAYER_LEAVE")
+                {
+                    if (stateService.CurrentRound != null && stateService.CurrentRound.InstancePlayersCount > 0)
+                    {
+                        stateService.CurrentRound.InstancePlayersCount--;
+                    }
+                }
                 else if (eventType == "OPTED_IN")
                 {
                     if (!isNotifyActivated)


### PR DESCRIPTION
## Summary
- track stat updates from STATS events
- record page count and player join/leave events for rounds
- add tests for StateService stat tracking

## Testing
- `dotnet test` *(fails: reference assemblies for .NET Framework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f93998d083299bba1e758e39ce26