### PR TITLE
Fix stack trace output formatting

### DIFF
--- a/Infrastructure/ErrorReporter.cs
+++ b/Infrastructure/ErrorReporter.cs
@@ -149,7 +149,12 @@ namespace ToNRoundCounter.Infrastructure
                 if (!string.IsNullOrWhiteSpace(ex.StackTrace))
                 {
                     sb.AppendLine("Stack Trace:");
-                    sb.AppendLine(ex.StackTrace);
+                    foreach (var line in ex.StackTrace
+                        .Replace("\r\n", "\n")
+                        .Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        sb.AppendLine(line);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Normalize stack trace line endings and append lines individually to avoid collapsing into a single line

## Testing
- `dotnet test` *(fails: Could not run the GenerateResource task with runtime "NET" and architecture "x86")*

------
https://chatgpt.com/codex/tasks/task_e_68c27473740c8329800f9ed93231550c