### PR TITLE
Expand module hooks and core customization

### DIFF
--- a/Application/Events.cs
+++ b/Application/Events.cs
@@ -1,11 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using Rug.Osc;
+using ToNRoundCounter.Domain;
+using ToNRoundCounter.UI;
+
 namespace ToNRoundCounter.Application
 {
-    public record WebSocketConnected;
-    public record WebSocketDisconnected;
+    public record WebSocketConnecting(Uri Endpoint);
+    public record WebSocketConnected(Uri Endpoint);
+    public record WebSocketDisconnected(Uri Endpoint, Exception? Exception = null);
+    public record WebSocketReconnecting(Uri Endpoint, Exception Exception);
     public record WebSocketMessageReceived(string Message);
-    public record OscMessageReceived(Rug.Osc.OscMessage Message);
-    public record OscConnected;
-    public record OscDisconnected;
-    public record SettingsValidationFailed(System.Collections.Generic.IEnumerable<string> Errors);
-    public record ModuleLoadFailed(string File, System.Exception Exception);
+    public record OscConnecting(int Port);
+    public record OscConnected(int Port);
+    public record OscDisconnected(int Port, Exception? Exception = null);
+    public record OscMessageReceived(OscMessage Message);
+    public record SettingsValidating(IAppSettings Settings, IList<string> Errors);
+    public record SettingsValidated(IAppSettings Settings);
+    public record SettingsValidationFailed(IAppSettings Settings, IReadOnlyList<string> Errors);
+    public record ModuleLoadFailed(string File, Exception Exception);
+
+    public record ModuleDiscoveryStarted(string Directory);
+    public record ModuleDiscoveryCompleted(IReadOnlyList<ModuleDiscoveryContext> Modules);
+    public record ModuleDiscovered(ModuleDiscoveryContext Context);
+    public record ModuleLoaded(ModuleDiscoveryContext Context);
+    public record ModuleServicesRegistering(ModuleServiceRegistrationContext Context);
+    public record ModuleServicesRegistered(ModuleServiceRegistrationContext Context);
+    public record ModuleServiceRegistrationFailed(ModuleDiscoveryContext Context, Exception Exception);
+    public record ModuleCallbackFailed(ModuleDiscoveryContext Context, string Stage, Exception Exception);
+    public record ServiceProviderBuilding(ModuleServiceProviderBuildContext Context);
+    public record ServiceProviderBuilt(ModuleServiceProviderContext Context);
+    public record MainWindowCreating(ModuleMainWindowCreationContext Context);
+    public record MainWindowCreated(ModuleMainWindowContext Context);
+    public record MainWindowShown(ModuleMainWindowLifecycleContext Context);
+    public record MainWindowClosing(ModuleMainWindowLifecycleContext Context);
+    public record SettingsLoading(IAppSettings Settings);
+    public record SettingsLoaded(IAppSettings Settings);
+    public record SettingsSaving(IAppSettings Settings);
+    public record SettingsSaved(IAppSettings Settings);
+    public record AutoSuicideRulesPrepared(IReadOnlyList<AutoSuicideRule> Rules, IAppSettings Settings);
+    public record AutoSuicideDecisionEvaluated(string RoundType, string? TerrorName, int Decision, bool HasPendingDelayed);
+    public record AutoSuicideScheduled(TimeSpan Delay, bool ResetStartTime);
+    public record AutoSuicideCancelled(TimeSpan? RemainingDelay);
+    public record AutoSuicideTriggered();
+    public record AutoLaunchEvaluating(IReadOnlyList<AutoLaunchPlan> Plans, IAppSettings Settings);
+    public record AutoLaunchStarting(AutoLaunchPlan Plan);
+    public record AutoLaunchFailed(AutoLaunchPlan Plan, Exception Exception);
+    public record AutoLaunchCompleted(AutoLaunchPlan Plan);
+    public record MainWindowThemeChanged(string ThemeKey, ThemeDescriptor Theme, Form Form);
+    public record MainWindowLayoutUpdated(Form Form);
+    public record AppRunStarting(ModuleAppRunContext Context);
+    public record AppRunCompleted(ModuleAppRunContext Context);
+    public record AppShutdownStarting(ModuleAppShutdownContext Context);
+    public record AppShutdownCompleted(ModuleAppShutdownContext Context);
+    public record UnhandledExceptionOccurred(Exception Exception, bool IsTerminating);
 }

--- a/Application/IAppSettings.cs
+++ b/Application/IAppSettings.cs
@@ -31,7 +31,7 @@ namespace ToNRoundCounter.Application
         List<string> RoundTypeStats { get; set; }
         bool AutoSuicideEnabled { get; set; }
         string apikey { get; set; }
-        ThemeType Theme { get; set; }
+        string ThemeKey { get; set; }
         string LogFilePath { get; set; }
         string WebSocketIp { get; set; }
         bool AutoLaunchEnabled { get; set; }

--- a/Application/IErrorReporter.cs
+++ b/Application/IErrorReporter.cs
@@ -5,6 +5,6 @@ namespace ToNRoundCounter.Application
     public interface IErrorReporter
     {
         void Register();
-        void Handle(Exception ex);
+        void Handle(Exception ex, bool isTerminating = false);
     }
 }

--- a/Application/IModule.cs
+++ b/Application/IModule.cs
@@ -1,12 +1,1240 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Windows.Forms;
 using Microsoft.Extensions.DependencyInjection;
+using Rug.Osc;
+using ToNRoundCounter.Domain;
+using ToNRoundCounter.UI;
 
 namespace ToNRoundCounter.Application
 {
     /// <summary>
-    /// Represents an extension module that can register its own services.
+    /// Represents an extension module that can register its own services and
+    /// participate in application lifecycle events.
     /// </summary>
     public interface IModule
     {
+        /// <summary>
+        /// Called immediately after the module has been discovered.
+        /// </summary>
+        /// <param name="context">Contextual information about the module discovery.</param>
+        void OnModuleLoaded(ModuleDiscoveryContext context);
+
+        /// <summary>
+        /// Called before dependency injection registrations occur.
+        /// </summary>
+        /// <param name="context">Contextual information about the registration operation.</param>
+        void OnBeforeServiceRegistration(ModuleServiceRegistrationContext context);
+
+        /// <summary>
+        /// Registers module specific services with the provided <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">Service collection used during application composition.</param>
         void RegisterServices(IServiceCollection services);
+
+        /// <summary>
+        /// Called after dependency injection registrations have completed.
+        /// </summary>
+        /// <param name="context">Contextual information about the registration operation.</param>
+        void OnAfterServiceRegistration(ModuleServiceRegistrationContext context);
+
+        /// <summary>
+        /// Called before the <see cref="IServiceProvider"/> is built.
+        /// </summary>
+        /// <param name="context">Contextual information about the service provider build.</param>
+        void OnBeforeServiceProviderBuild(ModuleServiceProviderBuildContext context);
+
+        /// <summary>
+        /// Called after the <see cref="IServiceProvider"/> has been created.
+        /// </summary>
+        /// <param name="context">Contextual information about the created provider.</param>
+        void OnAfterServiceProviderBuild(ModuleServiceProviderContext context);
+
+        /// <summary>
+        /// Called before the main window is instantiated.
+        /// </summary>
+        /// <param name="context">Contextual information about the window creation.</param>
+        void OnBeforeMainWindowCreation(ModuleMainWindowCreationContext context);
+
+        /// <summary>
+        /// Called after the main window has been instantiated.
+        /// </summary>
+        /// <param name="context">Contextual information about the instantiated window.</param>
+        void OnAfterMainWindowCreation(ModuleMainWindowContext context);
+
+        /// <summary>
+        /// Called when the main window has been shown to the user.
+        /// </summary>
+        /// <param name="context">Contextual information about the window lifecycle.</param>
+        void OnMainWindowShown(ModuleMainWindowLifecycleContext context);
+
+        /// <summary>
+        /// Called when the main window is about to close.
+        /// </summary>
+        /// <param name="context">Contextual information about the window lifecycle.</param>
+        void OnMainWindowClosing(ModuleMainWindowLifecycleContext context);
+
+        /// <summary>
+        /// Called before settings are loaded from storage.
+        /// </summary>
+        /// <param name="context">Contextual information about the settings lifecycle.</param>
+        void OnSettingsLoading(ModuleSettingsContext context);
+
+        /// <summary>
+        /// Called after settings have been loaded from storage.
+        /// </summary>
+        /// <param name="context">Contextual information about the settings lifecycle.</param>
+        void OnSettingsLoaded(ModuleSettingsContext context);
+
+        /// <summary>
+        /// Called before settings are persisted.
+        /// </summary>
+        /// <param name="context">Contextual information about the settings lifecycle.</param>
+        void OnSettingsSaving(ModuleSettingsContext context);
+
+        /// <summary>
+        /// Called after settings have been persisted.
+        /// </summary>
+        /// <param name="context">Contextual information about the settings lifecycle.</param>
+        void OnSettingsSaved(ModuleSettingsContext context);
+
+        /// <summary>
+        /// Called when the settings view is being composed prior to display.
+        /// </summary>
+        /// <param name="context">Contextual information about the settings UI.</param>
+        void OnSettingsViewBuilding(ModuleSettingsViewBuildContext context);
+
+        /// <summary>
+        /// Called once the settings view has been shown.
+        /// </summary>
+        /// <param name="context">Contextual information about the settings UI lifecycle.</param>
+        void OnSettingsViewOpened(ModuleSettingsViewLifecycleContext context);
+
+        /// <summary>
+        /// Called when the user confirms the settings view and changes are about to be applied.
+        /// </summary>
+        /// <param name="context">Contextual information about the settings UI lifecycle.</param>
+        void OnSettingsViewApplying(ModuleSettingsViewLifecycleContext context);
+
+        /// <summary>
+        /// Called when the settings view is closing.
+        /// </summary>
+        /// <param name="context">Contextual information about the settings UI lifecycle.</param>
+        void OnSettingsViewClosing(ModuleSettingsViewLifecycleContext context);
+
+        /// <summary>
+        /// Called after the settings view has closed.
+        /// </summary>
+        /// <param name="context">Contextual information about the settings UI lifecycle.</param>
+        void OnSettingsViewClosed(ModuleSettingsViewLifecycleContext context);
+
+        /// <summary>
+        /// Called immediately before the WinForms message loop begins.
+        /// </summary>
+        /// <param name="context">Contextual information about the application run.</param>
+        void OnAppRunStarting(ModuleAppRunContext context);
+
+        /// <summary>
+        /// Called once the WinForms message loop has finished executing.
+        /// </summary>
+        /// <param name="context">Contextual information about the application run.</param>
+        void OnAppRunCompleted(ModuleAppRunContext context);
+
+        /// <summary>
+        /// Called prior to application shutdown.
+        /// </summary>
+        /// <param name="context">Contextual information about the shutdown sequence.</param>
+        void OnBeforeAppShutdown(ModuleAppShutdownContext context);
+
+        /// <summary>
+        /// Called after application shutdown has completed.
+        /// </summary>
+        /// <param name="context">Contextual information about the shutdown sequence.</param>
+        void OnAfterAppShutdown(ModuleAppShutdownContext context);
+
+        /// <summary>
+        /// Called whenever an unhandled exception is observed by the host.
+        /// </summary>
+        /// <param name="context">Contextual information about the exception.</param>
+        void OnUnhandledException(ModuleExceptionContext context);
+
+        /// <summary>
+        /// Called when the application begins establishing the WebSocket connection.
+        /// </summary>
+        /// <param name="context">Contextual information about the WebSocket lifecycle.</param>
+        void OnWebSocketConnecting(ModuleWebSocketConnectionContext context);
+
+        /// <summary>
+        /// Called when the WebSocket connection has been established.
+        /// </summary>
+        /// <param name="context">Contextual information about the WebSocket lifecycle.</param>
+        void OnWebSocketConnected(ModuleWebSocketConnectionContext context);
+
+        /// <summary>
+        /// Called when the WebSocket connection has been closed.
+        /// </summary>
+        /// <param name="context">Contextual information about the WebSocket lifecycle.</param>
+        void OnWebSocketDisconnected(ModuleWebSocketConnectionContext context);
+
+        /// <summary>
+        /// Called when the WebSocket client schedules a reconnection attempt.
+        /// </summary>
+        /// <param name="context">Contextual information about the WebSocket lifecycle.</param>
+        void OnWebSocketReconnecting(ModuleWebSocketConnectionContext context);
+
+        /// <summary>
+        /// Called whenever a WebSocket message is received.
+        /// </summary>
+        /// <param name="context">Information about the received message.</param>
+        void OnWebSocketMessageReceived(ModuleWebSocketMessageContext context);
+
+        /// <summary>
+        /// Called when the OSC listener is preparing to connect.
+        /// </summary>
+        /// <param name="context">Contextual information about the OSC lifecycle.</param>
+        void OnOscConnecting(ModuleOscConnectionContext context);
+
+        /// <summary>
+        /// Called when the OSC listener has connected successfully.
+        /// </summary>
+        /// <param name="context">Contextual information about the OSC lifecycle.</param>
+        void OnOscConnected(ModuleOscConnectionContext context);
+
+        /// <summary>
+        /// Called when the OSC listener disconnects.
+        /// </summary>
+        /// <param name="context">Contextual information about the OSC lifecycle.</param>
+        void OnOscDisconnected(ModuleOscConnectionContext context);
+
+        /// <summary>
+        /// Called whenever an OSC message is received.
+        /// </summary>
+        /// <param name="context">Information about the received message.</param>
+        void OnOscMessageReceived(ModuleOscMessageContext context);
+
+        /// <summary>
+        /// Called before built-in validation runs for application settings.
+        /// </summary>
+        /// <param name="context">Contextual information about the validation pipeline.</param>
+        void OnBeforeSettingsValidation(ModuleSettingsValidationContext context);
+
+        /// <summary>
+        /// Called after settings have been validated without critical failures.
+        /// </summary>
+        /// <param name="context">Contextual information about the validation pipeline.</param>
+        void OnSettingsValidated(ModuleSettingsValidationContext context);
+
+        /// <summary>
+        /// Called when settings validation reports one or more failures.
+        /// </summary>
+        /// <param name="context">Contextual information about the validation pipeline.</param>
+        void OnSettingsValidationFailed(ModuleSettingsValidationContext context);
+
+        /// <summary>
+        /// Called after auto-suicide rules have been composed from application settings.
+        /// </summary>
+        /// <param name="context">Contextual information about the rule set.</param>
+        void OnAutoSuicideRulesPrepared(ModuleAutoSuicideRuleContext context);
+
+        /// <summary>
+        /// Called after the auto-suicide decision logic has evaluated the current round.
+        /// </summary>
+        /// <param name="context">Contextual information about the decision.</param>
+        void OnAutoSuicideDecisionEvaluated(ModuleAutoSuicideDecisionContext context);
+
+        /// <summary>
+        /// Called when a delayed auto-suicide action has been scheduled.
+        /// </summary>
+        /// <param name="context">Contextual information about the scheduled action.</param>
+        void OnAutoSuicideScheduled(ModuleAutoSuicideScheduleContext context);
+
+        /// <summary>
+        /// Called when a pending auto-suicide action has been cancelled.
+        /// </summary>
+        /// <param name="context">Contextual information about the scheduled action.</param>
+        void OnAutoSuicideCancelled(ModuleAutoSuicideScheduleContext context);
+
+        /// <summary>
+        /// Called when the scheduled auto-suicide callback is about to be executed.
+        /// </summary>
+        /// <param name="context">Contextual information about the execution.</param>
+        void OnAutoSuicideTriggered(ModuleAutoSuicideTriggerContext context);
+
+        /// <summary>
+        /// Called when the application determines which executables should be launched automatically.
+        /// </summary>
+        /// <param name="context">Contextual information about the auto-launch evaluation.</param>
+        void OnAutoLaunchEvaluating(ModuleAutoLaunchEvaluationContext context);
+
+        /// <summary>
+        /// Called immediately before an auto-launch process is started.
+        /// </summary>
+        /// <param name="context">Contextual information about the auto-launch execution.</param>
+        void OnAutoLaunchStarting(ModuleAutoLaunchExecutionContext context);
+
+        /// <summary>
+        /// Called when an auto-launch attempt fails.
+        /// </summary>
+        /// <param name="context">Contextual information about the auto-launch failure.</param>
+        void OnAutoLaunchFailed(ModuleAutoLaunchFailureContext context);
+
+        /// <summary>
+        /// Called after an auto-launch process has started successfully.
+        /// </summary>
+        /// <param name="context">Contextual information about the auto-launch execution.</param>
+        void OnAutoLaunchCompleted(ModuleAutoLaunchExecutionContext context);
+
+        /// <summary>
+        /// Called while the available UI themes are being collected.
+        /// </summary>
+        /// <param name="context">Contextual information about the theme catalog.</param>
+        void OnThemeCatalogBuilding(ModuleThemeCatalogContext context);
+
+        /// <summary>
+        /// Called when the main window menu is being constructed.
+        /// </summary>
+        /// <param name="context">Contextual information about the main menu.</param>
+        void OnMainWindowMenuBuilding(ModuleMainWindowMenuContext context);
+
+        /// <summary>
+        /// Called after the main window has constructed its core controls.
+        /// </summary>
+        /// <param name="context">Contextual information about the UI composition.</param>
+        void OnMainWindowUiComposed(ModuleMainWindowUiContext context);
+
+        /// <summary>
+        /// Called while auxiliary (tool) windows are being registered with the host.
+        /// </summary>
+        /// <param name="context">Contextual information about the auxiliary window catalog.</param>
+        void OnAuxiliaryWindowCatalogBuilding(ModuleAuxiliaryWindowCatalogContext context);
+
+        /// <summary>
+        /// Called immediately before an auxiliary window is shown.
+        /// </summary>
+        /// <param name="context">Contextual information about the auxiliary window lifecycle.</param>
+        void OnAuxiliaryWindowOpening(ModuleAuxiliaryWindowLifecycleContext context);
+
+        /// <summary>
+        /// Called after an auxiliary window has been shown.
+        /// </summary>
+        /// <param name="context">Contextual information about the auxiliary window lifecycle.</param>
+        void OnAuxiliaryWindowOpened(ModuleAuxiliaryWindowLifecycleContext context);
+
+        /// <summary>
+        /// Called when an auxiliary window begins closing.
+        /// </summary>
+        /// <param name="context">Contextual information about the auxiliary window lifecycle.</param>
+        void OnAuxiliaryWindowClosing(ModuleAuxiliaryWindowLifecycleContext context);
+
+        /// <summary>
+        /// Called after an auxiliary window has closed.
+        /// </summary>
+        /// <param name="context">Contextual information about the auxiliary window lifecycle.</param>
+        void OnAuxiliaryWindowClosed(ModuleAuxiliaryWindowLifecycleContext context);
+
+        /// <summary>
+        /// Called whenever the main window theme changes.
+        /// </summary>
+        /// <param name="context">Contextual information about the theme change.</param>
+        void OnMainWindowThemeChanged(ModuleMainWindowThemeContext context);
+
+        /// <summary>
+        /// Called when the main window layout has been (re)constructed.
+        /// </summary>
+        /// <param name="context">Contextual information about the layout.</param>
+        void OnMainWindowLayoutUpdated(ModuleMainWindowLayoutContext context);
+
+        /// <summary>
+        /// Called when another module reports that it has completed loading.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleLoaded(ModulePeerNotificationContext<ModuleDiscoveryContext> context);
+
+        /// <summary>
+        /// Called when another module begins its service registration sequence.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleBeforeServiceRegistration(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context);
+
+        /// <summary>
+        /// Called while another module is registering services.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleRegisteringServices(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context);
+
+        /// <summary>
+        /// Called after another module completes its service registration sequence.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleAfterServiceRegistration(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context);
+
+        /// <summary>
+        /// Called when another module begins participating in the service provider build.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleBeforeServiceProviderBuild(ModulePeerNotificationContext<ModuleServiceProviderBuildContext> context);
+
+        /// <summary>
+        /// Called when another module has completed its service provider build callbacks.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleAfterServiceProviderBuild(ModulePeerNotificationContext<ModuleServiceProviderContext> context);
+
+        /// <summary>
+        /// Called when another module is about to create the main window.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleBeforeMainWindowCreation(ModulePeerNotificationContext<ModuleMainWindowCreationContext> context);
+
+        /// <summary>
+        /// Called when another module has finished creating the main window.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleAfterMainWindowCreation(ModulePeerNotificationContext<ModuleMainWindowContext> context);
+
+        /// <summary>
+        /// Called when another module reports that the main window is shown.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleMainWindowShown(ModulePeerNotificationContext<ModuleMainWindowLifecycleContext> context);
+
+        /// <summary>
+        /// Called when another module reports that the main window is closing.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleMainWindowClosing(ModulePeerNotificationContext<ModuleMainWindowLifecycleContext> context);
+
+        /// <summary>
+        /// Called when another module participates in settings loading.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleSettingsLoading(ModulePeerNotificationContext<ModuleSettingsContext> context);
+
+        /// <summary>
+        /// Called when another module completes settings loading.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleSettingsLoaded(ModulePeerNotificationContext<ModuleSettingsContext> context);
+
+        /// <summary>
+        /// Called when another module participates in settings saving.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleSettingsSaving(ModulePeerNotificationContext<ModuleSettingsContext> context);
+
+        /// <summary>
+        /// Called when another module completes settings saving.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleSettingsSaved(ModulePeerNotificationContext<ModuleSettingsContext> context);
+
+        /// <summary>
+        /// Called when another module begins the application run sequence.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleAppRunStarting(ModulePeerNotificationContext<ModuleAppRunContext> context);
+
+        /// <summary>
+        /// Called when another module completes the application run sequence.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleAppRunCompleted(ModulePeerNotificationContext<ModuleAppRunContext> context);
+
+        /// <summary>
+        /// Called when another module is about to shut the application down.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleBeforeAppShutdown(ModulePeerNotificationContext<ModuleAppShutdownContext> context);
+
+        /// <summary>
+        /// Called when another module has completed the shutdown sequence.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleAfterAppShutdown(ModulePeerNotificationContext<ModuleAppShutdownContext> context);
+
+        /// <summary>
+        /// Called when another module observes an unhandled exception.
+        /// </summary>
+        /// <param name="context">Contextual information about the peer module.</param>
+        void OnPeerModuleUnhandledException(ModulePeerNotificationContext<ModuleExceptionContext> context);
+    }
+
+    /// <summary>
+    /// Provides information about the discovery of a module.
+    /// </summary>
+    public sealed class ModuleDiscoveryContext
+    {
+        public ModuleDiscoveryContext(string moduleName, Assembly assembly, string? sourcePath)
+        {
+            ModuleName = moduleName;
+            Assembly = assembly;
+            SourcePath = sourcePath;
+        }
+
+        public string ModuleName { get; }
+
+        public Assembly Assembly { get; }
+
+        public string? SourcePath { get; }
+    }
+
+    /// <summary>
+    /// Provides information related to service registration operations.
+    /// </summary>
+    public sealed class ModuleServiceRegistrationContext
+    {
+        public ModuleServiceRegistrationContext(ModuleDiscoveryContext module, IServiceCollection services, IEventLogger logger, IEventBus bus)
+        {
+            Module = module;
+            Services = services;
+            Logger = logger;
+            Bus = bus;
+        }
+
+        public ModuleDiscoveryContext Module { get; }
+
+        public IServiceCollection Services { get; }
+
+        public IEventLogger Logger { get; }
+
+        public IEventBus Bus { get; }
+    }
+
+    /// <summary>
+    /// Provides information about the imminent service provider build.
+    /// </summary>
+    public sealed class ModuleServiceProviderBuildContext
+    {
+        public ModuleServiceProviderBuildContext(IServiceCollection services, IEventLogger logger, IEventBus bus)
+        {
+            Services = services;
+            Logger = logger;
+            Bus = bus;
+        }
+
+        public IServiceCollection Services { get; }
+
+        public IEventLogger Logger { get; }
+
+        public IEventBus Bus { get; }
+    }
+
+    /// <summary>
+    /// Provides information about the constructed service provider.
+    /// </summary>
+    public sealed class ModuleServiceProviderContext
+    {
+        public ModuleServiceProviderContext(IServiceProvider serviceProvider, IEventLogger logger, IEventBus bus)
+        {
+            ServiceProvider = serviceProvider;
+            Logger = logger;
+            Bus = bus;
+        }
+
+        public IServiceProvider ServiceProvider { get; }
+
+        public IEventLogger Logger { get; }
+
+        public IEventBus Bus { get; }
+    }
+
+    /// <summary>
+    /// Provides information about the creation of the main window.
+    /// </summary>
+    public sealed class ModuleMainWindowCreationContext
+    {
+        public ModuleMainWindowCreationContext(IServiceProvider serviceProvider, Type windowType)
+        {
+            ServiceProvider = serviceProvider;
+            WindowType = windowType;
+        }
+
+        public IServiceProvider ServiceProvider { get; }
+
+        public Type WindowType { get; }
+    }
+
+    /// <summary>
+    /// Provides information about the instantiated main window.
+    /// </summary>
+    public sealed class ModuleMainWindowContext
+    {
+        public ModuleMainWindowContext(Form mainWindow, IServiceProvider serviceProvider)
+        {
+            MainWindow = mainWindow;
+            ServiceProvider = serviceProvider;
+        }
+
+        public Form MainWindow { get; }
+
+        public IServiceProvider ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about the lifecycle of the main window.
+    /// </summary>
+    public sealed class ModuleMainWindowLifecycleContext
+    {
+        public ModuleMainWindowLifecycleContext(Form mainWindow, IServiceProvider serviceProvider)
+        {
+            MainWindow = mainWindow;
+            ServiceProvider = serviceProvider;
+        }
+
+        public Form MainWindow { get; }
+
+        public IServiceProvider ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about settings lifecycle events.
+    /// </summary>
+    public sealed class ModuleSettingsContext
+    {
+        public ModuleSettingsContext(IAppSettings settings, IServiceProvider serviceProvider)
+        {
+            Settings = settings;
+            ServiceProvider = serviceProvider;
+        }
+
+        public IAppSettings Settings { get; }
+
+        public IServiceProvider ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about the WinForms application run lifecycle.
+    /// </summary>
+    public sealed class ModuleAppRunContext
+    {
+        public ModuleAppRunContext(Form mainWindow, IServiceProvider serviceProvider)
+        {
+            MainWindow = mainWindow;
+            ServiceProvider = serviceProvider;
+        }
+
+        public Form MainWindow { get; }
+
+        public IServiceProvider ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about application shutdown operations.
+    /// </summary>
+    public sealed class ModuleAppShutdownContext
+    {
+        public ModuleAppShutdownContext(IServiceProvider serviceProvider)
+        {
+            ServiceProvider = serviceProvider;
+        }
+
+        public IServiceProvider ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about unhandled exceptions observed by the host.
+    /// </summary>
+    public sealed class ModuleExceptionContext
+    {
+        public ModuleExceptionContext(Exception exception, bool isTerminating, IServiceProvider? serviceProvider)
+        {
+            Exception = exception;
+            IsTerminating = isTerminating;
+            ServiceProvider = serviceProvider;
+        }
+
+        public Exception Exception { get; }
+
+        public bool IsTerminating { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Describes the phase of the WebSocket connection lifecycle.
+    /// </summary>
+    public enum ModuleWebSocketConnectionPhase
+    {
+        Connecting,
+        Connected,
+        Disconnected,
+        Reconnecting
+    }
+
+    /// <summary>
+    /// Provides information about WebSocket connection lifecycle events.
+    /// </summary>
+    public sealed class ModuleWebSocketConnectionContext
+    {
+        public ModuleWebSocketConnectionContext(Uri endpoint, ModuleWebSocketConnectionPhase phase, IServiceProvider? serviceProvider, Exception? exception = null)
+        {
+            Endpoint = endpoint;
+            Phase = phase;
+            ServiceProvider = serviceProvider;
+            Exception = exception;
+        }
+
+        public Uri Endpoint { get; }
+
+        public ModuleWebSocketConnectionPhase Phase { get; }
+
+        public Exception? Exception { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about WebSocket messages dispatched by the host.
+    /// </summary>
+    public sealed class ModuleWebSocketMessageContext
+    {
+        public ModuleWebSocketMessageContext(string message, IServiceProvider? serviceProvider)
+        {
+            Message = message;
+            ServiceProvider = serviceProvider;
+        }
+
+        public string Message { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Describes the phase of the OSC connection lifecycle.
+    /// </summary>
+    public enum ModuleOscConnectionPhase
+    {
+        Connecting,
+        Connected,
+        Disconnected
+    }
+
+    /// <summary>
+    /// Provides information about OSC listener lifecycle events.
+    /// </summary>
+    public sealed class ModuleOscConnectionContext
+    {
+        public ModuleOscConnectionContext(int port, ModuleOscConnectionPhase phase, IServiceProvider? serviceProvider, Exception? exception = null)
+        {
+            Port = port;
+            Phase = phase;
+            ServiceProvider = serviceProvider;
+            Exception = exception;
+        }
+
+        public int Port { get; }
+
+        public ModuleOscConnectionPhase Phase { get; }
+
+        public Exception? Exception { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about OSC messages received by the host.
+    /// </summary>
+    public sealed class ModuleOscMessageContext
+    {
+        public ModuleOscMessageContext(OscMessage message, IServiceProvider? serviceProvider)
+        {
+            Message = message;
+            ServiceProvider = serviceProvider;
+        }
+
+        public OscMessage Message { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Represents the stage of application settings validation.
+    /// </summary>
+    public enum ModuleSettingsValidationStage
+    {
+        Validating,
+        Validated,
+        Failed
+    }
+
+    /// <summary>
+    /// Provides information about the application settings validation pipeline.
+    /// </summary>
+    public sealed class ModuleSettingsValidationContext
+    {
+        public ModuleSettingsValidationContext(IAppSettings settings, IList<string> errors, ModuleSettingsValidationStage stage, IServiceProvider? serviceProvider)
+        {
+            Settings = settings;
+            Errors = errors;
+            Stage = stage;
+            ServiceProvider = serviceProvider;
+        }
+
+        public IAppSettings Settings { get; }
+
+        public IList<string> Errors { get; }
+
+        public ModuleSettingsValidationStage Stage { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about the composed auto-suicide rule set.
+    /// </summary>
+    public sealed class ModuleAutoSuicideRuleContext
+    {
+        public ModuleAutoSuicideRuleContext(IList<AutoSuicideRule> rules, IAppSettings settings, IServiceProvider? serviceProvider)
+        {
+            Rules = rules;
+            Settings = settings;
+            ServiceProvider = serviceProvider;
+        }
+
+        public IList<AutoSuicideRule> Rules { get; }
+
+        public IAppSettings Settings { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about an auto-suicide decision.
+    /// </summary>
+    public sealed class ModuleAutoSuicideDecisionContext
+    {
+        public ModuleAutoSuicideDecisionContext(string roundType, string? terrorName, int decision, bool hasPendingDelayed, IServiceProvider? serviceProvider)
+        {
+            RoundType = roundType;
+            TerrorName = terrorName;
+            Decision = decision;
+            HasPendingDelayed = hasPendingDelayed;
+            ServiceProvider = serviceProvider;
+        }
+
+        public string RoundType { get; }
+
+        public string? TerrorName { get; }
+
+        public int Decision { get; private set; }
+
+        public bool HasPendingDelayed { get; private set; }
+
+        public bool IsOverridden { get; private set; }
+
+        public IServiceProvider? ServiceProvider { get; }
+
+        public void OverrideDecision(int decision, bool? hasPendingDelayed = null)
+        {
+            Decision = decision;
+            if (hasPendingDelayed.HasValue)
+            {
+                HasPendingDelayed = hasPendingDelayed.Value;
+            }
+
+            IsOverridden = true;
+        }
+    }
+
+    /// <summary>
+    /// Provides information about scheduled auto-suicide actions.
+    /// </summary>
+    public sealed class ModuleAutoSuicideScheduleContext
+    {
+        public ModuleAutoSuicideScheduleContext(TimeSpan delay, bool resetStartTime, IServiceProvider? serviceProvider)
+        {
+            Delay = delay;
+            ResetStartTime = resetStartTime;
+            ServiceProvider = serviceProvider;
+        }
+
+        public TimeSpan Delay { get; }
+
+        public bool ResetStartTime { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about the execution of a scheduled auto-suicide action.
+    /// </summary>
+    public sealed class ModuleAutoSuicideTriggerContext
+    {
+        public ModuleAutoSuicideTriggerContext(IServiceProvider? serviceProvider)
+        {
+            ServiceProvider = serviceProvider;
+        }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Represents a pending auto-launch request.
+    /// </summary>
+    public sealed record AutoLaunchPlan(string Path, string Arguments, string Origin);
+
+    /// <summary>
+    /// Provides information about auto-launch evaluation.
+    /// </summary>
+    public sealed class ModuleAutoLaunchEvaluationContext
+    {
+        public ModuleAutoLaunchEvaluationContext(IList<AutoLaunchPlan> plans, IAppSettings settings, IServiceProvider? serviceProvider)
+        {
+            Plans = plans;
+            Settings = settings;
+            ServiceProvider = serviceProvider;
+        }
+
+        public IList<AutoLaunchPlan> Plans { get; }
+
+        public IAppSettings Settings { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about an individual auto-launch execution.
+    /// </summary>
+    public class ModuleAutoLaunchExecutionContext
+    {
+        public ModuleAutoLaunchExecutionContext(AutoLaunchPlan plan, IServiceProvider? serviceProvider)
+        {
+            Plan = plan;
+            ServiceProvider = serviceProvider;
+        }
+
+        public AutoLaunchPlan Plan { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about a failed auto-launch attempt.
+    /// </summary>
+    public sealed class ModuleAutoLaunchFailureContext : ModuleAutoLaunchExecutionContext
+    {
+        public ModuleAutoLaunchFailureContext(AutoLaunchPlan plan, Exception exception, IServiceProvider? serviceProvider)
+            : base(plan, serviceProvider)
+        {
+            Exception = exception;
+        }
+
+        public Exception Exception { get; }
+    }
+
+    /// <summary>
+    /// Provides information about main window theme changes.
+    /// </summary>
+    public sealed class ModuleMainWindowThemeContext
+    {
+        public ModuleMainWindowThemeContext(Form form, string themeKey, ThemeDescriptor descriptor, IServiceProvider? serviceProvider)
+        {
+            Form = form ?? throw new ArgumentNullException(nameof(form));
+            ThemeKey = string.IsNullOrWhiteSpace(themeKey) ? descriptor?.Key ?? string.Empty : themeKey;
+            Theme = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+            ServiceProvider = serviceProvider;
+        }
+
+        public Form Form { get; }
+
+        public string ThemeKey { get; }
+
+        public ThemeDescriptor Theme { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about main window layout updates.
+    /// </summary>
+    public sealed class ModuleMainWindowLayoutContext
+    {
+        public ModuleMainWindowLayoutContext(Form form, IServiceProvider? serviceProvider)
+        {
+            Form = form;
+            ServiceProvider = serviceProvider;
+        }
+
+        public Form Form { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Indicates the stage of the settings view lifecycle.
+    /// </summary>
+    public enum ModuleSettingsViewStage
+    {
+        Opened,
+        Applying,
+        Closing,
+        Closed
+    }
+
+    /// <summary>
+    /// Provides information while the settings view is being composed.
+    /// </summary>
+    public sealed class ModuleSettingsViewBuildContext
+    {
+        public ModuleSettingsViewBuildContext(SettingsForm form, SettingsPanel panel, IAppSettings settings, IServiceProvider? serviceProvider)
+        {
+            Form = form ?? throw new ArgumentNullException(nameof(form));
+            Panel = panel ?? throw new ArgumentNullException(nameof(panel));
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            ServiceProvider = serviceProvider;
+        }
+
+        public SettingsForm Form { get; }
+
+        public SettingsPanel Panel { get; }
+
+        public IAppSettings Settings { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+
+        public T AddExtensionControl<T>(T control) where T : Control
+        {
+            return Panel.AddModuleExtensionControl(control);
+        }
+
+        public GroupBox AddSettingsGroup(string title)
+        {
+            return Panel.AddModuleSettingsGroup(title);
+        }
+    }
+
+    /// <summary>
+    /// Provides information about the lifecycle of the settings view dialog.
+    /// </summary>
+    public sealed class ModuleSettingsViewLifecycleContext
+    {
+        public ModuleSettingsViewLifecycleContext(SettingsForm form, SettingsPanel panel, IAppSettings settings, ModuleSettingsViewStage stage, DialogResult? dialogResult, IServiceProvider? serviceProvider)
+        {
+            Form = form ?? throw new ArgumentNullException(nameof(form));
+            Panel = panel ?? throw new ArgumentNullException(nameof(panel));
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            Stage = stage;
+            DialogResult = dialogResult;
+            ServiceProvider = serviceProvider;
+        }
+
+        public SettingsForm Form { get; }
+
+        public SettingsPanel Panel { get; }
+
+        public IAppSettings Settings { get; }
+
+        public ModuleSettingsViewStage Stage { get; }
+
+        public DialogResult? DialogResult { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides theme catalog information to modules.
+    /// </summary>
+    public sealed class ModuleThemeCatalogContext
+    {
+        private readonly Func<ThemeDescriptor, ThemeDescriptor> _register;
+
+        public ModuleThemeCatalogContext(IReadOnlyCollection<ThemeDescriptor> themes, Func<ThemeDescriptor, ThemeDescriptor> register, IServiceProvider? serviceProvider)
+        {
+            Themes = themes ?? throw new ArgumentNullException(nameof(themes));
+            _register = register ?? throw new ArgumentNullException(nameof(register));
+            ServiceProvider = serviceProvider;
+        }
+
+        public IReadOnlyCollection<ThemeDescriptor> Themes { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+
+        public ThemeDescriptor RegisterTheme(string key, string displayName, ThemeColors colors, Action<ThemeApplicationContext>? applyAction = null)
+        {
+            return _register(new ThemeDescriptor(key, displayName, colors, applyAction));
+        }
+
+        public ThemeDescriptor RegisterTheme(ThemeDescriptor descriptor)
+        {
+            return _register(descriptor);
+        }
+    }
+
+    /// <summary>
+    /// Provides information about the main window menu during construction.
+    /// </summary>
+    public sealed class ModuleMainWindowMenuContext
+    {
+        public ModuleMainWindowMenuContext(Form form, MenuStrip menu, IServiceProvider? serviceProvider)
+        {
+            Form = form ?? throw new ArgumentNullException(nameof(form));
+            MenuStrip = menu ?? throw new ArgumentNullException(nameof(menu));
+            ServiceProvider = serviceProvider;
+        }
+
+        public Form Form { get; }
+
+        public MenuStrip MenuStrip { get; }
+
+        public ToolStripItemCollection Items => MenuStrip.Items;
+
+        public IServiceProvider? ServiceProvider { get; }
+
+        public ToolStripMenuItem AddMenu(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                throw new ArgumentException("Menu text must be provided", nameof(text));
+            }
+
+            var item = new ToolStripMenuItem(text);
+            MenuStrip.Items.Add(item);
+            return item;
+        }
+    }
+
+    /// <summary>
+    /// Provides information about the main window UI composition.
+    /// </summary>
+    public sealed class ModuleMainWindowUiContext
+    {
+        public ModuleMainWindowUiContext(Form form, Control.ControlCollection controls, MenuStrip? menuStrip, IServiceProvider? serviceProvider)
+        {
+            Form = form ?? throw new ArgumentNullException(nameof(form));
+            Controls = controls ?? throw new ArgumentNullException(nameof(controls));
+            MenuStrip = menuStrip;
+            ServiceProvider = serviceProvider;
+        }
+
+        public Form Form { get; }
+
+        public Control.ControlCollection Controls { get; }
+
+        public MenuStrip? MenuStrip { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Describes an auxiliary window that can be launched by the host.
+    /// </summary>
+    public sealed class AuxiliaryWindowDescriptor
+    {
+        public AuxiliaryWindowDescriptor(string id, string displayName, Func<IServiceProvider?, Form> factory, bool allowMultipleInstances, bool showModal)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("Auxiliary window id must be provided", nameof(id));
+            }
+
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                throw new ArgumentException("Auxiliary window display name must be provided", nameof(displayName));
+            }
+
+            Id = id;
+            DisplayName = displayName;
+            Factory = factory ?? throw new ArgumentNullException(nameof(factory));
+            AllowMultipleInstances = allowMultipleInstances;
+            ShowModal = showModal;
+        }
+
+        public string Id { get; }
+
+        public string DisplayName { get; }
+
+        public Func<IServiceProvider?, Form> Factory { get; }
+
+        public bool AllowMultipleInstances { get; }
+
+        public bool ShowModal { get; }
+    }
+
+    /// <summary>
+    /// Coordinates auxiliary window registration.
+    /// </summary>
+    public sealed class ModuleAuxiliaryWindowCatalogContext
+    {
+        private readonly Action<AuxiliaryWindowDescriptor> _register;
+
+        public ModuleAuxiliaryWindowCatalogContext(IReadOnlyCollection<AuxiliaryWindowDescriptor> registeredWindows, Action<AuxiliaryWindowDescriptor> register, IServiceProvider? serviceProvider)
+        {
+            RegisteredWindows = registeredWindows ?? throw new ArgumentNullException(nameof(registeredWindows));
+            _register = register ?? throw new ArgumentNullException(nameof(register));
+            ServiceProvider = serviceProvider;
+        }
+
+        public IReadOnlyCollection<AuxiliaryWindowDescriptor> RegisteredWindows { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+
+        public AuxiliaryWindowDescriptor RegisterWindow(string id, string displayName, Func<IServiceProvider?, Form> factory, bool allowMultipleInstances = false, bool showModal = false)
+        {
+            var descriptor = new AuxiliaryWindowDescriptor(id, displayName, factory, allowMultipleInstances, showModal);
+            _register(descriptor);
+            return descriptor;
+        }
+
+        public void RegisterWindow(AuxiliaryWindowDescriptor descriptor)
+        {
+            _register(descriptor);
+        }
+    }
+
+    /// <summary>
+    /// Indicates the lifecycle stage for an auxiliary window notification.
+    /// </summary>
+    public enum ModuleAuxiliaryWindowStage
+    {
+        Opening,
+        Opened,
+        Closing,
+        Closed
+    }
+
+    /// <summary>
+    /// Provides information about an auxiliary window lifecycle event.
+    /// </summary>
+    public sealed class ModuleAuxiliaryWindowLifecycleContext
+    {
+        public ModuleAuxiliaryWindowLifecycleContext(AuxiliaryWindowDescriptor descriptor, Form window, ModuleAuxiliaryWindowStage stage, IServiceProvider? serviceProvider)
+        {
+            Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+            Window = window ?? throw new ArgumentNullException(nameof(window));
+            Stage = stage;
+            ServiceProvider = serviceProvider;
+        }
+
+        public AuxiliaryWindowDescriptor Descriptor { get; }
+
+        public Form Window { get; }
+
+        public ModuleAuxiliaryWindowStage Stage { get; }
+
+        public IServiceProvider? ServiceProvider { get; }
+    }
+
+    /// <summary>
+    /// Provides information about the activity of another module.
+    /// </summary>
+    /// <typeparam name="TContext">The type of event context being observed.</typeparam>
+    public sealed class ModulePeerNotificationContext<TContext>
+    {
+        public ModulePeerNotificationContext(ModuleDiscoveryContext observedModule, TContext eventContext)
+        {
+            ObservedModule = observedModule;
+            EventContext = eventContext;
+        }
+
+        /// <summary>
+        /// Gets the module whose activity is being observed.
+        /// </summary>
+        public ModuleDiscoveryContext ObservedModule { get; }
+
+        /// <summary>
+        /// Gets the context associated with the observed module activity.
+        /// </summary>
+        public TContext EventContext { get; }
     }
 }

--- a/Infrastructure/ModuleHost.cs
+++ b/Infrastructure/ModuleHost.cs
@@ -1,0 +1,1054 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog.Events;
+using System.Windows.Forms;
+using ToNRoundCounter.Application;
+using ToNRoundCounter.Domain;
+
+namespace ToNRoundCounter.Infrastructure
+{
+    /// <summary>
+    /// Coordinates lifecycle notifications for extension modules and surfaces
+    /// rich events for consumers who want to observe module activity.
+    /// </summary>
+    public sealed class ModuleHost
+    {
+        private readonly List<LoadedModule> _modules = new();
+        private readonly IEventLogger _logger;
+        private readonly IEventBus _bus;
+        private IServiceProvider? _serviceProvider;
+        private readonly Dictionary<string, AuxiliaryWindowDescriptor> _auxiliaryWindows = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, List<Form>> _activeAuxiliaryWindows = new(StringComparer.OrdinalIgnoreCase);
+
+        public ModuleHost(IEventLogger logger, IEventBus bus)
+        {
+            _logger = logger;
+            _bus = bus;
+
+            bus.Subscribe<WebSocketConnecting>(HandleWebSocketConnecting);
+            bus.Subscribe<WebSocketConnected>(HandleWebSocketConnected);
+            bus.Subscribe<WebSocketDisconnected>(HandleWebSocketDisconnected);
+            bus.Subscribe<WebSocketReconnecting>(HandleWebSocketReconnecting);
+            bus.Subscribe<WebSocketMessageReceived>(HandleWebSocketMessageReceived);
+            bus.Subscribe<OscConnecting>(HandleOscConnecting);
+            bus.Subscribe<OscConnected>(HandleOscConnected);
+            bus.Subscribe<OscDisconnected>(HandleOscDisconnected);
+            bus.Subscribe<OscMessageReceived>(HandleOscMessageReceived);
+            bus.Subscribe<SettingsValidating>(HandleSettingsValidating);
+            bus.Subscribe<SettingsValidated>(HandleSettingsValidated);
+            bus.Subscribe<SettingsValidationFailed>(HandleSettingsValidationFailed);
+            bus.Subscribe<SettingsLoading>(HandleSettingsLoading);
+            bus.Subscribe<SettingsLoaded>(HandleSettingsLoaded);
+            bus.Subscribe<SettingsSaving>(HandleSettingsSaving);
+            bus.Subscribe<SettingsSaved>(HandleSettingsSaved);
+            bus.Subscribe<AutoSuicideScheduled>(HandleAutoSuicideScheduled);
+            bus.Subscribe<AutoSuicideCancelled>(HandleAutoSuicideCancelled);
+            bus.Subscribe<AutoSuicideTriggered>(HandleAutoSuicideTriggered);
+            bus.Subscribe<UnhandledExceptionOccurred>(HandleUnhandledException);
+        }
+
+        /// <summary>
+        /// Occurs when module discovery begins.
+        /// </summary>
+        public event EventHandler<string>? DiscoveryStarted;
+
+        /// <summary>
+        /// Occurs after all modules have been discovered.
+        /// </summary>
+        public event EventHandler<IReadOnlyList<ModuleDiscoveryContext>>? DiscoveryCompleted;
+
+        /// <summary>
+        /// Occurs for each module that is discovered in the probing directory.
+        /// </summary>
+        public event EventHandler<ModuleDiscoveryContext>? ModuleDiscovered;
+
+        /// <summary>
+        /// Occurs once a module has acknowledged its discovery via
+        /// <see cref="IModule.OnModuleLoaded"/>.
+        /// </summary>
+        public event EventHandler<ModuleDiscoveryContext>? ModuleLoaded;
+
+        /// <summary>
+        /// Occurs immediately before service registration is performed.
+        /// </summary>
+        public event EventHandler<ModuleServiceRegistrationContext>? BeforeServiceRegistration;
+
+        /// <summary>
+        /// Occurs immediately after service registration is performed.
+        /// </summary>
+        public event EventHandler<ModuleServiceRegistrationContext>? AfterServiceRegistration;
+
+        /// <summary>
+        /// Occurs before the application builds the service provider.
+        /// </summary>
+        public event EventHandler<ModuleServiceProviderBuildContext>? ServiceProviderBuilding;
+
+        /// <summary>
+        /// Occurs after the application builds the service provider.
+        /// </summary>
+        public event EventHandler<ModuleServiceProviderContext>? ServiceProviderBuilt;
+
+        /// <summary>
+        /// Occurs before the main window is instantiated.
+        /// </summary>
+        public event EventHandler<ModuleMainWindowCreationContext>? MainWindowCreating;
+
+        /// <summary>
+        /// Occurs after the main window is instantiated.
+        /// </summary>
+        public event EventHandler<ModuleMainWindowContext>? MainWindowCreated;
+
+        /// <summary>
+        /// Occurs when the main window is shown for the first time.
+        /// </summary>
+        public event EventHandler<ModuleMainWindowLifecycleContext>? MainWindowShown;
+
+        /// <summary>
+        /// Occurs when the main window begins closing.
+        /// </summary>
+        public event EventHandler<ModuleMainWindowLifecycleContext>? MainWindowClosing;
+
+        /// <summary>
+        /// Occurs immediately before settings are loaded.
+        /// </summary>
+        public event EventHandler<ModuleSettingsContext>? SettingsLoading;
+
+        /// <summary>
+        /// Occurs after settings have been loaded.
+        /// </summary>
+        public event EventHandler<ModuleSettingsContext>? SettingsLoaded;
+
+        /// <summary>
+        /// Occurs immediately before settings are saved.
+        /// </summary>
+        public event EventHandler<ModuleSettingsContext>? SettingsSaving;
+
+        /// <summary>
+        /// Occurs after settings have been saved.
+        /// </summary>
+        public event EventHandler<ModuleSettingsContext>? SettingsSaved;
+
+        /// <summary>
+        /// Occurs when the settings view is being composed prior to display.
+        /// </summary>
+        public event EventHandler<ModuleSettingsViewBuildContext>? SettingsViewBuilding;
+
+        /// <summary>
+        /// Occurs once the settings view has been shown.
+        /// </summary>
+        public event EventHandler<ModuleSettingsViewLifecycleContext>? SettingsViewOpened;
+
+        /// <summary>
+        /// Occurs when the user confirms the settings view and changes are being applied.
+        /// </summary>
+        public event EventHandler<ModuleSettingsViewLifecycleContext>? SettingsViewApplying;
+
+        /// <summary>
+        /// Occurs when the settings view is closing.
+        /// </summary>
+        public event EventHandler<ModuleSettingsViewLifecycleContext>? SettingsViewClosing;
+
+        /// <summary>
+        /// Occurs after the settings view has closed.
+        /// </summary>
+        public event EventHandler<ModuleSettingsViewLifecycleContext>? SettingsViewClosed;
+
+        /// <summary>
+        /// Occurs before the WinForms message loop starts executing.
+        /// </summary>
+        public event EventHandler<ModuleAppRunContext>? AppRunStarting;
+
+        /// <summary>
+        /// Occurs after the WinForms message loop has terminated.
+        /// </summary>
+        public event EventHandler<ModuleAppRunContext>? AppRunCompleted;
+
+        /// <summary>
+        /// Occurs at the start of the shutdown sequence.
+        /// </summary>
+        public event EventHandler<ModuleAppShutdownContext>? AppShutdownStarting;
+
+        /// <summary>
+        /// Occurs once the shutdown sequence has finished.
+        /// </summary>
+        public event EventHandler<ModuleAppShutdownContext>? AppShutdownCompleted;
+
+        /// <summary>
+        /// Occurs when an unhandled exception is observed.
+        /// </summary>
+        public event EventHandler<ModuleExceptionContext>? UnhandledExceptionObserved;
+
+        /// <summary>
+        /// Occurs as the WebSocket connection lifecycle progresses.
+        /// </summary>
+        public event EventHandler<ModuleWebSocketConnectionContext>? WebSocketConnecting;
+
+        public event EventHandler<ModuleWebSocketConnectionContext>? WebSocketConnected;
+
+        public event EventHandler<ModuleWebSocketConnectionContext>? WebSocketDisconnected;
+
+        public event EventHandler<ModuleWebSocketConnectionContext>? WebSocketReconnecting;
+
+        /// <summary>
+        /// Occurs whenever a WebSocket message is dispatched to subscribers.
+        /// </summary>
+        public event EventHandler<ModuleWebSocketMessageContext>? WebSocketMessageReceived;
+
+        /// <summary>
+        /// Occurs as the OSC listener lifecycle progresses.
+        /// </summary>
+        public event EventHandler<ModuleOscConnectionContext>? OscConnecting;
+
+        public event EventHandler<ModuleOscConnectionContext>? OscConnected;
+
+        public event EventHandler<ModuleOscConnectionContext>? OscDisconnected;
+
+        public event EventHandler<ModuleOscMessageContext>? OscMessageReceived;
+
+        /// <summary>
+        /// Occurs during settings validation.
+        /// </summary>
+        public event EventHandler<ModuleSettingsValidationContext>? SettingsValidating;
+
+        public event EventHandler<ModuleSettingsValidationContext>? SettingsValidated;
+
+        public event EventHandler<ModuleSettingsValidationContext>? SettingsValidationFailed;
+
+        /// <summary>
+        /// Occurs when auto-suicide operations are coordinated.
+        /// </summary>
+        public event EventHandler<ModuleAutoSuicideRuleContext>? AutoSuicideRulesPrepared;
+
+        public event EventHandler<ModuleAutoSuicideDecisionContext>? AutoSuicideDecisionEvaluated;
+
+        public event EventHandler<ModuleAutoSuicideScheduleContext>? AutoSuicideScheduled;
+
+        public event EventHandler<ModuleAutoSuicideScheduleContext>? AutoSuicideCancelled;
+
+        public event EventHandler<ModuleAutoSuicideTriggerContext>? AutoSuicideTriggered;
+
+        /// <summary>
+        /// Occurs when auto-launch operations are coordinated.
+        /// </summary>
+        public event EventHandler<ModuleAutoLaunchEvaluationContext>? AutoLaunchEvaluating;
+
+        public event EventHandler<ModuleAutoLaunchExecutionContext>? AutoLaunchStarting;
+
+        public event EventHandler<ModuleAutoLaunchFailureContext>? AutoLaunchFailed;
+
+        public event EventHandler<ModuleAutoLaunchExecutionContext>? AutoLaunchCompleted;
+
+        /// <summary>
+        /// Occurs when the main window theme or layout changes.
+        /// </summary>
+        public event EventHandler<ModuleThemeCatalogContext>? ThemeCatalogBuilding;
+
+        public event EventHandler<ModuleMainWindowMenuContext>? MainWindowMenuBuilding;
+
+        public event EventHandler<ModuleMainWindowUiContext>? MainWindowUiComposed;
+
+        public event EventHandler<ModuleMainWindowThemeContext>? MainWindowThemeChanged;
+
+        public event EventHandler<ModuleMainWindowLayoutContext>? MainWindowLayoutUpdated;
+
+        /// <summary>
+        /// Occurs when auxiliary windows are coordinated.
+        /// </summary>
+        public event EventHandler<ModuleAuxiliaryWindowCatalogContext>? AuxiliaryWindowCatalogBuilding;
+
+        public event EventHandler<ModuleAuxiliaryWindowLifecycleContext>? AuxiliaryWindowOpening;
+
+        public event EventHandler<ModuleAuxiliaryWindowLifecycleContext>? AuxiliaryWindowOpened;
+
+        public event EventHandler<ModuleAuxiliaryWindowLifecycleContext>? AuxiliaryWindowClosing;
+
+        public event EventHandler<ModuleAuxiliaryWindowLifecycleContext>? AuxiliaryWindowClosed;
+
+        /// <summary>
+        /// Gets a snapshot of the modules known by the host.
+        /// </summary>
+        public IReadOnlyList<LoadedModule> Modules => _modules.AsReadOnly();
+
+        /// <summary>
+        /// Gets the active service provider, if available.
+        /// </summary>
+        public IServiceProvider? CurrentServiceProvider => _serviceProvider;
+
+        /// <summary>
+        /// Gets the auxiliary windows registered with the host.
+        /// </summary>
+        public IReadOnlyCollection<AuxiliaryWindowDescriptor> AuxiliaryWindows => _auxiliaryWindows.Values;
+
+        public void NotifyDiscoveryStarted(string directory)
+        {
+            DiscoveryStarted?.Invoke(this, directory);
+            _bus.Publish(new ModuleDiscoveryStarted(directory));
+        }
+
+        public void NotifyDiscoveryCompleted()
+        {
+            var snapshot = _modules.ConvertAll(m => m.Discovery);
+            var readOnly = snapshot.AsReadOnly();
+            DiscoveryCompleted?.Invoke(this, readOnly);
+            _bus.Publish(new ModuleDiscoveryCompleted(readOnly));
+        }
+
+        public void RegisterModule(IModule module, ModuleDiscoveryContext discovery, IServiceCollection services)
+        {
+            var loaded = new LoadedModule(module, discovery);
+            _modules.Add(loaded);
+
+            ModuleDiscovered?.Invoke(this, discovery);
+            _bus.Publish(new ModuleDiscovered(discovery));
+
+            if (InvokeModuleAction(loaded, discovery, static (m, ctx) => m.OnModuleLoaded(ctx), nameof(IModule.OnModuleLoaded)))
+            {
+                NotifyPeers(loaded, discovery, static (m, ctx) => m.OnPeerModuleLoaded(ctx), nameof(IModule.OnPeerModuleLoaded));
+            }
+
+            ModuleLoaded?.Invoke(this, discovery);
+            _bus.Publish(new ModuleLoaded(discovery));
+
+            var registrationContext = new ModuleServiceRegistrationContext(discovery, services, _logger, _bus);
+            BeforeServiceRegistration?.Invoke(this, registrationContext);
+            _bus.Publish(new ModuleServicesRegistering(registrationContext));
+
+            if (InvokeModuleAction(loaded, registrationContext, static (m, ctx) => m.OnBeforeServiceRegistration(ctx), nameof(IModule.OnBeforeServiceRegistration)))
+            {
+                NotifyPeers(loaded, registrationContext, static (m, ctx) => m.OnPeerModuleBeforeServiceRegistration(ctx), nameof(IModule.OnPeerModuleBeforeServiceRegistration));
+            }
+
+            NotifyPeers(loaded, registrationContext, static (m, ctx) => m.OnPeerModuleRegisteringServices(ctx), nameof(IModule.OnPeerModuleRegisteringServices));
+
+            try
+            {
+                module.RegisterServices(services);
+            }
+            catch (Exception ex)
+            {
+                HandleModuleException(loaded, nameof(IModule.RegisterServices), ex);
+                _bus.Publish(new ModuleServiceRegistrationFailed(discovery, ex));
+                return;
+            }
+
+            if (InvokeModuleAction(loaded, registrationContext, static (m, ctx) => m.OnAfterServiceRegistration(ctx), nameof(IModule.OnAfterServiceRegistration)))
+            {
+                NotifyPeers(loaded, registrationContext, static (m, ctx) => m.OnPeerModuleAfterServiceRegistration(ctx), nameof(IModule.OnPeerModuleAfterServiceRegistration));
+            }
+
+            AfterServiceRegistration?.Invoke(this, registrationContext);
+            _bus.Publish(new ModuleServicesRegistered(registrationContext));
+        }
+
+        public void NotifyServiceProviderBuilding(ModuleServiceProviderBuildContext context)
+        {
+            ServiceProviderBuilding?.Invoke(this, context);
+            _bus.Publish(new ServiceProviderBuilding(context));
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnBeforeServiceProviderBuild(ctx), nameof(IModule.OnBeforeServiceProviderBuild)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleBeforeServiceProviderBuild(ctx), nameof(IModule.OnPeerModuleBeforeServiceProviderBuild));
+                }
+            }
+        }
+
+        public void NotifyServiceProviderBuilt(ModuleServiceProviderContext context)
+        {
+            _serviceProvider = context.ServiceProvider;
+            ServiceProviderBuilt?.Invoke(this, context);
+            _bus.Publish(new ServiceProviderBuilt(context));
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnAfterServiceProviderBuild(ctx), nameof(IModule.OnAfterServiceProviderBuild)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleAfterServiceProviderBuild(ctx), nameof(IModule.OnPeerModuleAfterServiceProviderBuild));
+                }
+            }
+        }
+
+        public void NotifyMainWindowCreating(ModuleMainWindowCreationContext context)
+        {
+            MainWindowCreating?.Invoke(this, context);
+            _bus.Publish(new MainWindowCreating(context));
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnBeforeMainWindowCreation(ctx), nameof(IModule.OnBeforeMainWindowCreation)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleBeforeMainWindowCreation(ctx), nameof(IModule.OnPeerModuleBeforeMainWindowCreation));
+                }
+            }
+        }
+
+        public void NotifyMainWindowCreated(ModuleMainWindowContext context)
+        {
+            MainWindowCreated?.Invoke(this, context);
+            _bus.Publish(new MainWindowCreated(context));
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnAfterMainWindowCreation(ctx), nameof(IModule.OnAfterMainWindowCreation)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleAfterMainWindowCreation(ctx), nameof(IModule.OnPeerModuleAfterMainWindowCreation));
+                }
+            }
+        }
+
+        public void NotifyMainWindowShown(ModuleMainWindowLifecycleContext context)
+        {
+            MainWindowShown?.Invoke(this, context);
+            _bus.Publish(new MainWindowShown(context));
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnMainWindowShown(ctx), nameof(IModule.OnMainWindowShown)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleMainWindowShown(ctx), nameof(IModule.OnPeerModuleMainWindowShown));
+                }
+            }
+        }
+
+        public void NotifyMainWindowClosing(ModuleMainWindowLifecycleContext context)
+        {
+            MainWindowClosing?.Invoke(this, context);
+            _bus.Publish(new MainWindowClosing(context));
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnMainWindowClosing(ctx), nameof(IModule.OnMainWindowClosing)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleMainWindowClosing(ctx), nameof(IModule.OnPeerModuleMainWindowClosing));
+                }
+            }
+        }
+
+        public void NotifyAppRunStarting(ModuleAppRunContext context)
+        {
+            AppRunStarting?.Invoke(this, context);
+            _bus.Publish(new AppRunStarting(context));
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnAppRunStarting(ctx), nameof(IModule.OnAppRunStarting)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleAppRunStarting(ctx), nameof(IModule.OnPeerModuleAppRunStarting));
+                }
+            }
+        }
+
+        public void NotifyAppRunCompleted(ModuleAppRunContext context)
+        {
+            AppRunCompleted?.Invoke(this, context);
+            _bus.Publish(new AppRunCompleted(context));
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnAppRunCompleted(ctx), nameof(IModule.OnAppRunCompleted)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleAppRunCompleted(ctx), nameof(IModule.OnPeerModuleAppRunCompleted));
+                }
+            }
+        }
+
+        public void NotifyAppShutdownStarting(ModuleAppShutdownContext context)
+        {
+            AppShutdownStarting?.Invoke(this, context);
+            _bus.Publish(new AppShutdownStarting(context));
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnBeforeAppShutdown(ctx), nameof(IModule.OnBeforeAppShutdown)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleBeforeAppShutdown(ctx), nameof(IModule.OnPeerModuleBeforeAppShutdown));
+                }
+            }
+        }
+
+        public void NotifyAppShutdownCompleted(ModuleAppShutdownContext context)
+        {
+            AppShutdownCompleted?.Invoke(this, context);
+            _bus.Publish(new AppShutdownCompleted(context));
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnAfterAppShutdown(ctx), nameof(IModule.OnAfterAppShutdown)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleAfterAppShutdown(ctx), nameof(IModule.OnPeerModuleAfterAppShutdown));
+                }
+            }
+
+            _serviceProvider = null;
+        }
+
+        public void NotifyAutoSuicideRulesPrepared(ModuleAutoSuicideRuleContext context)
+        {
+            AutoSuicideRulesPrepared?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnAutoSuicideRulesPrepared(ctx), nameof(IModule.OnAutoSuicideRulesPrepared));
+            }
+
+            _bus.Publish(new AutoSuicideRulesPrepared(new List<AutoSuicideRule>(context.Rules).AsReadOnly(), context.Settings));
+        }
+
+        public void NotifyAutoSuicideDecisionEvaluated(ModuleAutoSuicideDecisionContext context)
+        {
+            AutoSuicideDecisionEvaluated?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnAutoSuicideDecisionEvaluated(ctx), nameof(IModule.OnAutoSuicideDecisionEvaluated));
+            }
+
+            _bus.Publish(new AutoSuicideDecisionEvaluated(context.RoundType, context.TerrorName, context.Decision, context.HasPendingDelayed));
+        }
+
+        public void NotifyAutoLaunchEvaluating(ModuleAutoLaunchEvaluationContext context)
+        {
+            AutoLaunchEvaluating?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnAutoLaunchEvaluating(ctx), nameof(IModule.OnAutoLaunchEvaluating));
+            }
+
+            _bus.Publish(new AutoLaunchEvaluating(new List<AutoLaunchPlan>(context.Plans).AsReadOnly(), context.Settings));
+        }
+
+        public void NotifyAutoLaunchStarting(ModuleAutoLaunchExecutionContext context)
+        {
+            AutoLaunchStarting?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnAutoLaunchStarting(ctx), nameof(IModule.OnAutoLaunchStarting));
+            }
+
+            _bus.Publish(new AutoLaunchStarting(context.Plan));
+        }
+
+        public void NotifyAutoLaunchFailed(ModuleAutoLaunchFailureContext context)
+        {
+            AutoLaunchFailed?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnAutoLaunchFailed(ctx), nameof(IModule.OnAutoLaunchFailed));
+            }
+
+            _bus.Publish(new AutoLaunchFailed(context.Plan, context.Exception));
+        }
+
+        public void NotifyAutoLaunchCompleted(ModuleAutoLaunchExecutionContext context)
+        {
+            AutoLaunchCompleted?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnAutoLaunchCompleted(ctx), nameof(IModule.OnAutoLaunchCompleted));
+            }
+
+            _bus.Publish(new AutoLaunchCompleted(context.Plan));
+        }
+
+        public void NotifyThemeCatalogBuilding(ModuleThemeCatalogContext context)
+        {
+            ThemeCatalogBuilding?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnThemeCatalogBuilding(ctx), nameof(IModule.OnThemeCatalogBuilding));
+            }
+        }
+
+        public void NotifyMainWindowMenuBuilding(ModuleMainWindowMenuContext context)
+        {
+            MainWindowMenuBuilding?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnMainWindowMenuBuilding(ctx), nameof(IModule.OnMainWindowMenuBuilding));
+            }
+        }
+
+        public void NotifyMainWindowUiComposed(ModuleMainWindowUiContext context)
+        {
+            MainWindowUiComposed?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnMainWindowUiComposed(ctx), nameof(IModule.OnMainWindowUiComposed));
+            }
+        }
+
+        public void NotifyMainWindowThemeChanged(ModuleMainWindowThemeContext context)
+        {
+            MainWindowThemeChanged?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnMainWindowThemeChanged(ctx), nameof(IModule.OnMainWindowThemeChanged));
+            }
+
+            _bus.Publish(new MainWindowThemeChanged(context.ThemeKey, context.Theme, context.Form));
+        }
+
+        public void NotifyMainWindowLayoutUpdated(ModuleMainWindowLayoutContext context)
+        {
+            MainWindowLayoutUpdated?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnMainWindowLayoutUpdated(ctx), nameof(IModule.OnMainWindowLayoutUpdated));
+            }
+
+            _bus.Publish(new MainWindowLayoutUpdated(context.Form));
+        }
+
+        public void NotifySettingsViewBuilding(ModuleSettingsViewBuildContext context)
+        {
+            SettingsViewBuilding?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsViewBuilding(ctx), nameof(IModule.OnSettingsViewBuilding));
+            }
+        }
+
+        public void NotifySettingsViewOpened(ModuleSettingsViewLifecycleContext context)
+        {
+            SettingsViewOpened?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsViewOpened(ctx), nameof(IModule.OnSettingsViewOpened));
+            }
+        }
+
+        public void NotifySettingsViewApplying(ModuleSettingsViewLifecycleContext context)
+        {
+            SettingsViewApplying?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsViewApplying(ctx), nameof(IModule.OnSettingsViewApplying));
+            }
+        }
+
+        public void NotifySettingsViewClosing(ModuleSettingsViewLifecycleContext context)
+        {
+            SettingsViewClosing?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsViewClosing(ctx), nameof(IModule.OnSettingsViewClosing));
+            }
+        }
+
+        public void NotifySettingsViewClosed(ModuleSettingsViewLifecycleContext context)
+        {
+            SettingsViewClosed?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsViewClosed(ctx), nameof(IModule.OnSettingsViewClosed));
+            }
+        }
+
+        public ModuleAuxiliaryWindowCatalogContext NotifyAuxiliaryWindowCatalogBuilding()
+        {
+            var snapshot = new List<AuxiliaryWindowDescriptor>(_auxiliaryWindows.Values).AsReadOnly();
+            var context = new ModuleAuxiliaryWindowCatalogContext(snapshot, RegisterAuxiliaryWindow, _serviceProvider);
+            AuxiliaryWindowCatalogBuilding?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnAuxiliaryWindowCatalogBuilding(ctx), nameof(IModule.OnAuxiliaryWindowCatalogBuilding));
+            }
+
+            return context;
+        }
+
+        public Form? ShowAuxiliaryWindow(string id, Form? owner = null)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return null;
+            }
+
+            if (!_auxiliaryWindows.TryGetValue(id, out var descriptor))
+            {
+                return null;
+            }
+
+            if (!descriptor.AllowMultipleInstances && _activeAuxiliaryWindows.TryGetValue(descriptor.Id, out var existingList))
+            {
+                var existing = existingList.Find(f => f != null && !f.IsDisposed);
+                if (existing != null)
+                {
+                    if (existing.WindowState == FormWindowState.Minimized)
+                    {
+                        existing.WindowState = FormWindowState.Normal;
+                    }
+
+                    existing.BringToFront();
+                    existing.Activate();
+                    return existing;
+                }
+            }
+
+            Form window;
+            try
+            {
+                window = descriptor.Factory(_serviceProvider);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogEvent("ModuleHost", $"Auxiliary window '{descriptor.Id}' factory failed: {ex}", LogEventLevel.Error);
+                return null;
+            }
+
+            if (window == null)
+            {
+                return null;
+            }
+
+            if (!_activeAuxiliaryWindows.TryGetValue(descriptor.Id, out var instances))
+            {
+                instances = new List<Form>();
+                _activeAuxiliaryWindows[descriptor.Id] = instances;
+            }
+
+            instances.Add(window);
+
+            var openingContext = new ModuleAuxiliaryWindowLifecycleContext(descriptor, window, ModuleAuxiliaryWindowStage.Opening, _serviceProvider);
+            NotifyAuxiliaryWindowLifecycle(openingContext, AuxiliaryWindowOpening, static (m, ctx) => m.OnAuxiliaryWindowOpening(ctx), nameof(IModule.OnAuxiliaryWindowOpening));
+
+            window.Shown += (s, e) =>
+            {
+                var openedContext = new ModuleAuxiliaryWindowLifecycleContext(descriptor, window, ModuleAuxiliaryWindowStage.Opened, _serviceProvider);
+                NotifyAuxiliaryWindowLifecycle(openedContext, AuxiliaryWindowOpened, static (m, ctx) => m.OnAuxiliaryWindowOpened(ctx), nameof(IModule.OnAuxiliaryWindowOpened));
+            };
+
+            window.FormClosing += (s, e) =>
+            {
+                var closingContext = new ModuleAuxiliaryWindowLifecycleContext(descriptor, window, ModuleAuxiliaryWindowStage.Closing, _serviceProvider);
+                NotifyAuxiliaryWindowLifecycle(closingContext, AuxiliaryWindowClosing, static (m, ctx) => m.OnAuxiliaryWindowClosing(ctx), nameof(IModule.OnAuxiliaryWindowClosing));
+            };
+
+            window.FormClosed += (s, e) =>
+            {
+                if (_activeAuxiliaryWindows.TryGetValue(descriptor.Id, out var active))
+                {
+                    active.Remove(window);
+                }
+
+                var closedContext = new ModuleAuxiliaryWindowLifecycleContext(descriptor, window, ModuleAuxiliaryWindowStage.Closed, _serviceProvider);
+                NotifyAuxiliaryWindowLifecycle(closedContext, AuxiliaryWindowClosed, static (m, ctx) => m.OnAuxiliaryWindowClosed(ctx), nameof(IModule.OnAuxiliaryWindowClosed));
+            };
+
+            if (owner != null && !descriptor.ShowModal)
+            {
+                window.Owner = owner;
+            }
+
+            if (descriptor.ShowModal && owner != null)
+            {
+                window.StartPosition = FormStartPosition.CenterParent;
+                window.ShowDialog(owner);
+            }
+            else if (descriptor.ShowModal)
+            {
+                window.StartPosition = FormStartPosition.CenterScreen;
+                window.ShowDialog();
+            }
+            else
+            {
+                window.Show(owner);
+            }
+
+            return window;
+        }
+
+        private void HandleWebSocketConnecting(WebSocketConnecting message)
+        {
+            var context = new ModuleWebSocketConnectionContext(message.Endpoint, ModuleWebSocketConnectionPhase.Connecting, _serviceProvider);
+            WebSocketConnecting?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnWebSocketConnecting(ctx), nameof(IModule.OnWebSocketConnecting));
+            }
+        }
+
+        private void HandleWebSocketConnected(WebSocketConnected message)
+        {
+            var context = new ModuleWebSocketConnectionContext(message.Endpoint, ModuleWebSocketConnectionPhase.Connected, _serviceProvider);
+            WebSocketConnected?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnWebSocketConnected(ctx), nameof(IModule.OnWebSocketConnected));
+            }
+        }
+
+        private void HandleWebSocketDisconnected(WebSocketDisconnected message)
+        {
+            var context = new ModuleWebSocketConnectionContext(message.Endpoint, ModuleWebSocketConnectionPhase.Disconnected, _serviceProvider, message.Exception);
+            WebSocketDisconnected?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnWebSocketDisconnected(ctx), nameof(IModule.OnWebSocketDisconnected));
+            }
+        }
+
+        private void HandleWebSocketReconnecting(WebSocketReconnecting message)
+        {
+            var context = new ModuleWebSocketConnectionContext(message.Endpoint, ModuleWebSocketConnectionPhase.Reconnecting, _serviceProvider, message.Exception);
+            WebSocketReconnecting?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnWebSocketReconnecting(ctx), nameof(IModule.OnWebSocketReconnecting));
+            }
+        }
+
+        private void HandleWebSocketMessageReceived(WebSocketMessageReceived message)
+        {
+            var context = new ModuleWebSocketMessageContext(message.Message, _serviceProvider);
+            WebSocketMessageReceived?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnWebSocketMessageReceived(ctx), nameof(IModule.OnWebSocketMessageReceived));
+            }
+        }
+
+        private void HandleOscConnecting(OscConnecting message)
+        {
+            var context = new ModuleOscConnectionContext(message.Port, ModuleOscConnectionPhase.Connecting, _serviceProvider);
+            OscConnecting?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnOscConnecting(ctx), nameof(IModule.OnOscConnecting));
+            }
+        }
+
+        private void HandleOscConnected(OscConnected message)
+        {
+            var context = new ModuleOscConnectionContext(message.Port, ModuleOscConnectionPhase.Connected, _serviceProvider);
+            OscConnected?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnOscConnected(ctx), nameof(IModule.OnOscConnected));
+            }
+        }
+
+        private void HandleOscDisconnected(OscDisconnected message)
+        {
+            var context = new ModuleOscConnectionContext(message.Port, ModuleOscConnectionPhase.Disconnected, _serviceProvider, message.Exception);
+            OscDisconnected?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnOscDisconnected(ctx), nameof(IModule.OnOscDisconnected));
+            }
+        }
+
+        private void HandleOscMessageReceived(OscMessageReceived message)
+        {
+            var context = new ModuleOscMessageContext(message.Message, _serviceProvider);
+            OscMessageReceived?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnOscMessageReceived(ctx), nameof(IModule.OnOscMessageReceived));
+            }
+        }
+
+        private void HandleSettingsValidating(SettingsValidating message)
+        {
+            var context = new ModuleSettingsValidationContext(message.Settings, message.Errors, ModuleSettingsValidationStage.Validating, _serviceProvider);
+            SettingsValidating?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnBeforeSettingsValidation(ctx), nameof(IModule.OnBeforeSettingsValidation));
+            }
+        }
+
+        private void HandleSettingsValidated(SettingsValidated message)
+        {
+            var context = new ModuleSettingsValidationContext(message.Settings, new List<string>(), ModuleSettingsValidationStage.Validated, _serviceProvider);
+            SettingsValidated?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsValidated(ctx), nameof(IModule.OnSettingsValidated));
+            }
+        }
+
+        private void HandleSettingsValidationFailed(SettingsValidationFailed message)
+        {
+            var context = new ModuleSettingsValidationContext(message.Settings, new List<string>(message.Errors), ModuleSettingsValidationStage.Failed, _serviceProvider);
+            SettingsValidationFailed?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsValidationFailed(ctx), nameof(IModule.OnSettingsValidationFailed));
+            }
+        }
+
+        private void HandleSettingsLoading(SettingsLoading message)
+        {
+            if (_serviceProvider == null)
+            {
+                return;
+            }
+
+            var context = new ModuleSettingsContext(message.Settings, _serviceProvider);
+            SettingsLoading?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsLoading(ctx), nameof(IModule.OnSettingsLoading)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleSettingsLoading(ctx), nameof(IModule.OnPeerModuleSettingsLoading));
+                }
+            }
+        }
+
+        private void HandleSettingsLoaded(SettingsLoaded message)
+        {
+            if (_serviceProvider == null)
+            {
+                return;
+            }
+
+            var context = new ModuleSettingsContext(message.Settings, _serviceProvider);
+            SettingsLoaded?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsLoaded(ctx), nameof(IModule.OnSettingsLoaded)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleSettingsLoaded(ctx), nameof(IModule.OnPeerModuleSettingsLoaded));
+                }
+            }
+        }
+
+        private void HandleSettingsSaving(SettingsSaving message)
+        {
+            if (_serviceProvider == null)
+            {
+                return;
+            }
+
+            var context = new ModuleSettingsContext(message.Settings, _serviceProvider);
+            SettingsSaving?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsSaving(ctx), nameof(IModule.OnSettingsSaving)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleSettingsSaving(ctx), nameof(IModule.OnPeerModuleSettingsSaving));
+                }
+            }
+        }
+
+        private void HandleSettingsSaved(SettingsSaved message)
+        {
+            if (_serviceProvider == null)
+            {
+                return;
+            }
+
+            var context = new ModuleSettingsContext(message.Settings, _serviceProvider);
+            SettingsSaved?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnSettingsSaved(ctx), nameof(IModule.OnSettingsSaved)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleSettingsSaved(ctx), nameof(IModule.OnPeerModuleSettingsSaved));
+                }
+            }
+        }
+
+        private void HandleAutoSuicideScheduled(AutoSuicideScheduled message)
+        {
+            var context = new ModuleAutoSuicideScheduleContext(message.Delay, message.ResetStartTime, _serviceProvider);
+            AutoSuicideScheduled?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnAutoSuicideScheduled(ctx), nameof(IModule.OnAutoSuicideScheduled));
+            }
+        }
+
+        private void HandleAutoSuicideCancelled(AutoSuicideCancelled message)
+        {
+            var context = new ModuleAutoSuicideScheduleContext(message.RemainingDelay ?? TimeSpan.Zero, resetStartTime: false, _serviceProvider);
+            AutoSuicideCancelled?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnAutoSuicideCancelled(ctx), nameof(IModule.OnAutoSuicideCancelled));
+            }
+        }
+
+        private void HandleAutoSuicideTriggered(AutoSuicideTriggered message)
+        {
+            var context = new ModuleAutoSuicideTriggerContext(_serviceProvider);
+            AutoSuicideTriggered?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, static (m, ctx) => m.OnAutoSuicideTriggered(ctx), nameof(IModule.OnAutoSuicideTriggered));
+            }
+        }
+
+        private void HandleUnhandledException(UnhandledExceptionOccurred message)
+        {
+            var context = new ModuleExceptionContext(message.Exception, message.IsTerminating, _serviceProvider);
+            UnhandledExceptionObserved?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                if (InvokeModuleAction(module, context, static (m, ctx) => m.OnUnhandledException(ctx), nameof(IModule.OnUnhandledException)))
+                {
+                    NotifyPeers(module, context, static (m, ctx) => m.OnPeerModuleUnhandledException(ctx), nameof(IModule.OnPeerModuleUnhandledException));
+                }
+            }
+        }
+
+        private bool InvokeModuleAction<TContext>(LoadedModule module, TContext context, Action<IModule, TContext> action, string stage)
+        {
+            try
+            {
+                action(module.Instance, context);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                HandleModuleException(module, stage, ex);
+                return false;
+            }
+        }
+
+        private void NotifyPeers<TContext>(LoadedModule subject, TContext context, Action<IModule, ModulePeerNotificationContext<TContext>> peerAction, string stage)
+        {
+            if (_modules.Count <= 1)
+            {
+                return;
+            }
+
+            var notification = new ModulePeerNotificationContext<TContext>(subject.Discovery, context);
+
+            foreach (var peer in _modules)
+            {
+                if (ReferenceEquals(peer, subject))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    peerAction(peer.Instance, notification);
+                }
+                catch (Exception ex)
+                {
+                    HandleModuleException(peer, stage, ex);
+                }
+            }
+        }
+
+        private void HandleModuleException(LoadedModule module, string stage, Exception exception)
+        {
+            _logger.LogEvent("ModuleHost", $"Module '{module.Discovery.ModuleName}' failed during {stage}: {exception}", LogEventLevel.Error);
+            _bus.Publish(new ModuleCallbackFailed(module.Discovery, stage, exception));
+        }
+
+        private void RegisterAuxiliaryWindow(AuxiliaryWindowDescriptor descriptor)
+        {
+            if (descriptor == null)
+            {
+                return;
+            }
+
+            _auxiliaryWindows[descriptor.Id] = descriptor;
+        }
+
+        private void NotifyAuxiliaryWindowLifecycle(ModuleAuxiliaryWindowLifecycleContext context, EventHandler<ModuleAuxiliaryWindowLifecycleContext>? handler, Action<IModule, ModuleAuxiliaryWindowLifecycleContext> action, string stage)
+        {
+            handler?.Invoke(this, context);
+            foreach (var module in _modules)
+            {
+                InvokeModuleAction(module, context, action, stage);
+            }
+        }
+
+        public sealed record LoadedModule(IModule Instance, ModuleDiscoveryContext Discovery);
+    }
+}

--- a/Modules/AfkJumpModule/AfkJumpModule.cs
+++ b/Modules/AfkJumpModule/AfkJumpModule.cs
@@ -5,15 +5,321 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Rug.Osc;
 using Serilog.Events;
+using System.Windows.Forms;
 using ToNRoundCounter.Application;
 
 namespace ToNRoundCounter.Modules.AfkJump
 {
     public sealed class AfkJumpModule : IModule
     {
+        public void OnModuleLoaded(ModuleDiscoveryContext context)
+        {
+        }
+
+        public void OnBeforeServiceRegistration(ModuleServiceRegistrationContext context)
+        {
+        }
+
         public void RegisterServices(IServiceCollection services)
         {
             services.AddSingleton<IAfkWarningHandler>(sp => new AfkJumpHandler(sp.GetRequiredService<IEventLogger>()));
+        }
+
+        public void OnAfterServiceRegistration(ModuleServiceRegistrationContext context)
+        {
+        }
+
+        public void OnBeforeServiceProviderBuild(ModuleServiceProviderBuildContext context)
+        {
+        }
+
+        public void OnAfterServiceProviderBuild(ModuleServiceProviderContext context)
+        {
+        }
+
+        public void OnBeforeMainWindowCreation(ModuleMainWindowCreationContext context)
+        {
+        }
+
+        public void OnAfterMainWindowCreation(ModuleMainWindowContext context)
+        {
+        }
+
+        public void OnMainWindowShown(ModuleMainWindowLifecycleContext context)
+        {
+        }
+
+        public void OnMainWindowClosing(ModuleMainWindowLifecycleContext context)
+        {
+        }
+
+        public void OnSettingsLoading(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsLoaded(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsSaving(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsSaved(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsViewBuilding(ModuleSettingsViewBuildContext context)
+        {
+            if (context == null)
+            {
+                return;
+            }
+
+            var group = context.AddSettingsGroup("AFK Jump");
+            var description = new Label
+            {
+                AutoSize = true,
+                Text = "AFKジャンプモジュールには設定項目はありません。"
+            };
+
+            group.Controls.Add(description);
+        }
+
+        public void OnSettingsViewOpened(ModuleSettingsViewLifecycleContext context)
+        {
+        }
+
+        public void OnSettingsViewApplying(ModuleSettingsViewLifecycleContext context)
+        {
+        }
+
+        public void OnSettingsViewClosing(ModuleSettingsViewLifecycleContext context)
+        {
+        }
+
+        public void OnSettingsViewClosed(ModuleSettingsViewLifecycleContext context)
+        {
+        }
+
+        public void OnAppRunStarting(ModuleAppRunContext context)
+        {
+        }
+
+        public void OnAppRunCompleted(ModuleAppRunContext context)
+        {
+        }
+
+        public void OnBeforeAppShutdown(ModuleAppShutdownContext context)
+        {
+        }
+
+        public void OnAfterAppShutdown(ModuleAppShutdownContext context)
+        {
+        }
+
+        public void OnUnhandledException(ModuleExceptionContext context)
+        {
+        }
+
+        public void OnWebSocketConnecting(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketConnected(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketDisconnected(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketReconnecting(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketMessageReceived(ModuleWebSocketMessageContext context)
+        {
+        }
+
+        public void OnOscConnecting(ModuleOscConnectionContext context)
+        {
+        }
+
+        public void OnOscConnected(ModuleOscConnectionContext context)
+        {
+        }
+
+        public void OnOscDisconnected(ModuleOscConnectionContext context)
+        {
+        }
+
+        public void OnOscMessageReceived(ModuleOscMessageContext context)
+        {
+        }
+
+        public void OnBeforeSettingsValidation(ModuleSettingsValidationContext context)
+        {
+        }
+
+        public void OnSettingsValidated(ModuleSettingsValidationContext context)
+        {
+        }
+
+        public void OnSettingsValidationFailed(ModuleSettingsValidationContext context)
+        {
+        }
+
+        public void OnAutoSuicideRulesPrepared(ModuleAutoSuicideRuleContext context)
+        {
+        }
+
+        public void OnAutoSuicideDecisionEvaluated(ModuleAutoSuicideDecisionContext context)
+        {
+        }
+
+        public void OnAutoSuicideScheduled(ModuleAutoSuicideScheduleContext context)
+        {
+        }
+
+        public void OnAutoSuicideCancelled(ModuleAutoSuicideScheduleContext context)
+        {
+        }
+
+        public void OnAutoSuicideTriggered(ModuleAutoSuicideTriggerContext context)
+        {
+        }
+
+        public void OnAutoLaunchEvaluating(ModuleAutoLaunchEvaluationContext context)
+        {
+        }
+
+        public void OnAutoLaunchStarting(ModuleAutoLaunchExecutionContext context)
+        {
+        }
+
+        public void OnAutoLaunchFailed(ModuleAutoLaunchFailureContext context)
+        {
+        }
+
+        public void OnAutoLaunchCompleted(ModuleAutoLaunchExecutionContext context)
+        {
+        }
+
+        public void OnThemeCatalogBuilding(ModuleThemeCatalogContext context)
+        {
+        }
+
+        public void OnMainWindowMenuBuilding(ModuleMainWindowMenuContext context)
+        {
+        }
+
+        public void OnMainWindowUiComposed(ModuleMainWindowUiContext context)
+        {
+        }
+
+        public void OnMainWindowThemeChanged(ModuleMainWindowThemeContext context)
+        {
+        }
+
+        public void OnMainWindowLayoutUpdated(ModuleMainWindowLayoutContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowCatalogBuilding(ModuleAuxiliaryWindowCatalogContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowOpening(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowOpened(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowClosing(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowClosed(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnPeerModuleLoaded(ModulePeerNotificationContext<ModuleDiscoveryContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeServiceRegistration(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context)
+        {
+        }
+
+        public void OnPeerModuleRegisteringServices(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterServiceRegistration(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeServiceProviderBuild(ModulePeerNotificationContext<ModuleServiceProviderBuildContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterServiceProviderBuild(ModulePeerNotificationContext<ModuleServiceProviderContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeMainWindowCreation(ModulePeerNotificationContext<ModuleMainWindowCreationContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterMainWindowCreation(ModulePeerNotificationContext<ModuleMainWindowContext> context)
+        {
+        }
+
+        public void OnPeerModuleMainWindowShown(ModulePeerNotificationContext<ModuleMainWindowLifecycleContext> context)
+        {
+        }
+
+        public void OnPeerModuleMainWindowClosing(ModulePeerNotificationContext<ModuleMainWindowLifecycleContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsLoading(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsLoaded(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsSaving(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsSaved(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleAppRunStarting(ModulePeerNotificationContext<ModuleAppRunContext> context)
+        {
+        }
+
+        public void OnPeerModuleAppRunCompleted(ModulePeerNotificationContext<ModuleAppRunContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeAppShutdown(ModulePeerNotificationContext<ModuleAppShutdownContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterAppShutdown(ModulePeerNotificationContext<ModuleAppShutdownContext> context)
+        {
+        }
+
+        public void OnPeerModuleUnhandledException(ModulePeerNotificationContext<ModuleExceptionContext> context)
+        {
         }
     }
 

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -191,6 +191,7 @@
     <Compile Include="Infrastructure\WinFormsDispatcher.cs" />
     <Compile Include="Infrastructure\ChannelReaderExtensions.cs" />
     <Compile Include="Infrastructure\HttpClientWrapper.cs" />
+    <Compile Include="Infrastructure\ModuleHost.cs" />
     <Compile Include="Infrastructure\ModuleLoader.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/UI/LogPanel.cs
+++ b/UI/LogPanel.cs
@@ -21,7 +21,7 @@ namespace ToNRoundCounter.UI
             AggregateStatsTextBox.ReadOnly = true;
             AggregateStatsTextBox.BorderStyle = BorderStyle.FixedSingle;
             AggregateStatsTextBox.Font = new Font("Arial", 10);
-            AggregateStatsTextBox.BackColor = Theme.Current == Theme.Light ? Color.White : Theme.Current.Background;
+            AggregateStatsTextBox.BackColor = Theme.Current.PanelBackground;
             AggregateStatsTextBox.ForeColor = Theme.Current.Foreground;
             AggregateStatsTextBox.Location = new Point(margin, margin);
             AggregateStatsTextBox.Size = new Size(540, 150);
@@ -31,7 +31,7 @@ namespace ToNRoundCounter.UI
             RoundLogTextBox.ReadOnly = true;
             RoundLogTextBox.BorderStyle = BorderStyle.FixedSingle;
             RoundLogTextBox.Font = new Font("Arial", 10);
-            RoundLogTextBox.BackColor = Theme.Current == Theme.Light ? Color.White : Theme.Current.Background;
+            RoundLogTextBox.BackColor = Theme.Current.PanelBackground;
             RoundLogTextBox.ForeColor = Theme.Current.Foreground;
             RoundLogTextBox.Location = new Point(margin, AggregateStatsTextBox.Bottom + margin);
             RoundLogTextBox.Size = new Size(540, 150);

--- a/docs/module-development.md
+++ b/docs/module-development.md
@@ -22,6 +22,22 @@
 ## IModule の実装
 モジュールは `ToNRoundCounter.Application.IModule` を実装するクラスを少なくとも 1 つ公開する必要があります。`RegisterServices` メソッド内で必要なサービスを `IServiceCollection` に追加すると、アプリ本体の DI コンテナから解決できるようになります。
 
+`IModule` にはアプリケーションのライフサイクルに応じた多数のフックメソッドが用意されており、必要に応じて任意のメソッドをオーバーライドできます。主なメソッドは以下の通りです。
+
+- `OnModuleLoaded` / `OnBeforeServiceRegistration` / `OnAfterServiceRegistration` などの DI 登録フェーズ向けフック。
+- `OnBeforeServiceProviderBuild` / `OnAfterServiceProviderBuild` によるサービスプロバイダー構築前後の処理。
+- `OnBeforeMainWindowCreation` / `OnAfterMainWindowCreation` / `OnMainWindowShown` / `OnMainWindowClosing` によるメインウィンドウ操作の拡張。
+- `OnSettingsLoading` / `OnSettingsLoaded` / `OnSettingsSaving` / `OnSettingsSaved` による設定ファイル読み書きの監視。
+- `OnAppRunStarting` / `OnAppRunCompleted` / `OnBeforeAppShutdown` / `OnAfterAppShutdown` / `OnUnhandledException` といったアプリケーション全体のライフサイクルイベント。【F:Application/IModule.cs†L13-L126】
+- WebSocket・OSC 通信のライフサイクルを監視する `OnWebSocket...` および `OnOsc...` 系のハンドラー。再接続通知や受信メッセージを横取りして独自ロジックを挿入できます。【F:Application/IModule.cs†L128-L177】
+- 設定バリデーションを拡張する `OnBeforeSettingsValidation` / `OnSettingsValidated` / `OnSettingsValidationFailed`。エラーメッセージの追加や検証成功時の後処理を実装できます。【F:Application/IModule.cs†L179-L207】【F:Infrastructure/AppSettings.cs†L82-L134】
+- オート自殺ロジックをカスタマイズする `OnAutoSuicideRulesPrepared` / `OnAutoSuicideDecisionEvaluated` / `OnAutoSuicideScheduled` などのハンドラー。ルール集合の編集や判定結果の上書き、キャンセル検知が可能です。【F:Application/IModule.cs†L209-L247】【F:UI/MainForm.cs†L1548-L1587】【F:Application/AutoSuicideService.cs†L10-L81】
+- 自動起動機能を制御する `OnAutoLaunchEvaluating` / `OnAutoLaunchStarting` / `OnAutoLaunchFailed` / `OnAutoLaunchCompleted`。起動対象の追加・削除や失敗時のフォールバック処理を実装できます。【F:Application/IModule.cs†L249-L263】【F:Program.cs†L118-L189】
+- `OnThemeCatalogBuilding` / `OnMainWindowMenuBuilding` / `OnMainWindowUiComposed` / `OnMainWindowThemeChanged` / `OnMainWindowLayoutUpdated` による UI カスタマイズ。テーマカタログの拡張、メニューの挿入、ウィンドウ再構成の通知を一括で扱えます。【F:Application/IModule.cs†L241-L330】【F:UI/MainForm.cs†L115-L219】
+- モジュール間連携を可能にする `OnPeerModule...` ハンドラー群。`ModulePeerNotificationContext<T>` を受け取り、他モジュールが DI 登録・サービスプロバイダー構築・メインウィンドウ操作・設定読み書き・アプリ終了・例外通知など各フェーズに入ったタイミングを監視できます。診断ログの追加や順序制御など、複数モジュールを跨いだ拡張に活用できます。【F:Application/IModule.cs†L128-L240】【F:Application/IModule.cs†L434-L455】
+
+これらのメソッドはすべて任意実装であり、特定のフェーズだけをターゲットにした拡張も可能です。既存の `AfkJumpModule` のように未使用のメソッドは空実装としておくこともできます。【F:Modules/AfkJumpModule/AfkJumpModule.cs†L12-L165】
+
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
 using ToNRoundCounter.Application;
@@ -39,13 +55,23 @@ namespace ToNRoundCounter.Modules.Sample
 ```
 
 - 依存関係の解決やロギングのために、アプリ本体のサービス (`IEventLogger` や `IEventBus` など) をコンストラクターインジェクションで受け取ることができます。
-- `IModule` 実装クラスはパラメーター無しのコンストラクターを持っている必要があります。`ModuleLoader` は `Activator.CreateInstance` を使用してモジュールを生成するためです。【F:Infrastructure/ModuleLoader.cs†L15-L36】
+- `IModule` 実装クラスはパラメーター無しのコンストラクターを持っている必要があります。`ModuleLoader` は `Activator.CreateInstance` を使用してモジュールを生成するためです。【F:Infrastructure/ModuleLoader.cs†L15-L40】
 
 ## モジュールの読み込み仕組み
-`Program` 起動時に `ModuleLoader.LoadModules` が呼び出され、`Modules` フォルダー内の DLL を列挙して `IModule` 実装を探索します。【F:Program.cs†L61-L69】【F:Infrastructure/ModuleLoader.cs†L15-L36】
+`Program` 起動時に `ModuleLoader.LoadModules` が呼び出され、`Modules` フォルダー内の DLL を列挙して `IModule` 実装を探索します。【F:Program.cs†L43-L112】【F:Infrastructure/ModuleLoader.cs†L13-L47】
 
 - DLL 名に制限はありませんが、`IModule` を実装した型を公開し、`public` である必要があります。
-- 読み込みに失敗した場合は `ModuleLoadFailed` イベントが発行され、ログにもエラーが出力されます。【F:Infrastructure/ModuleLoader.cs†L32-L36】
+- 読み込みに失敗した場合は `ModuleLoadFailed` イベントが発行され、ログにもエラーが出力されます。【F:Infrastructure/ModuleLoader.cs†L35-L40】
+
+読み込み・初期化に関する詳細なイベントは `ModuleHost` が管理します。`ModuleHost` は `IEventBus` と連携して各フェーズの開始・完了イベント (`ModuleDiscoveryStarted`, `ModuleServicesRegistering`, `ServiceProviderBuilt`, `MainWindowShown` など) を発行し、モジュールや他サービスが購読できるようになっています。WebSocket/OSC の接続状態や設定バリデーション、オート自殺・自動起動・メインウィンドウのテーマ更新といったコア機能についても同様に通知されるため、ほぼすべての重要なアプリ内イベントをモジュールから観測・拡張できます。【F:Infrastructure/ModuleHost.cs†L1-L625】【F:Application/Events.cs†L7-L39】
+
+### コア機能のカスタマイズ例
+
+- **オート自殺の柔軟化**: `ModuleAutoSuicideRuleContext.Rules` は `List<AutoSuicideRule>` として公開されており、ルールの追加・削除や並び替えが可能です。`ModuleAutoSuicideDecisionContext.OverrideDecision` を呼び出すことで判定結果や遅延フラグを上書きできます。【F:Application/IModule.cs†L209-L243】【F:UI/MainForm.cs†L1548-L1587】
+- **自動起動の差し替え**: `ModuleAutoLaunchEvaluationContext.Plans` に対して `AutoLaunchPlan` を追加すれば、設定ファイルに書かれていない実行ファイルも起動対象に含められます。`OnAutoLaunchFailed` でエラーを検知し、リトライや代替起動を実装することもできます。【F:Application/IModule.cs†L249-L263】【F:Program.cs†L134-L186】【F:Infrastructure/ModuleHost.cs†L222-L332】
+- **UI テーマ・レイアウト・メニューの調整**: `OnThemeCatalogBuilding` で `Theme.RegisterTheme` を呼び出すと、ライト／ダーク以外のテーマをカタログへ追加できます。`OnMainWindowMenuBuilding` と `OnMainWindowUiComposed` はメニューやメインフォーム上のコントロールを並べ替えたり追加するための拡張ポイントです。テーマ変更時には `OnMainWindowThemeChanged` がテーマキーと `ThemeDescriptor` を渡すため、カスタムテーマに合わせた描画を行えます。【F:Application/IModule.cs†L241-L330】【F:UI/MainForm.cs†L115-L219】
+- **設定ビューの拡張**: `OnSettingsViewBuilding` で `ModuleSettingsViewBuildContext.AddSettingsGroup` や `AddExtensionControl` を利用すると、モジュール専用のグループボックスや任意のコントロールを `SettingsPanel` 上に動的追加できます。`OnSettingsViewOpened`/`Applying`/`Closing`/`Closed` ではダイアログのライフサイクルを追跡しながら設定値の読み書きを実装できます。【F:Application/IModule.cs†L988-L1004】【F:UI/MainForm.cs†L372-L520】【F:UI/SettingsPanel.cs†L1225-L1330】
+- **補助ウィンドウの提供**: `OnAuxiliaryWindowCatalogBuilding` で `AuxiliaryWindowDescriptor` を登録すると、「ウィンドウ」メニューにモジュール独自のフォームを追加でき、`OnAuxiliaryWindowOpening`/`Opened`/`Closing`/`Closed` で表示状態を監視できます。【F:Application/IModule.cs†L282-L330】【F:Infrastructure/ModuleHost.cs†L200-L365】【F:UI/MainForm.cs†L115-L520】
 
 ## サービス登録のベストプラクティス
 - ライフタイム: ステートレスなサービスには `AddSingleton` を使用し、状態を持つサービスには `AddTransient` または `AddScoped` を検討してください (WinForms アプリであるためスコープは限定的です)。
@@ -60,9 +86,10 @@ namespace ToNRoundCounter.Modules.Sample
 ## 例: AFK ジャンプ モジュール
 `AfkJumpModule` は AFK 警告イベントをフックしてジャンプ入力を送信するサンプル モジュールです。以下のポイントが参考になります。
 
-- `IAfkWarningHandler` を `AddSingleton` で登録し、警告発生時の挙動をオーバーライドしています。【F:Modules/AfkJumpModule/AfkJumpModule.cs†L14-L51】
-- `Rug.Osc` を用いて `/input/Jump` への OSC メッセージを送信し、モジュール独自のアクションを実行しています。【F:Modules/AfkJumpModule/AfkJumpModule.cs†L33-L47】
-- 処理中の例外は `IEventLogger` を通じてログ出力し、ユーザーに診断しやすい情報を提供しています。【F:Modules/AfkJumpModule/AfkJumpModule.cs†L31-L50】
+- `IAfkWarningHandler` を `AddSingleton` で登録し、警告発生時の挙動をオーバーライドしています。【F:Modules/AfkJumpModule/AfkJumpModule.cs†L23-L26】
+- `Rug.Osc` を用いて `/input/Jump` への OSC メッセージを送信し、モジュール独自のアクションを実行しています。【F:Modules/AfkJumpModule/AfkJumpModule.cs†L189-L205】
+- 設定ビュー拡張フックでは `AddSettingsGroup` を使って案内ラベルを追加する実装例を含み、モジュール固有の UI 要素を差し込む方法を示しています。【F:Modules/AfkJumpModule/AfkJumpModule.cs†L72-L86】
+- 処理中の例外は `IEventLogger` を通じてログ出力し、ユーザーに診断しやすい情報を提供しています。【F:Modules/AfkJumpModule/AfkJumpModule.cs†L197-L205】
 
 このモジュールをテンプレートとして、独自機能を実装したクラスと DI 登録を組み合わせることで簡単に拡張機能を追加できます。
 


### PR DESCRIPTION
## Summary
- expand `IModule` with WebSocket/OSC, settings validation, auto-suicide, auto-launch, and UI layout hooks along with the supporting context types and ModuleHost notifications
- publish detailed runtime events from the WebSocket client, OSC listener, app settings pipeline, auto-suicide service, program auto-launch flow, and main window so modules can override hard-coded behaviour
- document the new extension points and show how modules can customize auto-suicide rules, auto-launch plans, and main window styling
- add helper APIs for module settings UI composition and update the sample module/documentation to demonstrate the workflow

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5de51f34c83298bb8a2be8f3dfe3a