### PR TITLE
Improve dependency resolution and module registration

### DIFF
--- a/Infrastructure/SimpleServiceCollection.cs
+++ b/Infrastructure/SimpleServiceCollection.cs
@@ -14,26 +14,34 @@ namespace Microsoft.Extensions.DependencyInjection
 
     public class ServiceCollection : IServiceCollection
     {
-        private readonly Dictionary<Type, Func<IServiceProvider, object>> _registrations = new();
+        private readonly Dictionary<Type, List<Func<IServiceProvider, object>>> _registrations = new();
 
         public void AddSingleton<TService, TImplementation>() where TImplementation : TService, new()
         {
-            _registrations[typeof(TService)] = _ => new TImplementation();
+            AddSingleton<TService>(_ => new TImplementation());
         }
 
         public void AddSingleton<TService>() where TService : class, new()
         {
-            _registrations[typeof(TService)] = _ => new TService();
+            AddSingleton<TService>(_ => new TService());
         }
 
         public void AddSingleton<TService>(Func<IServiceProvider, TService> factory)
         {
-            _registrations[typeof(TService)] = sp => factory(sp)!;
+            if (factory == null) throw new ArgumentNullException(nameof(factory));
+
+            if (!_registrations.TryGetValue(typeof(TService), out var factories))
+            {
+                factories = new List<Func<IServiceProvider, object>>();
+                _registrations[typeof(TService)] = factories;
+            }
+
+            factories.Add(sp => factory(sp)!);
         }
 
         public void AddSingleton<TService>(TService instance)
         {
-            _registrations[typeof(TService)] = _ => instance!;
+            AddSingleton<TService>(_ => instance!);
         }
 
         public IServiceProvider BuildServiceProvider()
@@ -44,32 +52,96 @@ namespace Microsoft.Extensions.DependencyInjection
 
     internal class SimpleServiceProvider : IServiceProvider, IDisposable
     {
-        private readonly Dictionary<Type, Func<IServiceProvider, object>> _registrations;
-        private readonly Dictionary<Type, object> _instances = new();
+        private readonly Dictionary<Type, List<Func<IServiceProvider, object>>> _registrations;
+        private readonly Dictionary<Type, List<object?>> _instances = new();
 
-        public SimpleServiceProvider(Dictionary<Type, Func<IServiceProvider, object>> registrations)
+        public SimpleServiceProvider(Dictionary<Type, List<Func<IServiceProvider, object>>> registrations)
         {
             _registrations = registrations;
         }
 
-        public object GetService(Type serviceType)
+        public object? GetService(Type serviceType)
         {
-            if (!_instances.TryGetValue(serviceType, out var instance))
+            if (serviceType == null)
             {
-                if (_registrations.TryGetValue(serviceType, out var factory))
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
+            if (serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                var elementType = serviceType.GetGenericArguments()[0];
+                return ResolveAll(elementType);
+            }
+
+            return ResolveSingle(serviceType);
+        }
+
+        private object? ResolveSingle(Type serviceType)
+        {
+            if (!_registrations.TryGetValue(serviceType, out var factories) || factories.Count == 0)
+            {
+                return null;
+            }
+
+            var instances = GetInstanceList(serviceType, factories.Count);
+            if (instances[0] == null)
+            {
+                instances[0] = factories[0](this);
+            }
+
+            return instances[0];
+        }
+
+        private object ResolveAll(Type serviceType)
+        {
+            if (!_registrations.TryGetValue(serviceType, out var factories) || factories.Count == 0)
+            {
+                return Array.CreateInstance(serviceType, 0);
+            }
+
+            var instances = GetInstanceList(serviceType, factories.Count);
+            for (var i = 0; i < factories.Count; i++)
+            {
+                if (instances[i] == null)
                 {
-                    instance = factory(this);
-                    _instances[serviceType] = instance;
+                    instances[i] = factories[i](this);
                 }
             }
-            return instance!;
+
+            var array = Array.CreateInstance(serviceType, factories.Count);
+            for (var i = 0; i < factories.Count; i++)
+            {
+                array.SetValue(instances[i], i);
+            }
+            return array;
+        }
+
+        private List<object?> GetInstanceList(Type serviceType, int requiredCount)
+        {
+            if (!_instances.TryGetValue(serviceType, out var instances))
+            {
+                instances = new List<object?>(new object?[requiredCount]);
+                _instances[serviceType] = instances;
+            }
+            else if (instances.Count < requiredCount)
+            {
+                while (instances.Count < requiredCount)
+                {
+                    instances.Add(null);
+                }
+            }
+
+            return instances;
         }
 
         public void Dispose()
         {
-            foreach (var disposable in _instances.Values)
+            foreach (var instanceList in _instances.Values)
             {
-                (disposable as IDisposable)?.Dispose();
+                foreach (var disposable in instanceList)
+                {
+                    (disposable as IDisposable)?.Dispose();
+                }
             }
         }
     }
@@ -78,12 +150,22 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static T GetRequiredService<T>(this IServiceProvider provider)
         {
+            if (provider == null) throw new ArgumentNullException(nameof(provider));
+
             var service = provider.GetService(typeof(T));
             if (service == null)
             {
                 throw new InvalidOperationException($"Service of type {typeof(T)} is not registered.");
             }
             return (T)service;
+        }
+
+        public static IEnumerable<T> GetServices<T>(this IServiceProvider provider)
+        {
+            if (provider == null) throw new ArgumentNullException(nameof(provider));
+
+            var services = provider.GetService(typeof(IEnumerable<T>));
+            return services as IEnumerable<T> ?? Array.Empty<T>();
         }
     }
 }

--- a/Modules/AfkJumpModule/AfkJumpModule.cs
+++ b/Modules/AfkJumpModule/AfkJumpModule.cs
@@ -13,7 +13,7 @@ namespace ToNRoundCounter.Modules.AfkJump
     {
         public void RegisterServices(IServiceCollection services)
         {
-            services.AddSingleton<IAfkWarningHandler, AfkJumpHandler>();
+            services.AddSingleton<IAfkWarningHandler>(sp => new AfkJumpHandler(sp.GetRequiredService<IEventLogger>()));
         }
     }
 

--- a/Modules/AfkJumpModule/AfkJumpModule.csproj
+++ b/Modules/AfkJumpModule/AfkJumpModule.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
   </ItemGroup>
 
   <Target Name="CopyModuleToOutput" AfterTargets="Build">


### PR DESCRIPTION
## Summary
- extend the custom service collection so it can keep multiple registrations and expose `GetServices<T>()`
- register the AFK jump handler through a factory so its dependencies are resolved by the container
- add an explicit Serilog package reference for the module project so logging types compile

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd56c708048329a0871091aa075db5