### PR TITLE
Fix delayed auto suicide scheduling

### DIFF
--- a/Domain/AutoSuicideRule.cs
+++ b/Domain/AutoSuicideRule.cs
@@ -148,6 +148,14 @@ namespace ToNRoundCounter.Domain
             return roundMatch && terrorMatch;
         }
 
+        public bool MatchesRound(string round, Func<string, string, bool> comparer)
+        {
+            if (RoundExpression == null)
+                return true;
+            bool match = Evaluate(RoundExpression, round, comparer);
+            return RoundNegate ? !match : match;
+        }
+
         public bool Covers(AutoSuicideRule other)
         {
             // Determine if this rule's conditions cover another rule's conditions.


### PR DESCRIPTION
## Summary
- add a round-only match helper to auto-suicide rules so we can detect rules that require terror info
- adjust auto-suicide scheduling to defer to the delayed timer when a delayed rule might apply even before terror data arrives
- expose an overload of ShouldAutoSuicide that reports pending delayed rules for callers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4b36904883299163ef4aead59479