### PR TITLE
Add detailed errors for auto-suicide rule parsing

### DIFF
--- a/ToNRoundCounter.Tests/AutoSuicideRuleTests.cs
+++ b/ToNRoundCounter.Tests/AutoSuicideRuleTests.cs
@@ -90,6 +90,30 @@ namespace ToNRoundCounter.Tests
         }
 
         [Fact]
+        public void TryParseDetailed_ReturnsSegmentError()
+        {
+            var ok = AutoSuicideRule.TryParseDetailed("A:1", out var _, out var err);
+            Assert.False(ok);
+            Assert.Equal("セグメント数不正", err);
+        }
+
+        [Fact]
+        public void TryParseDetailed_ReturnsValueError()
+        {
+            var ok = AutoSuicideRule.TryParseDetailed("A:B:5", out var _, out var err);
+            Assert.False(ok);
+            Assert.Equal("値が 0/1/2 以外", err);
+        }
+
+        [Fact]
+        public void TryParseDetailed_ReturnsExpressionError()
+        {
+            var ok = AutoSuicideRule.TryParseDetailed("(A:B:1", out var _, out var err);
+            Assert.False(ok);
+            Assert.Equal("括弧の不整合や演算子の誤用", err);
+        }
+
+        [Fact]
         public void Covers_DetectsBroaderRules()
         {
             AutoSuicideRule.TryParse("A::1", out var broad);

--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -381,7 +381,7 @@ namespace ToNRoundCounter.UI
                     }
                     else
                     {
-                        errors.Add($"{i + 1}行目: {err}");
+                        errors.Add($"{i + 1}行目: {LanguageManager.Translate(err)}");
                     }
                 }
                 if (errors.Any())


### PR DESCRIPTION
## Summary
- return specific error strings in `AutoSuicideRule.TryParseDetailed` for invalid segment counts, illegal values, and malformed expressions
- surface detailed error messages in settings panel validation
- add unit tests covering the new detailed error cases

## Testing
- `dotnet test` *(fails: Could not run the "GenerateResource" task because MSBuild could not create or connect to a task host with runtime "NET" and architecture "x86")*

------
https://chatgpt.com/codex/tasks/task_e_68c244a21a8c8329b6dfc7d274ed60eb