### PR TITLE
Add AFK jump module and handler infrastructure

### DIFF
--- a/Application/IAfkWarningHandler.cs
+++ b/Application/IAfkWarningHandler.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ToNRoundCounter.Application
+{
+    /// <summary>
+    /// Provides information related to an AFK warning trigger.
+    /// </summary>
+    public sealed class AfkWarningContext
+    {
+        public AfkWarningContext(double idleSeconds)
+        {
+            IdleSeconds = idleSeconds;
+        }
+
+        /// <summary>
+        /// Gets the number of seconds the player has been idle when the warning fired.
+        /// </summary>
+        public double IdleSeconds { get; }
+    }
+
+    /// <summary>
+    /// Represents a handler that can intercept the AFK warning behaviour.
+    /// </summary>
+    public interface IAfkWarningHandler
+    {
+        /// <summary>
+        /// Handles the AFK warning.
+        /// </summary>
+        /// <param name="context">Contextual data about the warning.</param>
+        /// <param name="cancellationToken">Token used to observe cancellation requests.</param>
+        /// <returns><c>true</c> if the handler has processed the warning and the default behaviour should be skipped; otherwise, <c>false</c>.</returns>
+        Task<bool> HandleAsync(AfkWarningContext context, CancellationToken cancellationToken);
+    }
+}

--- a/Modules/AfkJumpModule/AfkJumpModule.cs
+++ b/Modules/AfkJumpModule/AfkJumpModule.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Rug.Osc;
+using Serilog.Events;
+using ToNRoundCounter.Application;
+
+namespace ToNRoundCounter.Modules.AfkJump
+{
+    public sealed class AfkJumpModule : IModule
+    {
+        public void RegisterServices(IServiceCollection services)
+        {
+            services.AddSingleton<IAfkWarningHandler, AfkJumpHandler>();
+        }
+    }
+
+    internal sealed class AfkJumpHandler : IAfkWarningHandler
+    {
+        private static readonly TimeSpan FirstDelay = TimeSpan.FromSeconds(0.2);
+        private static readonly TimeSpan SecondDelay = TimeSpan.FromSeconds(0.8);
+        private readonly IEventLogger _logger;
+
+        public AfkJumpHandler(IEventLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task<bool> HandleAsync(AfkWarningContext context, CancellationToken cancellationToken)
+        {
+            try
+            {
+                _logger.LogEvent("AfkJumpModule", "Suppressing AFK sound and sending jump input sequence.");
+                using (var sender = new OscSender(IPAddress.Loopback, 0, 9000))
+                {
+                    sender.Connect();
+                    SendJumpValue(sender, 0);
+                    await Task.Delay(FirstDelay, cancellationToken);
+                    SendJumpValue(sender, 1);
+                    await Task.Delay(SecondDelay, cancellationToken);
+                    SendJumpValue(sender, 0);
+                    sender.Close();
+                }
+
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogEvent("AfkJumpModule", "Jump input sequence cancelled.", LogEventLevel.Warning);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogEvent("AfkJumpModule", $"Failed to send jump input sequence: {ex}", LogEventLevel.Error);
+                return false;
+            }
+        }
+
+        private static void SendJumpValue(OscSender sender, int value)
+        {
+            var message = new OscMessage("/input/Jump", value);
+            sender.Send(message);
+        }
+    }
+}

--- a/Modules/AfkJumpModule/AfkJumpModule.csproj
+++ b/Modules/AfkJumpModule/AfkJumpModule.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)..\..\</SolutionDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ToNRoundCounter.csproj" />
+    <Reference Include="Rug.Osc">
+      <HintPath>..\..\packages\Rug.Osc.1.2.5\lib\Rug.Osc.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+  <Target Name="CopyModuleToOutput" AfterTargets="Build">
+    <MakeDir Directories="$(SolutionDir)Modules" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)Modules" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/Program.cs
+++ b/Program.cs
@@ -74,7 +74,8 @@ namespace ToNRoundCounter
                 sp.GetRequiredService<IEventBus>(),
                 sp.GetRequiredService<ICancellationProvider>(),
                 sp.GetRequiredService<IInputSender>(),
-                sp.GetRequiredService<IUiDispatcher>()));
+                sp.GetRequiredService<IUiDispatcher>(),
+                sp.GetServices<IAfkWarningHandler>()));
 
             var provider = services.BuildServiceProvider();
             provider.GetRequiredService<IErrorReporter>().Register();

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Application\IOSCListener.cs" />
     <Compile Include="Application\IAppSettings.cs" />
     <Compile Include="Application\IInputSender.cs" />
+    <Compile Include="Application\IAfkWarningHandler.cs" />
     <Compile Include="Application\IErrorReporter.cs" />
     <Compile Include="Application\IUiDispatcher.cs" />
     <Compile Include="Application\IModule.cs" />

--- a/ToNRoundCounter.sln
+++ b/ToNRoundCounter.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Updater", "Updater\Updater.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToNRoundCounter.Tests", "ToNRoundCounter.Tests\ToNRoundCounter.Tests.csproj", "{A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AfkJumpModule", "Modules\AfkJumpModule\AfkJumpModule.csproj", "{884DDD21-B2B5-465D-AE30-24A2CB1D6934}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,11 +39,19 @@ Global
 		{A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Debug|x64.Build.0 = Debug|Any CPU
-		{A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Release|x64.ActiveCfg = Release|Any CPU
-		{A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Release|x64.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Release|x64.ActiveCfg = Release|Any CPU
+                {A0A9AD68-4D08-4D1A-ADEE-708CF89FBB60}.Release|x64.Build.0 = Release|Any CPU
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Debug|x64.Build.0 = Debug|Any CPU
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|Any CPU.Build.0 = Release|Any CPU
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|x64.ActiveCfg = Release|Any CPU
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|x64.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add an extensibility interface for AFK warning handlers and hook it into the main form
- create an AFK jump module that replaces the AFK sound with an OSC jump input sequence
- register the new module project inside the solution so it is copied to the runtime Modules folder

## Testing
- not run (dotnet tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd4ed114cc83299ea40150e3913b3a