### PR TITLE
Fix nested negation test expectation

### DIFF
--- a/ToNRoundCounter.Tests/AutoSuicideRuleTests.cs
+++ b/ToNRoundCounter.Tests/AutoSuicideRuleTests.cs
@@ -69,7 +69,7 @@ namespace ToNRoundCounter.Tests
         {
             var ok = AutoSuicideRule.TryParse("!(!(A||B)&&C)::1", out var rule);
             Assert.True(ok);
-            Assert.True(rule.Matches("C", null, (a, b) => a == b));
+            Assert.False(rule.Matches("C", null, (a, b) => a == b));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- correct nested negation test to assert non-match for round "C"

## Testing
- `dotnet test` *(fails: reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c240e2ad708329b1f9e40ed2dc0c49