### PR TITLE
Implement IDisposable for HttpClientWrapper

### DIFF
--- a/Infrastructure/HttpClientWrapper.cs
+++ b/Infrastructure/HttpClientWrapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,11 +9,13 @@ namespace ToNRoundCounter.Infrastructure
     /// <summary>
     /// Default implementation of <see cref="IHttpClient"/> using <see cref="HttpClient"/>.
     /// </summary>
-    public class HttpClientWrapper : IHttpClient
+    public class HttpClientWrapper : IHttpClient, IDisposable
     {
         private readonly HttpClient _client = new HttpClient();
 
         public Task<HttpResponseMessage> PostAsync(string url, HttpContent content, CancellationToken cancellationToken)
             => _client.PostAsync(url, content, cancellationToken);
+
+        public void Dispose() => _client.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- dispose underlying HttpClient by having HttpClientWrapper implement IDisposable

## Testing
- `dotnet test` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c228620b2c832986e6864414595002