### PR TITLE
Support multiple auto launch and item music configurations

### DIFF
--- a/Application/IAppSettings.cs
+++ b/Application/IAppSettings.cs
@@ -35,13 +35,9 @@ namespace ToNRoundCounter.Application
         string LogFilePath { get; set; }
         string WebSocketIp { get; set; }
         bool AutoLaunchEnabled { get; set; }
-        string AutoLaunchExecutablePath { get; set; }
-        string AutoLaunchArguments { get; set; }
+        List<AutoLaunchEntry> AutoLaunchEntries { get; set; }
         bool ItemMusicEnabled { get; set; }
-        string ItemMusicItemName { get; set; }
-        string ItemMusicSoundPath { get; set; }
-        double ItemMusicMinSpeed { get; set; }
-        double ItemMusicMaxSpeed { get; set; }
+        List<ItemMusicEntry> ItemMusicEntries { get; set; }
         string DiscordWebhookUrl { get; set; }
         string LastSaveCode { get; set; }
         void Load();

--- a/Domain/AutoLaunchEntry.cs
+++ b/Domain/AutoLaunchEntry.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace ToNRoundCounter.Domain
+{
+    public class AutoLaunchEntry
+    {
+        public bool Enabled { get; set; }
+
+        public string ExecutablePath { get; set; } = string.Empty;
+
+        public string Arguments { get; set; } = string.Empty;
+
+        public AutoLaunchEntry Clone()
+        {
+            return new AutoLaunchEntry
+            {
+                Enabled = Enabled,
+                ExecutablePath = ExecutablePath ?? string.Empty,
+                Arguments = Arguments ?? string.Empty
+            };
+        }
+
+        public bool HasExecutablePath()
+        {
+            return !string.IsNullOrWhiteSpace(ExecutablePath);
+        }
+    }
+}

--- a/Domain/ItemMusicEntry.cs
+++ b/Domain/ItemMusicEntry.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace ToNRoundCounter.Domain
+{
+    public class ItemMusicEntry
+    {
+        public bool Enabled { get; set; }
+
+        public string ItemName { get; set; } = string.Empty;
+
+        public string SoundPath { get; set; } = string.Empty;
+
+        public double MinSpeed { get; set; }
+
+        public double MaxSpeed { get; set; }
+
+        public ItemMusicEntry Clone()
+        {
+            return new ItemMusicEntry
+            {
+                Enabled = Enabled,
+                ItemName = ItemName ?? string.Empty,
+                SoundPath = SoundPath ?? string.Empty,
+                MinSpeed = MinSpeed,
+                MaxSpeed = MaxSpeed
+            };
+        }
+    }
+}

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -159,6 +159,8 @@
     <Compile Include="Domain\TerrorMapNameCollection.cs" />
     <Compile Include="Domain\AutoSuicideRule.cs" />
     <Compile Include="Domain\AutoSuicidePreset.cs" />
+    <Compile Include="Domain\AutoLaunchEntry.cs" />
+    <Compile Include="Domain\ItemMusicEntry.cs" />
     <Compile Include="Domain\UnboundRoundDefinitions.cs" />
     <Compile Include="Application\AutoSuicideService.cs" />
     <Compile Include="Application\StateService.cs" />


### PR DESCRIPTION
## Summary
- add domain models and appsettings support for lists of auto-launch and item-music entries with legacy migration
- redesign settings panel UI to manage multiple auto-launch executables and item music triggers via editable grids
- update program startup and runtime item music playback to iterate over configured entries and handle per-entry loading

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c15eb84c8329b8455fe9105724ba