### PR TITLE
Fix warnings and file write compatibility

### DIFF
--- a/Infrastructure/AppSettings.cs
+++ b/Infrastructure/AppSettings.cs
@@ -129,7 +129,10 @@ namespace ToNRoundCounter.Infrastructure
             string json = JsonConvert.SerializeObject(settings, Formatting.Indented);
             try
             {
-                await File.WriteAllTextAsync(settingsFile, json);
+                using (var writer = new StreamWriter(settingsFile, false))
+                {
+                    await writer.WriteAsync(json).ConfigureAwait(false);
+                }
             }
             catch (Exception ex)
             {

--- a/Infrastructure/OSCListener.cs
+++ b/Infrastructure/OSCListener.cs
@@ -17,7 +17,7 @@ namespace ToNRoundCounter.Infrastructure
         private readonly ICancellationProvider _cancellation;
         private readonly IEventLogger _logger;
         private readonly Channel<OscMessage> _channel = Channel.CreateUnbounded<OscMessage>();
-        private Task? _processingTask;
+        private Task _processingTask;
 
         public OSCListener(IEventBus bus, ICancellationProvider cancellation, IEventLogger logger)
         {

--- a/Infrastructure/WebSocketClient.cs
+++ b/Infrastructure/WebSocketClient.cs
@@ -22,7 +22,7 @@ namespace ToNRoundCounter.Infrastructure
         private readonly ICancellationProvider _cancellation;
         private readonly IEventLogger _logger;
         private readonly Channel<string> _channel = Channel.CreateUnbounded<string>();
-        private Task? _processingTask;
+        private Task _processingTask;
 
         public WebSocketClient(string url, IEventBus bus, ICancellationProvider cancellation, IEventLogger logger)
         {


### PR DESCRIPTION
## Summary
- use StreamWriter for settings save to avoid missing File.WriteAllTextAsync API
- remove nullable annotations outside nullable context

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*
- `dotnet test` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2366fc8948329850afa9bd17cb6c4