### PR TITLE
Allow escaped colons in auto suicide rule expressions

### DIFF
--- a/ToNRoundCounter.Tests/AutoSuicideRuleTests.cs
+++ b/ToNRoundCounter.Tests/AutoSuicideRuleTests.cs
@@ -71,5 +71,15 @@ namespace ToNRoundCounter.Tests
             Assert.True(ok);
             Assert.True(rule.Matches("C", null, (a, b) => a == b));
         }
+
+        [Fact]
+        public void TryParse_AllowsEscapedColon()
+        {
+            var ok = AutoSuicideRule.TryParse(@"A\:B:C\:D:1", out var rule);
+            Assert.True(ok);
+            Assert.Equal("A:B", rule.Round);
+            Assert.Equal("C:D", rule.Terror);
+            Assert.Equal(1, rule.Value);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Handle escaped `:` when parsing auto suicide rules and escape them when serializing
- Add unit test validating expressions can include escaped `:`

## Testing
- `FrameworkPathOverride=/usr/lib/mono/4.8-api dotnet test` *(fails: Could not run the "GenerateResource" task because MSBuild could not create or connect to a task host with runtime "NET" and architecture "x86".)*

------
https://chatgpt.com/codex/tasks/task_e_68c22b0fefdc8329aec7675ee9c52f3d