### PR TITLE
Use main form for UI dispatcher

### DIFF
--- a/Infrastructure/WinFormsDispatcher.cs
+++ b/Infrastructure/WinFormsDispatcher.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Linq;
 using System.Windows.Forms;
 using ToNRoundCounter.Application;
-using WinFormsApp = System.Windows.Forms.Application;
 
 namespace ToNRoundCounter.Infrastructure
 {
@@ -11,19 +9,29 @@ namespace ToNRoundCounter.Infrastructure
     /// </summary>
     public class WinFormsDispatcher : IUiDispatcher
     {
+        private Form? _mainForm;
+
+        public void SetMainForm(Form form)
+        {
+            _mainForm = form;
+        }
+
         public void Invoke(Action action)
         {
-            if (WinFormsApp.OpenForms.Count > 0)
+            var form = _mainForm;
+            if (form == null || form.IsDisposed)
             {
-                var form = WinFormsApp.OpenForms.Cast<Form>().First();
-                if (form.InvokeRequired)
-                {
-                    form.BeginInvoke(action);
-                }
-                else
-                {
-                    action();
-                }
+                return;
+            }
+
+            if (!form.IsHandleCreated)
+            {
+                return;
+            }
+
+            if (form.InvokeRequired)
+            {
+                form.BeginInvoke(action);
             }
             else
             {

--- a/Program.cs
+++ b/Program.cs
@@ -79,13 +79,16 @@ namespace ToNRoundCounter
             var provider = services.BuildServiceProvider();
             provider.GetRequiredService<IErrorReporter>().Register();
 
+            var mainForm = provider.GetRequiredService<MainForm>();
+            ((WinFormsDispatcher)provider.GetRequiredService<IUiDispatcher>()).SetMainForm(mainForm);
+
             if (args.Contains("--debug") &&
                 args.SkipWhile(a => a != "--test").Skip(1).FirstOrDefault() == "crashreporting")
             {
                 throw new InvalidOperationException("Crash report test triggered");
             }
 
-            WinFormsApp.Run(provider.GetRequiredService<MainForm>());
+            WinFormsApp.Run(mainForm);
             (provider as IDisposable)?.Dispose();
         }
     }


### PR DESCRIPTION
## Summary
- Store main form at startup and use it for UI dispatching
- Safely handle disposed or uninitialized forms before invoking actions
- Initialize dispatcher with main form in Program

## Testing
- `dotnet test` *(fails: Could not run the "GenerateResource" task with x86 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ac7733108329b957709b5305c102