### PR TITLE
Dispose token and lock scheduling

### DIFF
--- a/Application/AutoSuicideService.cs
+++ b/Application/AutoSuicideService.cs
@@ -9,20 +9,38 @@ namespace ToNRoundCounter.Application
     /// </summary>
     public class AutoSuicideService
     {
+        private readonly object _lock = new object();
         private CancellationTokenSource _tokenSource;
         public DateTime RoundStartTime { get; private set; }
 
-        public bool HasScheduled => _tokenSource != null;
+        public bool HasScheduled
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _tokenSource != null && !_tokenSource.IsCancellationRequested;
+                }
+            }
+        }
 
         public void Schedule(TimeSpan delay, bool resetStartTime, Action action)
         {
-            _tokenSource?.Cancel();
-            if (resetStartTime || RoundStartTime == default(DateTime))
+            CancellationTokenSource oldCts;
+            CancellationTokenSource cts;
+            lock (_lock)
             {
-                RoundStartTime = DateTime.UtcNow;
+                oldCts = _tokenSource;
+                if (resetStartTime || RoundStartTime == default(DateTime))
+                {
+                    RoundStartTime = DateTime.UtcNow;
+                }
+                cts = new CancellationTokenSource();
+                _tokenSource = cts;
             }
-            var cts = new CancellationTokenSource();
-            _tokenSource = cts;
+            oldCts?.Cancel();
+            oldCts?.Dispose();
+
             _ = Task.Run(async () =>
             {
                 try
@@ -38,18 +56,28 @@ namespace ToNRoundCounter.Application
                 }
                 finally
                 {
-                    if (_tokenSource == cts)
+                    lock (_lock)
                     {
-                        _tokenSource = null;
+                        if (_tokenSource == cts)
+                        {
+                            _tokenSource = null;
+                        }
                     }
+                    cts.Dispose();
                 }
             });
         }
 
         public void Cancel()
         {
-            _tokenSource?.Cancel();
-            _tokenSource = null;
+            CancellationTokenSource cts;
+            lock (_lock)
+            {
+                cts = _tokenSource;
+                _tokenSource = null;
+            }
+            cts?.Cancel();
+            cts?.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- dispose existing CancellationTokenSource when scheduling or cancelling
- synchronize token access with a lock and update HasScheduled to reflect cancellation state

## Testing
- `dotnet test` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c22962bf048329980b863697a5b9b6