### PR TITLE
Allow manual workflow execution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build-release:
-    if: startsWith(github.event.head_commit.message, 'release ')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'release ')
     runs-on: windows-latest
     permissions:
       contents: write
@@ -28,6 +29,7 @@ jobs:
       - name: Package
         run: Compress-Archive -Path .\bin\x64\Release\* -DestinationPath ToNRoundCounter_latest.zip
       - name: Extract version
+        if: github.event_name != 'workflow_dispatch'
         id: get_version
         shell: bash
         run: |
@@ -35,6 +37,7 @@ jobs:
           VERSION="${MESSAGE#release }"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Create Release
+        if: github.event_name != 'workflow_dispatch'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
## Summary
- allow the release workflow to be run manually without relying on a commit message
- prevent the manual run from creating a GitHub release

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d561b0049c8329ae20ab294333a9f9