### PR TITLE
Cancel scheduled suicide when overridden by terror rules

### DIFF
--- a/ToNRoundCounter.Tests/AutoSuicideCancelTests.cs
+++ b/ToNRoundCounter.Tests/AutoSuicideCancelTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ToNRoundCounter.Application;
+using ToNRoundCounter.Domain;
+using Xunit;
+
+namespace ToNRoundCounter.Tests
+{
+    public class AutoSuicideCancelTests
+    {
+        [Fact]
+        public async Task TerrorRuleCancelsScheduledSuicide()
+        {
+            // Arrange
+            AutoSuicideRule.TryParse("クラシック::1", out var rule1);
+            AutoSuicideRule.TryParse("クラシック:Don't Touch Me:0", out var rule2);
+            var rules = new List<AutoSuicideRule> { rule1, rule2 };
+
+            int ShouldAutoSuicide(string roundType, string terrorName)
+            {
+                for (int i = rules.Count - 1; i >= 0; i--)
+                {
+                    if (rules[i].Matches(roundType, terrorName, (a, b) => a == b))
+                        return rules[i].Value;
+                }
+                return 0;
+            }
+
+            var service = new AutoSuicideService();
+            bool triggered = false;
+
+            // Simulate ROUND_TYPE event
+            int action = ShouldAutoSuicide("クラシック", null);
+            if (action == 1)
+            {
+                service.Schedule(TimeSpan.FromMilliseconds(50), true, () => triggered = true);
+            }
+
+            // Act: TERRORS event
+            int terrorAction = ShouldAutoSuicide("クラシック", "Don't Touch Me");
+            if (terrorAction == 0 && service.HasScheduled)
+            {
+                service.Cancel();
+            }
+            else if (terrorAction == 1)
+            {
+                service.Schedule(TimeSpan.Zero, false, () => triggered = true);
+            }
+            else if (terrorAction == 2)
+            {
+                service.Schedule(TimeSpan.FromMilliseconds(50), false, () => triggered = true);
+            }
+
+            await Task.Delay(100);
+
+            // Assert
+            Assert.False(triggered);
+            Assert.False(service.HasScheduled);
+        }
+    }
+}
+

--- a/ToNRoundCounter.Tests/ToNRoundCounter.Tests.csproj
+++ b/ToNRoundCounter.Tests/ToNRoundCounter.Tests.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="AutoSuicideRuleTests.cs" />
     <Compile Include="StateServiceTests.cs" />
+    <Compile Include="AutoSuicideCancelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ToNRoundCounter.csproj">

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -662,6 +662,10 @@ namespace ToNRoundCounter.UI
                         }
                         //もしroundTypeが自動自殺ラウンド対象なら自動自殺
                         int terrorAction = ShouldAutoSuicide(roundType, stateService.CurrentRound.TerrorKey);
+                        if (terrorAction == 0 && autoSuicideService.HasScheduled)
+                        {
+                            autoSuicideService.Cancel();
+                        }
                         if (issetAllSelfKillMode || terrorAction == 1)
                         {
                             _ = Task.Run(() => PerformAutoSuicide());


### PR DESCRIPTION
## Summary
- cancel pending auto-suicide when a later TERRORS rule disables it
- add regression test ensuring TERRORS("Don't Touch Me") cancels auto-suicide scheduled from ROUND_TYPE

## Testing
- `dotnet test` *(fails: Could not run the "GenerateResource" task because MSBuild could not create or connect to a task host with runtime "NET" and architecture "x86".)*


------
https://chatgpt.com/codex/tasks/task_e_68c23b232fd083298d1829169aabf605