### PR TITLE
Fix release workflow NuGet restore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,12 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1
       - name: Restore NuGet packages
-        run: nuget restore ToNRoundCounter.sln
+        run: nuget restore ToNRoundCounter.sln -ConfigFile NuGet.config
       - name: Build
         run: msbuild ToNRoundCounter.sln /p:Configuration=Release /p:Platform=x64
       - name: Include updater

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <config>
+    <add key="repositoryPath" value="packages" />
+    <add key="globalPackagesFolder" value="packages" />
+  </config>
+</configuration>


### PR DESCRIPTION
## Summary
- install the official NuGet CLI before building
- restore packages using a repository NuGet.config that pins the nuget.org feed

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d566cf36ac8329a20a07d3d160855c