### PR TITLE
Expand test coverage for rule parsing and aggregates

### DIFF
--- a/ToNRoundCounter.Tests/AutoSuicideRuleTests.cs
+++ b/ToNRoundCounter.Tests/AutoSuicideRuleTests.cs
@@ -81,5 +81,22 @@ namespace ToNRoundCounter.Tests
             Assert.Equal("C:D", rule.Terror);
             Assert.Equal(1, rule.Value);
         }
+
+        [Fact]
+        public void ToString_PreservesEscapes()
+        {
+            AutoSuicideRule.TryParse(@"A\:B:C\\D:1", out var rule);
+            Assert.Equal(@"A\:B:C\\D:1", rule.ToString());
+        }
+
+        [Fact]
+        public void Covers_DetectsBroaderRules()
+        {
+            AutoSuicideRule.TryParse("A::1", out var broad);
+            AutoSuicideRule.TryParse("A:B:0", out var specific);
+
+            Assert.True(broad.Covers(specific));
+            Assert.False(specific.Covers(broad));
+        }
     }
 }

--- a/ToNRoundCounter.Tests/RoundAggregateTests.cs
+++ b/ToNRoundCounter.Tests/RoundAggregateTests.cs
@@ -1,0 +1,22 @@
+using ToNRoundCounter.Domain;
+using Xunit;
+
+namespace ToNRoundCounter.Tests
+{
+    public class RoundAggregateTests
+    {
+        [Fact]
+        public void SurvivalRate_IsZeroWhenTotalZero()
+        {
+            var agg = new RoundAggregate();
+            Assert.Equal(0, agg.SurvivalRate);
+        }
+
+        [Fact]
+        public void SurvivalRate_ComputesPercentage()
+        {
+            var agg = new RoundAggregate { Total = 4, Survival = 1, Death = 3 };
+            Assert.Equal(25, agg.SurvivalRate);
+        }
+    }
+}

--- a/ToNRoundCounter.Tests/ToNRoundCounter.Tests.csproj
+++ b/ToNRoundCounter.Tests/ToNRoundCounter.Tests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="AutoSuicideRuleTests.cs" />
     <Compile Include="StateServiceTests.cs" />
     <Compile Include="AutoSuicideCancelTests.cs" />
+    <Compile Include="RoundAggregateTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ToNRoundCounter.csproj">
@@ -52,6 +53,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -221,6 +221,8 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
## Summary
- add coverage tests for AutoSuicideRule ToString and Covers
- test RoundAggregate.SurvivalRate calculations
- include Microsoft.NETFramework.ReferenceAssemblies for cross-platform builds

## Testing
- `dotnet test` *(fails: Could not run the "GenerateResource" task because MSBuild could not create or connect to a task host with runtime "NET" and architecture "x86".)*

------
https://chatgpt.com/codex/tasks/task_e_68c243732ffc83298c70112a86e09f64