### PR TITLE
Add missing legacy app settings properties to interface

### DIFF
--- a/Application/IAppSettings.cs
+++ b/Application/IAppSettings.cs
@@ -36,8 +36,14 @@ namespace ToNRoundCounter.Application
         string WebSocketIp { get; set; }
         bool AutoLaunchEnabled { get; set; }
         List<AutoLaunchEntry> AutoLaunchEntries { get; set; }
+        string AutoLaunchExecutablePath { get; set; }
+        string AutoLaunchArguments { get; set; }
         bool ItemMusicEnabled { get; set; }
         List<ItemMusicEntry> ItemMusicEntries { get; set; }
+        string ItemMusicItemName { get; set; }
+        string ItemMusicSoundPath { get; set; }
+        double ItemMusicMinSpeed { get; set; }
+        double ItemMusicMaxSpeed { get; set; }
         string DiscordWebhookUrl { get; set; }
         string LastSaveCode { get; set; }
         void Load();


### PR DESCRIPTION
## Summary
- expose legacy auto-launch and item music properties on the IAppSettings interface so implementations compile

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c808c0f08329b85a521670facbd3