### PR TITLE
Add crash report generation

### DIFF
--- a/Infrastructure/ErrorReporter.cs
+++ b/Infrastructure/ErrorReporter.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Management;
+using System.Text;
 using System.Windows.Forms;
+using Microsoft.VisualBasic.Devices;
 using ToNRoundCounter.Application;
 using WinFormsApp = System.Windows.Forms.Application;
 
@@ -27,6 +33,124 @@ namespace ToNRoundCounter.Infrastructure
         {
             if (ex == null) return;
             _logger.LogEvent("Unhandled", ex.ToString(), Serilog.Events.LogEventLevel.Error);
+            try
+            {
+                var dir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "crash-reports");
+                Directory.CreateDirectory(dir);
+                var path = Path.Combine(dir, $"crash-{DateTime.UtcNow:yyyyMMddHHmmssfff}.txt");
+                var sb = new StringBuilder();
+                sb.AppendLine($"Time: {DateTime.UtcNow:O}");
+                sb.AppendLine($"OS: {Environment.OSVersion}");
+                sb.AppendLine($"64-bit OS: {Environment.Is64BitOperatingSystem}");
+                sb.AppendLine($"Processor Count: {Environment.ProcessorCount}");
+                sb.AppendLine($"Machine Name: {Environment.MachineName}");
+                sb.AppendLine($"User: {Environment.UserName}");
+                try
+                {
+                    var info = new ComputerInfo();
+                    sb.AppendLine($"Total Physical Memory: {info.TotalPhysicalMemory}");
+                    sb.AppendLine($"Available Physical Memory: {info.AvailablePhysicalMemory}");
+                }
+                catch
+                {
+                    // ignore memory query errors
+                }
+                try
+                {
+                    var cpuSearcher = new ManagementObjectSearcher("SELECT Name FROM Win32_Processor");
+                    var cpu = cpuSearcher.Get().Cast<ManagementObject>().FirstOrDefault()?[
+                        "Name"]?.ToString();
+                    if (!string.IsNullOrWhiteSpace(cpu))
+                    {
+                        sb.AppendLine($"CPU Name: {cpu}");
+                    }
+                }
+                catch
+                {
+                    // ignore CPU query errors
+                }
+                try
+                {
+                    var gpuSearcher = new ManagementObjectSearcher("SELECT Name, DriverVersion FROM Win32_VideoController");
+                    foreach (ManagementObject obj in gpuSearcher.Get())
+                    {
+                        var name = obj["Name"]?.ToString();
+                        var driver = obj["DriverVersion"]?.ToString();
+                        if (!string.IsNullOrWhiteSpace(name))
+                        {
+                            sb.AppendLine($"GPU Name: {name}");
+                        }
+                        if (!string.IsNullOrWhiteSpace(driver))
+                        {
+                            sb.AppendLine($"GPU Driver Version: {driver}");
+                        }
+                        break;
+                    }
+                }
+                catch
+                {
+                    // ignore GPU query errors
+                }
+                try
+                {
+                    var drive = new DriveInfo(Path.GetPathRoot(AppDomain.CurrentDomain.BaseDirectory));
+                    long total = drive.TotalSize;
+                    long used = total - drive.AvailableFreeSpace;
+                    double percent = total > 0 ? (double)used / total * 100 : 0;
+                    try
+                    {
+                        var query =
+                            $"ASSOCIATORS OF {{Win32_LogicalDisk.DeviceID='{drive.Name.TrimEnd('\\')}'}} WHERE AssocClass = Win32_LogicalDiskToPartition";
+                        using var partitionSearcher = new ManagementObjectSearcher(query);
+                        foreach (ManagementObject partition in partitionSearcher.Get())
+                        {
+                            var driveQuery =
+                                $"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{partition["DeviceID"]}'}} WHERE AssocClass = Win32_DiskDriveToDiskPartition";
+                            using var driveSearcher = new ManagementObjectSearcher(driveQuery);
+                            foreach (ManagementObject disk in driveSearcher.Get())
+                            {
+                                var model = disk["Model"]?.ToString();
+                                if (!string.IsNullOrWhiteSpace(model))
+                                {
+                                    sb.AppendLine($"SSD Name: {model}");
+                                }
+                                break;
+                            }
+                            break;
+                        }
+                    }
+                    catch
+                    {
+                        // ignore SSD model query errors
+                    }
+                    sb.AppendLine($"SSD Total Size: {total}");
+                    sb.AppendLine($"SSD Used Size: {used} ({percent:F2}%)");
+                }
+                catch
+                {
+                    // ignore SSD query errors
+                }
+                sb.AppendLine("Running Processes:");
+                try
+                {
+                    var procs = Process.GetProcesses().OrderBy(p => p.ProcessName).Select(p => $"{p.ProcessName} ({p.Id})");
+                    foreach (var proc in procs)
+                    {
+                        sb.AppendLine($"  {proc}");
+                    }
+                }
+                catch
+                {
+                    sb.AppendLine("  <Failed to enumerate processes>");
+                }
+                sb.AppendLine();
+                sb.AppendLine(ex.ToString());
+                File.WriteAllText(path, sb.ToString());
+            }
+            catch
+            {
+                // ignore file I/O errors
+            }
             try
             {
                 MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using ToNRoundCounter.UI;
@@ -11,7 +12,7 @@ namespace ToNRoundCounter
     static class Program
     {
         [STAThread]
-        static void Main()
+        static void Main(string[] args)
         {
             WinFormsApp.EnableVisualStyles();
             WinFormsApp.SetCompatibleTextRenderingDefault(false);
@@ -57,6 +58,13 @@ namespace ToNRoundCounter
 
             var provider = services.BuildServiceProvider();
             provider.GetRequiredService<IErrorReporter>().Register();
+
+            if (args.Contains("--debug") &&
+                args.SkipWhile(a => a != "--test").Skip(1).FirstOrDefault() == "crashreporting")
+            {
+                throw new InvalidOperationException("Crash report test triggered");
+            }
+
             WinFormsApp.Run(provider.GetRequiredService<MainForm>());
             (provider as IDisposable)?.Dispose();
         }

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -106,10 +106,12 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Deployment" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Compression" />
+  <Reference Include="System.Data" />
+  <Reference Include="System.Deployment" />
+  <Reference Include="System.Drawing" />
+  <Reference Include="Microsoft.VisualBasic" />
+  <Reference Include="System.Management" />
+  <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />


### PR DESCRIPTION
## Summary
- Capture OS details, memory stats, running processes, CPU and GPU names, GPU driver version, and SSD model/usage in crash reports
- Reference `Microsoft.VisualBasic` and `System.Management` for system and hardware information
- Add test mode to intentionally trigger a crash report when launched with `--debug --test crashreporting`

## Testing
- `~/.dotnet/dotnet test` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c215b507848329975981b73cbbdd3b