### PR TITLE
Clarify auto-suicide message for negated rounds

### DIFF
--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -466,13 +466,13 @@ namespace ToNRoundCounter.UI
                     bool useBullet = ShouldBullet(rounds);
                     if (useBullet)
                     {
-                        sb.AppendLine($"全てのラウンドで以下のラウンド以外が出現した時、{GetActionText(g.Key)}");
+                        sb.AppendLine($"全てのラウンドで以下のラウンド以外のラウンドが出現した時、{GetActionText(g.Key)}");
                         foreach (var r in rounds)
                             sb.AppendLine($"・{r}");
                     }
                     else
                     {
-                        sb.AppendLine($"全てのラウンドで{string.Join(",", rounds)}以外が出現した時、{GetActionText(g.Key)}");
+                        sb.AppendLine($"全てのラウンドで{string.Join(",", rounds)}以外のラウンドが出現した時、{GetActionText(g.Key)}");
                     }
                 }
 


### PR DESCRIPTION
## Summary
- clarify text when specifying negated rounds in auto-suicide settings

## Testing
- `dotnet test` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c201f12f4c8329885573657b2250fc