### PR TITLE
Fix missing dependencies for AFK module support

### DIFF
--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -14,6 +14,7 @@
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -90,6 +91,12 @@
     </Reference>
     <Reference Include="Serilog.Sinks.File">
       <HintPath>packages\Serilog.Sinks.File.5.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Extensions.DependencyInjection.8.0.0\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Extensions.DependencyInjection.Abstractions.8.0.0\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/packages.config
+++ b/packages.config
@@ -5,6 +5,8 @@
   <package id="Serilog" version="4.0.0" targetFramework="net48" />
   <package id="Serilog.Sinks.Console" version="6.0.0" targetFramework="net48" />
   <package id="Serilog.Sinks.File" version="5.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="8.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="8.0.1" targetFramework="net48" />


### PR DESCRIPTION
## Summary
- add Microsoft.Extensions.DependencyInjection dependencies so AFK warning handlers can be resolved at runtime
- enable nullable reference types to silence compiler diagnostics about nullable annotations

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd55927b9c8329969c31b3cad46f14