### PR TITLE
Avoid clearing InfoPanel on missing ROUND_ACTIVE value

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1267,8 +1267,11 @@ namespace ToNRoundCounter.UI
         }
         private void ProcessRoundActive(JObject json)
         {
-            bool active = json["Value"] != null && json["Value"].ToObject<bool>();
-            if (active)
+            bool? active = json["Value"]?.ToObject<bool?>();
+            if (active == null)
+                return;
+
+            if (active == true)
             {
                 if (stateService.CurrentRound == null)
                 {


### PR DESCRIPTION
## Summary
- guard ProcessRoundActive against missing `Value` to avoid destroying InfoPanel when ROUND_ACTIVE event is malformed

## Testing
- `dotnet test` *(fails: Could not run the "GenerateResource" task because MSBuild could not create or connect to a task host with runtime "NET" and architecture "x86".)*

------
https://chatgpt.com/codex/tasks/task_e_68c28c0e6c30832989bb2d93feb76ce6