### PR TITLE
Log module loader exceptions

### DIFF
--- a/Application/Events.cs
+++ b/Application/Events.cs
@@ -7,4 +7,5 @@ namespace ToNRoundCounter.Application
     public record OscConnected;
     public record OscDisconnected;
     public record SettingsValidationFailed(System.Collections.Generic.IEnumerable<string> Errors);
+    public record ModuleLoadFailed(string File, System.Exception Exception);
 }

--- a/Infrastructure/ModuleLoader.cs
+++ b/Infrastructure/ModuleLoader.cs
@@ -12,7 +12,7 @@ namespace ToNRoundCounter.Infrastructure
     /// </summary>
     public static class ModuleLoader
     {
-        public static void LoadModules(IServiceCollection services, string path = "Modules")
+        public static void LoadModules(IServiceCollection services, IEventLogger logger, IEventBus bus, string path = "Modules")
         {
             if (!Directory.Exists(path))
                 return;
@@ -32,9 +32,10 @@ namespace ToNRoundCounter.Infrastructure
                         }
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Ignore modules that fail to load
+                    logger.LogEvent("ModuleLoad", "Failed to load module " + file + ": " + ex.Message, Serilog.Events.LogEventLevel.Error);
+                    bus.Publish(new ModuleLoadFailed(file, ex));
                 }
             }
         }

--- a/Program.cs
+++ b/Program.cs
@@ -25,9 +25,12 @@ namespace ToNRoundCounter
 
             var services = new ServiceCollection();
 
+            var eventLogger = new EventLogger();
+            var eventBus = new EventBus();
+
             services.AddSingleton<ICancellationProvider, CancellationProvider>();
-            services.AddSingleton<IEventLogger, EventLogger>();
-            services.AddSingleton<IEventBus, EventBus>();
+            services.AddSingleton<IEventLogger>(eventLogger);
+            services.AddSingleton<IEventBus>(eventBus);
             services.AddSingleton<IOSCListener>(sp => new OSCListener(sp.GetRequiredService<IEventBus>(), sp.GetRequiredService<ICancellationProvider>(), sp.GetRequiredService<IEventLogger>()));
             services.AddSingleton<IWebSocketClient>(sp => new WebSocketClient("ws://127.0.0.1:11398", sp.GetRequiredService<IEventBus>(), sp.GetRequiredService<ICancellationProvider>(), sp.GetRequiredService<IEventLogger>()));
             services.AddSingleton<AutoSuicideService>();
@@ -42,7 +45,7 @@ namespace ToNRoundCounter
                 sp.GetRequiredService<IAppSettings>(),
                 sp.GetRequiredService<IEventLogger>(),
                 sp.GetRequiredService<IHttpClient>()));
-            ModuleLoader.LoadModules(services);
+            ModuleLoader.LoadModules(services, eventLogger, eventBus);
             services.AddSingleton<MainForm>(sp => new MainForm(
                 sp.GetRequiredService<IWebSocketClient>(),
                 sp.GetRequiredService<IOSCListener>(),


### PR DESCRIPTION
## Summary
- log module load failures
- notify event bus when modules fail to load
- expose ModuleLoadFailed event and pass logger/bus to ModuleLoader

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c22965adf483298da919e64fbdbf16