### PR TITLE
Add detailed diagnostics logging

### DIFF
--- a/Application/StateService.cs
+++ b/Application/StateService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Serilog.Events;
 using ToNRoundCounter.Domain;
 
 namespace ToNRoundCounter.Application
@@ -9,6 +10,7 @@ namespace ToNRoundCounter.Application
         public event Action StateChanged;
 
         private readonly object _sync = new object();
+        private readonly IEventLogger? _logger;
 
         public string PlayerDisplayName { get; set; } = string.Empty;
         public Round CurrentRound { get; private set; }
@@ -20,44 +22,82 @@ namespace ToNRoundCounter.Application
         private readonly Dictionary<string, object> _stats = new();
         public int RoundCycle { get; private set; } = 0;
 
+        public StateService(IEventLogger? logger = null)
+        {
+            _logger = logger;
+            _logger?.LogEvent("StateService", "State service instantiated.", LogEventLevel.Debug);
+        }
+
+        private void NotifyStateChanged(string reason)
+        {
+            var handlers = StateChanged;
+            if (handlers == null)
+            {
+                _logger?.LogEvent("StateService", $"State change '{reason}' occurred but no subscribers were registered.", LogEventLevel.Debug);
+                return;
+            }
+
+            var subscriberCount = handlers.GetInvocationList().Length;
+            _logger?.LogEvent("StateService", $"Notifying {subscriberCount} subscriber(s) of state change '{reason}'.", LogEventLevel.Debug);
+            handlers.Invoke();
+            _logger?.LogEvent("StateService", $"State change '{reason}' notifications completed.", LogEventLevel.Debug);
+        }
+
+        private static string DescribeRound(Round? round)
+        {
+            if (round == null)
+            {
+                return "<null>";
+            }
+
+            return $"{round.RoundType ?? "<unknown>"} (Terror: {round.TerrorKey ?? "<none>"}, Map: {round.MapName ?? "<none>"})";
+        }
+
         public void UpdateCurrentRound(Round round)
         {
+            _logger?.LogEvent("StateService", $"Updating current round to {DescribeRound(round)}.");
             lock (_sync)
             {
                 CurrentRound = round;
             }
-            StateChanged?.Invoke();
+            NotifyStateChanged(nameof(UpdateCurrentRound));
         }
 
         public void AddRoundLog(Round round, string logEntry)
         {
+            _logger?.LogEvent("StateService", $"Appending round log entry for {DescribeRound(round)}: {logEntry}");
             lock (_sync)
             {
                 _roundLogHistory.Add(new Tuple<Round, string>(round, logEntry));
             }
-            StateChanged?.Invoke();
+            NotifyStateChanged(nameof(AddRoundLog));
         }
 
         public void IncrementRoundCycle()
         {
+            int updatedValue;
             lock (_sync)
             {
                 RoundCycle++;
+                updatedValue = RoundCycle;
             }
-            StateChanged?.Invoke();
+            _logger?.LogEvent("StateService", $"Round cycle incremented to {updatedValue}.");
+            NotifyStateChanged(nameof(IncrementRoundCycle));
         }
 
         public void SetRoundCycle(int value)
         {
+            _logger?.LogEvent("StateService", $"Setting round cycle to {value}.");
             lock (_sync)
             {
                 RoundCycle = value;
             }
-            StateChanged?.Invoke();
+            NotifyStateChanged(nameof(SetRoundCycle));
         }
 
         public void RecordRoundResult(string roundType, string terrorType, bool survived)
         {
+            _logger?.LogEvent("StateService", $"Recording round result. Round: {roundType}, Terror: {terrorType ?? "<none>"}, Survived: {survived}");
             lock (_sync)
             {
                 if (!_roundAggregates.TryGetValue(roundType, out var roundAgg))
@@ -76,20 +116,22 @@ namespace ToNRoundCounter.Application
                 }
             }
 
-            StateChanged?.Invoke();
+            NotifyStateChanged(nameof(RecordRoundResult));
         }
 
         public void UpdateStat(string name, object value)
         {
+            _logger?.LogEvent("StateService", $"Updating stat '{name}' to value '{value}'.", LogEventLevel.Debug);
             lock (_sync)
             {
                 _stats[name] = value;
             }
-            StateChanged?.Invoke();
+            NotifyStateChanged(nameof(UpdateStat));
         }
 
         public void Reset()
         {
+            _logger?.LogEvent("StateService", "Resetting state service to defaults.");
             lock (_sync)
             {
                 CurrentRound = null;
@@ -102,71 +144,88 @@ namespace ToNRoundCounter.Application
                 _stats.Clear();
             }
 
-            StateChanged?.Invoke();
+            NotifyStateChanged(nameof(Reset));
         }
 
         public IReadOnlyDictionary<string, RoundAggregate> GetRoundAggregates()
         {
+            Dictionary<string, RoundAggregate> snapshot;
             lock (_sync)
             {
-                return new Dictionary<string, RoundAggregate>(_roundAggregates);
+                snapshot = new Dictionary<string, RoundAggregate>(_roundAggregates);
             }
+            _logger?.LogEvent("StateService", $"Providing round aggregates snapshot with {snapshot.Count} entries.", LogEventLevel.Debug);
+            return snapshot;
         }
 
         public bool TryGetTerrorAggregates(string round, out Dictionary<string, TerrorAggregate> terrorDict)
         {
+            _logger?.LogEvent("StateService", $"Retrieving terror aggregates for round '{round}'.", LogEventLevel.Debug);
             lock (_sync)
             {
                 if (_terrorAggregates.TryGetRound(round, out var dict))
                 {
                     terrorDict = new Dictionary<string, TerrorAggregate>(dict);
+                    _logger?.LogEvent("StateService", $"Terror aggregates retrieval succeeded for round '{round}' with {terrorDict.Count} entries.", LogEventLevel.Debug);
                     return true;
                 }
                 terrorDict = null;
+                _logger?.LogEvent("StateService", $"Terror aggregates retrieval failed for round '{round}'.", LogEventLevel.Debug);
                 return false;
             }
         }
 
         public IReadOnlyDictionary<string, string> GetRoundMapNames()
         {
+            Dictionary<string, string> snapshot;
             lock (_sync)
             {
-                return new Dictionary<string, string>(_roundMapNames);
+                snapshot = new Dictionary<string, string>(_roundMapNames);
             }
+            _logger?.LogEvent("StateService", $"Providing round map names snapshot with {snapshot.Count} entries.", LogEventLevel.Debug);
+            return snapshot;
         }
 
         public void SetRoundMapName(string roundType, string mapName)
         {
+            _logger?.LogEvent("StateService", $"Associating map '{mapName}' with round '{roundType}'.");
             lock (_sync)
             {
                 _roundMapNames[roundType] = mapName;
             }
-            StateChanged?.Invoke();
+            NotifyStateChanged(nameof(SetRoundMapName));
         }
 
         public void SetTerrorMapName(string round, string terror, string mapName)
         {
+            _logger?.LogEvent("StateService", $"Associating terror map '{mapName}' with round '{round}' / terror '{terror}'.");
             lock (_sync)
             {
                 _terrorMapNames.Set(round, terror, mapName);
             }
-            StateChanged?.Invoke();
+            NotifyStateChanged(nameof(SetTerrorMapName));
         }
 
         public IReadOnlyList<Tuple<Round, string>> GetRoundLogHistory()
         {
+            Tuple<Round, string>[] snapshot;
             lock (_sync)
             {
-                return _roundLogHistory.ToArray();
+                snapshot = _roundLogHistory.ToArray();
             }
+            _logger?.LogEvent("StateService", $"Providing round log history snapshot with {snapshot.Length} entries.", LogEventLevel.Debug);
+            return snapshot;
         }
 
         public IReadOnlyDictionary<string, object> GetStats()
         {
+            Dictionary<string, object> snapshot;
             lock (_sync)
             {
-                return new Dictionary<string, object>(_stats);
+                snapshot = new Dictionary<string, object>(_stats);
             }
+            _logger?.LogEvent("StateService", $"Providing statistics snapshot with {snapshot.Count} entries.", LogEventLevel.Debug);
+            return snapshot;
         }
     }
 }

--- a/UI/MainForm.Sound.cs
+++ b/UI/MainForm.Sound.cs
@@ -32,6 +32,7 @@ namespace ToNRoundCounter.UI
 
         private void InitializeSoundPlayers()
         {
+            LogUi("Initializing media players for notifications.", LogEventLevel.Debug);
             notifyPlayer.Stop();
             afkPlayer.Stop();
             punishPlayer.Stop();
@@ -47,6 +48,7 @@ namespace ToNRoundCounter.UI
         {
             if (!_settings.ItemMusicEnabled || entry == null || !entry.Enabled)
             {
+                LogUi("Item music playback skipped due to settings or entry state.", LogEventLevel.Debug);
                 return;
             }
 
@@ -57,6 +59,7 @@ namespace ToNRoundCounter.UI
                 itemMusicLoopRequested = true;
                 itemMusicActive = true;
                 PlayFromStart(itemMusicPlayer);
+                LogUi($"Item music started for '{entry.DisplayName}'.");
             }
         }
 
@@ -65,10 +68,12 @@ namespace ToNRoundCounter.UI
             itemMusicLoopRequested = false;
             itemMusicActive = false;
             itemMusicPlayer?.Stop();
+            LogUi("Item music playback stopped.", LogEventLevel.Debug);
         }
 
         private void ResetItemMusicTracking()
         {
+            LogUi("Resetting item music tracking state.", LogEventLevel.Debug);
             itemMusicMatchStart = DateTime.MinValue;
             itemMusicLoopRequested = false;
             if (itemMusicActive)
@@ -81,6 +86,7 @@ namespace ToNRoundCounter.UI
         {
             if (!_settings.ItemMusicEnabled || entry == null || !entry.Enabled)
             {
+                LogUi("EnsureItemMusicPlayer skipped due to configuration.", LogEventLevel.Debug);
                 return;
             }
 
@@ -91,6 +97,7 @@ namespace ToNRoundCounter.UI
 
             if (needsReload)
             {
+                LogUi("Reloading item music player due to configuration change.", LogEventLevel.Debug);
                 UpdateItemMusicPlayer(entry);
             }
         }
@@ -103,6 +110,7 @@ namespace ToNRoundCounter.UI
 
                 if (!_settings.ItemMusicEnabled)
                 {
+                    LogUi("Item music disabled. Skipping player update.", LogEventLevel.Debug);
                     return;
                 }
 
@@ -110,12 +118,14 @@ namespace ToNRoundCounter.UI
 
                 if (entry == null || !entry.Enabled)
                 {
+                    LogUi("No active item music entry. Player not updated.", LogEventLevel.Debug);
                     return;
                 }
 
                 string configuredPath = entry.SoundPath ?? string.Empty;
                 if (string.IsNullOrWhiteSpace(configuredPath))
                 {
+                    LogUi("Item music entry has no configured path.", LogEventLevel.Warning);
                     return;
                 }
 
@@ -123,6 +133,7 @@ namespace ToNRoundCounter.UI
                 if (!File.Exists(fullPath))
                 {
                     _logger.LogEvent("ItemMusic", $"Sound file not found: {fullPath}", LogEventLevel.Warning);
+                    LogUi($"Configured item music file not found: {fullPath}.", LogEventLevel.Warning);
                     return;
                 }
 
@@ -132,10 +143,12 @@ namespace ToNRoundCounter.UI
                 itemMusicPlayer.MediaFailed += ItemMusicPlayer_MediaFailed;
                 lastLoadedItemMusicPath = fullPath;
                 _logger.LogEvent("ItemMusic", $"Loaded sound file: {fullPath}");
+                LogUi($"Item music player loaded file '{fullPath}'.", LogEventLevel.Debug);
             }
             catch (Exception ex)
             {
                 _logger.LogEvent("ItemMusic", ex.ToString(), LogEventLevel.Error);
+                LogUi($"Failed to update item music player: {ex.Message}", LogEventLevel.Error);
             }
         }
 
@@ -156,6 +169,7 @@ namespace ToNRoundCounter.UI
                 finally
                 {
                     itemMusicPlayer = null;
+                    LogUi("Item music player disposed.", LogEventLevel.Debug);
                 }
             }
 
@@ -169,6 +183,7 @@ namespace ToNRoundCounter.UI
         {
             if (itemMusicLoopRequested && itemMusicPlayer != null)
             {
+                LogUi("Item music track ended. Loop restart requested.", LogEventLevel.Debug);
                 PlayFromStart(itemMusicPlayer);
             }
         }
@@ -176,6 +191,7 @@ namespace ToNRoundCounter.UI
         private void ItemMusicPlayer_MediaFailed(object sender, ExceptionEventArgs e)
         {
             _logger.LogEvent("ItemMusic", $"Failed to play sound: {e.ErrorException?.Message}", LogEventLevel.Error);
+            LogUi($"Item music playback failure: {e.ErrorException?.Message}", LogEventLevel.Error);
             StopItemMusic();
         }
     }

--- a/UI/MainForm.WebSocket.cs
+++ b/UI/MainForm.WebSocket.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Rug.Osc;
+using Serilog.Events;
 
 namespace ToNRoundCounter.UI
 {
@@ -24,13 +25,16 @@ namespace ToNRoundCounter.UI
             instanceWsConnection = new ClientWebSocket();
             try
             {
+                LogUi($"Connecting to shared instance stream at {url}.");
                 await instanceWsConnection.ConnectAsync(new Uri(url), _cancellation.Token);
+                LogUi("Instance WebSocket connection established.", LogEventLevel.Debug);
                 while (instanceWsConnection.State == WebSocketState.Open)
                 {
                     var buffer = new byte[8192];
                     WebSocketReceiveResult result = await instanceWsConnection.ReceiveAsync(new ArraySegment<byte>(buffer), _cancellation.Token);
                     if (result.MessageType == WebSocketMessageType.Close)
                     {
+                        LogUi("Instance WebSocket close frame received. Closing connection.", LogEventLevel.Debug);
                         await instanceWsConnection.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", _cancellation.Token);
                         break;
                     }
@@ -44,12 +48,14 @@ namespace ToNRoundCounter.UI
                             messageBytes.AddRange(buffer.Take(result.Count));
                         }
                         string msg = Encoding.UTF8.GetString(messageBytes.ToArray());
+                        LogUi($"Instance WebSocket message received ({msg.Length} chars).", LogEventLevel.Debug);
                         ProcessInstanceMessage(msg);
                     }
                 }
             }
             catch (Exception ex)
             {
+                LogUi($"Instance WebSocket connection failed: {ex.Message}", LogEventLevel.Error);
                 _logger.LogEvent("InstanceError", ex.ToString(), Serilog.Events.LogEventLevel.Error);
             }
             finally
@@ -59,6 +65,7 @@ namespace ToNRoundCounter.UI
                     try { await instanceWsConnection.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", _cancellation.Token); } catch { }
                     instanceWsConnection.Dispose();
                     instanceWsConnection = null;
+                    LogUi("Instance WebSocket connection disposed. Scheduling reconnect.", LogEventLevel.Warning);
                     await Task.Delay(300);
                     _ = Task.Run(() => ConnectToInstance(instanceValue));
                 }
@@ -71,6 +78,7 @@ namespace ToNRoundCounter.UI
             {
                 var json = JObject.Parse(message);
                 string type = json.Value<string>("type") ?? "";
+                LogUi($"Processing instance message of type '{type}'.", LogEventLevel.Debug);
                 _logger.LogEvent("ReceivedWSType", type);
                 if (type == "JoinedMember" || type == "LeavedMember")
                 {
@@ -82,6 +90,7 @@ namespace ToNRoundCounter.UI
                 }
                 else if (type == "alertIncoming")
                 {
+                    LogUi("Instance alert incoming event received.");
                     using (var sender = new OscSender(IPAddress.Parse("127.0.0.1"), 9000))
                     {
                         _logger.LogEvent("alertIncoming", "start process");
@@ -100,12 +109,14 @@ namespace ToNRoundCounter.UI
             }
             catch (Exception ex)
             {
+                LogUi($"Failed to process instance message: {ex.Message}", LogEventLevel.Error);
                 _logger.LogEvent("InstanceProcessError", ex.ToString(), Serilog.Events.LogEventLevel.Error);
             }
         }
 
         private async Task SendAlertOscMessagesAsync(float alertNum, bool isLocal = true)
         {
+            LogUi($"Sending OSC alert sequence (Value: {alertNum}, Local: {isLocal}).", LogEventLevel.Debug);
             await sendAlertSemaphore.WaitAsync();
             try
             {
@@ -138,12 +149,14 @@ namespace ToNRoundCounter.UI
             }
             finally
             {
+                LogUi("OSC alert sequence completed.", LogEventLevel.Debug);
                 sendAlertSemaphore.Release();
             }
         }
 
         private async Task disableAutoFollofSelfKillOscMessagesAsync()
         {
+            LogUi("Disabling follow auto self kill via OSC.", LogEventLevel.Debug);
             await sendAlertSemaphore.WaitAsync();
             try
             {
@@ -160,12 +173,14 @@ namespace ToNRoundCounter.UI
             }
             finally
             {
+                LogUi("Follow auto self kill disable sequence completed.", LogEventLevel.Debug);
                 sendAlertSemaphore.Release();
             }
         }
 
         private async Task SendPieSizeOscMessagesAsync(float piesizetNum, bool isLocal = true)
         {
+            LogUi($"Sending pie size OSC sequence (Value: {piesizetNum}, Local: {isLocal}).", LogEventLevel.Debug);
             await sendAlertSemaphore.WaitAsync();
             try
             {
@@ -187,6 +202,7 @@ namespace ToNRoundCounter.UI
             }
             finally
             {
+                LogUi("Pie size OSC sequence completed.", LogEventLevel.Debug);
                 sendAlertSemaphore.Release();
             }
         }
@@ -195,6 +211,7 @@ namespace ToNRoundCounter.UI
         {
             if (instanceWsConnection != null && instanceWsConnection.State == WebSocketState.Open)
             {
+                LogUi($"Forwarding alert value {alertNum} to TonSprink backend.", LogEventLevel.Debug);
                 var jsonMessage = new JObject
                 {
                     ["type"] = "Alert",
@@ -206,6 +223,7 @@ namespace ToNRoundCounter.UI
             }
             else
             {
+                LogUi("Unable to forward alert to TonSprink because instance connection is unavailable.", LogEventLevel.Warning);
                 _logger.LogEvent("AlertSendError", "Instance WebSocket connection is not available.");
             }
         }


### PR DESCRIPTION
## Summary
- add debug-level instrumentation throughout `StateService` to log state transitions and snapshot access
- extend the main form partial classes to emit detailed lifecycle, OSC, WebSocket, and media playback diagnostics via the centralized UI logger

## Testing
- dotnet test *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d61f7145f4832981b5898905a6a75a