### PR TITLE
Include stack trace in crash report

### DIFF
--- a/Infrastructure/ErrorReporter.cs
+++ b/Infrastructure/ErrorReporter.cs
@@ -144,7 +144,17 @@ namespace ToNRoundCounter.Infrastructure
                     sb.AppendLine("  <Failed to enumerate processes>");
                 }
                 sb.AppendLine();
-                sb.AppendLine(ex.ToString());
+                sb.AppendLine($"Exception Type: {ex.GetType()}");
+                sb.AppendLine($"Message: {ex.Message}");
+                if (!string.IsNullOrWhiteSpace(ex.StackTrace))
+                {
+                    sb.AppendLine("Stack Trace:");
+                    sb.AppendLine(ex.StackTrace);
+                }
+                else
+                {
+                    sb.AppendLine("Stack Trace: <none>");
+                }
                 File.WriteAllText(path, sb.ToString());
             }
             catch


### PR DESCRIPTION
## Summary
- include exception type, message, and stack trace in generated crash reports

## Testing
- `dotnet test` *(fails: Could not run the "GenerateResource" task because MSBuild could not create or connect to a task host with runtime "NET" and architecture "x86")*

------
https://chatgpt.com/codex/tasks/task_e_68c262016c8c8329ac0aee36aefbd89f