### PR TITLE
Add EnumeratorCancellation attribute to ReadAllAsync

### DIFF
--- a/Infrastructure/ChannelReaderExtensions.cs
+++ b/Infrastructure/ChannelReaderExtensions.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
+using System.Runtime.CompilerServices;
 
 namespace ToNRoundCounter.Infrastructure
 {
@@ -9,7 +10,7 @@ namespace ToNRoundCounter.Infrastructure
     /// </summary>
     public static class ChannelReaderExtensions
     {
-        public static async IAsyncEnumerable<T> ReadAllAsync<T>(this ChannelReader<T> reader, CancellationToken cancellationToken = default)
+        public static async IAsyncEnumerable<T> ReadAllAsync<T>(this ChannelReader<T> reader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
             {


### PR DESCRIPTION
## Summary
- apply `EnumeratorCancellation` attribute to `ReadAllAsync` cancellation token
- include missing compiler services namespace

## Testing
- `dotnet build` *(fails: Could not run "GenerateResource" task; missing NET x86 task host)*

------
https://chatgpt.com/codex/tasks/task_e_68c2295b6f7c83299e9c310de9fbee1a