### PR TITLE
Fix potential NullReferenceException when updating damage display

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -712,14 +712,15 @@ namespace ToNRoundCounter.UI
                 else if (eventType == "DAMAGED")
                 {
                     int damageValue = json.Value<int>("Value");
-                    if (stateService.CurrentRound != null)
+                    var currentRound = stateService.CurrentRound;
+                    if (currentRound != null)
                     {
-                        stateService.CurrentRound.Damage += damageValue;
+                        currentRound.Damage += damageValue;
                         _dispatcher.Invoke(() =>
                         {
                             if (InfoPanel?.DamageValue != null)
                             {
-                                InfoPanel.DamageValue.Text = stateService.CurrentRound.Damage.ToString();
+                                InfoPanel.DamageValue.Text = currentRound.Damage.ToString();
                             }
                         });
                     }


### PR DESCRIPTION
## Summary
- Avoid NullReferenceException when updating damage statistics by capturing the current round before dispatching UI updates

## Testing
- `dotnet build` *(fails: Could not run the "GenerateResource" task because MSBuild could not create or connect to a task host with runtime "NET" and architecture "x86". See logs for details)*
- `dotnet test` *(fails: Could not run the "GenerateResource" task because MSBuild could not create or connect to a task host with runtime "NET" and architecture "x86". See logs for details)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a58840a08329ad179fa290b69998