### PR TITLE
Ensure OSCRepeater is restarted cleanly

### DIFF
--- a/UI/MainForm.OSC.cs
+++ b/UI/MainForm.OSC.cs
@@ -26,6 +26,30 @@ namespace ToNRoundCounter.UI
         {
             if (File.Exists("./OscRepeater.exe"))
             {
+                foreach (var processName in new[] { "OscRepeater", "OSCRepeater" })
+                {
+                    foreach (var existingProcess in Process.GetProcessesByName(processName))
+                    {
+                        try
+                        {
+                            if (!existingProcess.HasExited)
+                            {
+                                _logger?.LogEvent("OSCRepeater", "Existing OSCRepeater instance detected. Terminating before restart.");
+                                existingProcess.Kill();
+                                existingProcess.WaitForExit(5000);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger?.LogEvent("OSCRepeater", $"Failed to terminate existing OSCRepeater process: {ex.Message}");
+                        }
+                        finally
+                        {
+                            existingProcess.Dispose();
+                        }
+                    }
+                }
+
                 if (!_settings.OSCPortChanged)
                 {
                     int port = 30000;


### PR DESCRIPTION
## Summary
- terminate any already running OSCRepeater.exe instance before starting a new one
- log failures when attempting to stop a lingering OSCRepeater process

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c7e7cb0883298f4fb94a5c472970