### PR TITLE
Handle negated terms in auto rule cleanup

### DIFF
--- a/Domain/AutoSuicideRule.cs
+++ b/Domain/AutoSuicideRule.cs
@@ -95,8 +95,17 @@ namespace ToNRoundCounter.Domain
             // present in the other rule's expressions.
             Func<string, string, bool> comparer = (a, b) => a == b;
 
-            var roundTerms = other.GetRoundTerms() ?? new List<string> { null };
-            var terrorTerms = other.GetTerrorTerms() ?? new List<string> { null };
+            var roundTerms = other.GetRoundTerms();
+            if (roundTerms == null || roundTerms.Count == 0)
+                roundTerms = new List<string> { null };
+            else if (other.RoundNegate)
+                roundTerms.Add(null);
+
+            var terrorTerms = other.GetTerrorTerms();
+            if (terrorTerms == null || terrorTerms.Count == 0)
+                terrorTerms = new List<string> { null };
+            else if (other.TerrorNegate)
+                terrorTerms.Add(null);
 
             foreach (var round in roundTerms)
             {


### PR DESCRIPTION
## Summary
- fix rule coverage logic so negated round or terror expressions are evaluated against both positive and null terms

## Testing
- `dotnet test` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c200735e6c832995e1f9bbd1608368