### PR TITLE
Fix debug info color for velocity and members

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -177,7 +177,7 @@ namespace ToNRoundCounter.UI
             // デバッグ情報用ラベル
             lblDebugInfo = new Label();
             lblDebugInfo.Text = "";
-            lblDebugInfo.ForeColor = Theme.Current.Foreground;
+            lblDebugInfo.ForeColor = Color.Blue;
             lblDebugInfo.AutoSize = true;
             lblDebugInfo.Location = new Point(lblOSCStatus.Right + 10, currentY);
             this.Controls.Add(lblDebugInfo);
@@ -269,7 +269,7 @@ namespace ToNRoundCounter.UI
         private void ApplyTheme()
         {
             this.BackColor = Theme.Current.Background;
-            lblDebugInfo.ForeColor = Theme.Current.Foreground;
+            lblDebugInfo.ForeColor = Color.Blue;
             InfoPanel.ApplyTheme();
             InfoPanel.BackColor = _settings.Theme == ThemeType.Dark ? Theme.Current.PanelBackground : _settings.BackgroundColor_InfoPanel;
             rtbStatsDisplay.ForeColor = Theme.Current.Foreground;


### PR DESCRIPTION
## Summary
- ensure velocity and member debug info label renders in blue across themes

## Testing
- `dotnet test` *(fails: The reference assemblies for .NETFramework, Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c214358ac8832988542bff9f289874