### PR TITLE
Improve thread safety in core utilities

### DIFF
--- a/Infrastructure/EventBus.cs
+++ b/Infrastructure/EventBus.cs
@@ -10,42 +10,31 @@ namespace ToNRoundCounter.Infrastructure
     /// </summary>
     public class EventBus : IEventBus
     {
-        private readonly ConcurrentDictionary<Type, List<Delegate>> _handlers = new();
+        private readonly ConcurrentDictionary<Type, ConcurrentDictionary<Delegate, byte>> _handlers = new();
 
         public void Subscribe<T>(Action<T> handler)
         {
-            var list = _handlers.GetOrAdd(typeof(T), _ => new List<Delegate>());
-            lock (list)
-            {
-                list.Add(handler);
-            }
+            var dict = _handlers.GetOrAdd(typeof(T), _ => new ConcurrentDictionary<Delegate, byte>());
+            dict.TryAdd(handler, 0);
         }
 
         public void Unsubscribe<T>(Action<T> handler)
         {
-            if (_handlers.TryGetValue(typeof(T), out var list))
+            if (_handlers.TryGetValue(typeof(T), out var dict))
             {
-                lock (list)
+                dict.TryRemove(handler, out _);
+                if (dict.IsEmpty)
                 {
-                    list.Remove(handler);
-                    if (list.Count == 0)
-                    {
-                        _handlers.TryRemove(typeof(T), out _);
-                    }
+                    _handlers.TryRemove(typeof(T), out _);
                 }
             }
         }
 
         public void Publish<T>(T message)
         {
-            if (_handlers.TryGetValue(typeof(T), out var list))
+            if (_handlers.TryGetValue(typeof(T), out var dict))
             {
-                Delegate[] snapshot;
-                lock (list)
-                {
-                    snapshot = list.ToArray();
-                }
-                foreach (var d in snapshot)
+                foreach (var d in dict.Keys)
                 {
                     if (d is Action<T> action)
                     {

--- a/Infrastructure/LanguageManager.cs
+++ b/Infrastructure/LanguageManager.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Resources;
+using System.Threading;
 
 namespace ToNRoundCounter.Infrastructure
 {
@@ -12,12 +13,13 @@ namespace ToNRoundCounter.Infrastructure
 
         public static void SetLanguage(string cultureCode)
         {
-            _culture = new CultureInfo(cultureCode);
+            Interlocked.Exchange(ref _culture, new CultureInfo(cultureCode));
         }
 
         public static string Translate(string key)
         {
-            return _resourceManager.GetString(key, _culture) ?? key;
+            var culture = Volatile.Read(ref _culture);
+            return _resourceManager.GetString(key, culture) ?? key;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace lock-based event bus with concurrent dictionary approach
- Guard LanguageManager culture updates with interlocked operations

## Testing
- `dotnet test` *(fails: Could not run GenerateResource task because MSBuild could not create or connect to a task host with runtime "NET" and architecture "x86")*

------
https://chatgpt.com/codex/tasks/task_e_68c2af6d90e8832997261da20b72b3ce