### PR TITLE
Fix potential crash when damage info panel unavailable

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -695,7 +695,10 @@ namespace ToNRoundCounter.UI
                         stateService.CurrentRound.Damage += damageValue;
                         _dispatcher.Invoke(() =>
                         {
-                            InfoPanel.DamageValue.Text = stateService.CurrentRound.Damage.ToString();
+                            if (InfoPanel?.DamageValue != null)
+                            {
+                                InfoPanel.DamageValue.Text = stateService.CurrentRound.Damage.ToString();
+                            }
                         });
                     }
                 }


### PR DESCRIPTION
## Summary
- Avoid `NullReferenceException` when updating damage text if the info panel or label isn't present

## Testing
- `dotnet test` *(fails: Could not run "GenerateResource" task because MSBuild could not create or connect to a task host with runtime "NET" and architecture "x86")*


------
https://chatgpt.com/codex/tasks/task_e_68c2822444988329bc913708bbf74315