### PR TITLE
Add modules to suppress AFK warning audio and disable OSC repeater

### DIFF
--- a/Application/IAppSettings.cs
+++ b/Application/IAppSettings.cs
@@ -46,6 +46,7 @@ namespace ToNRoundCounter.Application
         double ItemMusicMaxSpeed { get; set; }
         string DiscordWebhookUrl { get; set; }
         string LastSaveCode { get; set; }
+        bool AfkSoundCancelEnabled { get; set; }
         void Load();
         Task SaveAsync();
     }

--- a/Application/IOscRepeaterPolicy.cs
+++ b/Application/IOscRepeaterPolicy.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace ToNRoundCounter.Application
+{
+    /// <summary>
+    /// Provides a policy that can allow or prevent OSC repeater startup.
+    /// </summary>
+    public interface IOscRepeaterPolicy
+    {
+        /// <summary>
+        /// Determines whether the OSC repeater should be started.
+        /// </summary>
+        /// <param name="settings">The current application settings.</param>
+        /// <returns><c>true</c> to allow startup; otherwise <c>false</c>.</returns>
+        bool ShouldStartOscRepeater(IAppSettings settings);
+    }
+}

--- a/Infrastructure/AppSettings.cs
+++ b/Infrastructure/AppSettings.cs
@@ -67,6 +67,7 @@ namespace ToNRoundCounter.Infrastructure
         public double ItemMusicMaxSpeed { get; set; }
         public string DiscordWebhookUrl { get; set; } = string.Empty;
         public string LastSaveCode { get; set; } = string.Empty;
+        public bool AfkSoundCancelEnabled { get; set; } = true;
 
         public void Load()
         {
@@ -313,7 +314,8 @@ namespace ToNRoundCounter.Infrastructure
                 ItemMusicEnabled = ItemMusicEnabled,
                 ItemMusicEntries = ItemMusicEntries,
                 DiscordWebhookUrl = DiscordWebhookUrl,
-                LastSaveCode = LastSaveCode
+                LastSaveCode = LastSaveCode,
+                AfkSoundCancelEnabled = AfkSoundCancelEnabled
             };
 
             string json = JsonConvert.SerializeObject(settings, Formatting.Indented);
@@ -377,5 +379,6 @@ namespace ToNRoundCounter.Infrastructure
         public List<ItemMusicEntry> ItemMusicEntries { get; set; } = new List<ItemMusicEntry>();
         public string DiscordWebhookUrl { get; set; } = string.Empty;
         public string LastSaveCode { get; set; } = string.Empty;
+        public bool AfkSoundCancelEnabled { get; set; } = true;
     }
 }

--- a/Modules/AfkSoundCancelModule/AfkSoundCancelModule.cs
+++ b/Modules/AfkSoundCancelModule/AfkSoundCancelModule.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog.Events;
+using ToNRoundCounter.Application;
+
+namespace ToNRoundCounter.Modules.AfkSoundCancel
+{
+    public sealed class AfkSoundCancelModule : IModule
+    {
+        private CheckBox? _enableCheckBox;
+
+        public void OnModuleLoaded(ModuleDiscoveryContext context)
+        {
+        }
+
+        public void OnBeforeServiceRegistration(ModuleServiceRegistrationContext context)
+        {
+        }
+
+        public void RegisterServices(IServiceCollection services)
+        {
+            services.AddSingleton<IAfkWarningHandler, AfkSoundCancelHandler>();
+        }
+
+        public void OnAfterServiceRegistration(ModuleServiceRegistrationContext context)
+        {
+        }
+
+        public void OnBeforeServiceProviderBuild(ModuleServiceProviderBuildContext context)
+        {
+        }
+
+        public void OnAfterServiceProviderBuild(ModuleServiceProviderContext context)
+        {
+        }
+
+        public void OnBeforeMainWindowCreation(ModuleMainWindowCreationContext context)
+        {
+        }
+
+        public void OnAfterMainWindowCreation(ModuleMainWindowContext context)
+        {
+        }
+
+        public void OnMainWindowShown(ModuleMainWindowLifecycleContext context)
+        {
+        }
+
+        public void OnMainWindowClosing(ModuleMainWindowLifecycleContext context)
+        {
+        }
+
+        public void OnSettingsLoading(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsLoaded(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsSaving(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsSaved(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsViewBuilding(ModuleSettingsViewBuildContext context)
+        {
+            if (context == null)
+            {
+                return;
+            }
+
+            var group = context.AddSettingsGroup("AFK音キャンセル");
+            var checkbox = new CheckBox
+            {
+                AutoSize = true,
+                Text = "AFK警告音を再生しない",
+                Checked = context.Settings.AfkSoundCancelEnabled
+            };
+
+            group.Controls.Add(checkbox);
+            _enableCheckBox = checkbox;
+        }
+
+        public void OnSettingsViewOpened(ModuleSettingsViewLifecycleContext context)
+        {
+            if (context?.Settings == null || _enableCheckBox == null)
+            {
+                return;
+            }
+
+            _enableCheckBox.Checked = context.Settings.AfkSoundCancelEnabled;
+        }
+
+        public void OnSettingsViewApplying(ModuleSettingsViewLifecycleContext context)
+        {
+            if (context == null || context.Stage != ModuleSettingsViewStage.Applying)
+            {
+                return;
+            }
+
+            if (_enableCheckBox != null)
+            {
+                context.Settings.AfkSoundCancelEnabled = _enableCheckBox.Checked;
+            }
+        }
+
+        public void OnSettingsViewClosing(ModuleSettingsViewLifecycleContext context)
+        {
+        }
+
+        public void OnSettingsViewClosed(ModuleSettingsViewLifecycleContext context)
+        {
+            _enableCheckBox = null;
+        }
+
+        public void OnAppRunStarting(ModuleAppRunContext context)
+        {
+        }
+
+        public void OnAppRunCompleted(ModuleAppRunContext context)
+        {
+        }
+
+        public void OnBeforeAppShutdown(ModuleAppShutdownContext context)
+        {
+        }
+
+        public void OnAfterAppShutdown(ModuleAppShutdownContext context)
+        {
+        }
+
+        public void OnUnhandledException(ModuleExceptionContext context)
+        {
+        }
+
+        public void OnWebSocketConnecting(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketConnected(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketDisconnected(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketReconnecting(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketMessageReceived(ModuleWebSocketMessageContext context)
+        {
+        }
+
+        public void OnOscConnecting(ModuleOscConnectionContext context)
+        {
+        }
+
+        public void OnOscConnected(ModuleOscConnectionContext context)
+        {
+        }
+
+        public void OnOscDisconnected(ModuleOscConnectionContext context)
+        {
+        }
+
+        public void OnOscMessageReceived(ModuleOscMessageContext context)
+        {
+        }
+
+        public void OnBeforeSettingsValidation(ModuleSettingsValidationContext context)
+        {
+        }
+
+        public void OnSettingsValidated(ModuleSettingsValidationContext context)
+        {
+        }
+
+        public void OnSettingsValidationFailed(ModuleSettingsValidationContext context)
+        {
+        }
+
+        public void OnAutoSuicideRulesPrepared(ModuleAutoSuicideRuleContext context)
+        {
+        }
+
+        public void OnAutoSuicideDecisionEvaluated(ModuleAutoSuicideDecisionContext context)
+        {
+        }
+
+        public void OnAutoSuicideScheduled(ModuleAutoSuicideScheduleContext context)
+        {
+        }
+
+        public void OnAutoSuicideCancelled(ModuleAutoSuicideScheduleContext context)
+        {
+        }
+
+        public void OnAutoSuicideTriggered(ModuleAutoSuicideTriggerContext context)
+        {
+        }
+
+        public void OnAutoLaunchEvaluating(ModuleAutoLaunchEvaluationContext context)
+        {
+        }
+
+        public void OnAutoLaunchStarting(ModuleAutoLaunchExecutionContext context)
+        {
+        }
+
+        public void OnAutoLaunchFailed(ModuleAutoLaunchFailureContext context)
+        {
+        }
+
+        public void OnAutoLaunchCompleted(ModuleAutoLaunchExecutionContext context)
+        {
+        }
+
+        public void OnThemeCatalogBuilding(ModuleThemeCatalogContext context)
+        {
+        }
+
+        public void OnMainWindowMenuBuilding(ModuleMainWindowMenuContext context)
+        {
+        }
+
+        public void OnMainWindowUiComposed(ModuleMainWindowUiContext context)
+        {
+        }
+
+        public void OnMainWindowThemeChanged(ModuleMainWindowThemeContext context)
+        {
+        }
+
+        public void OnMainWindowLayoutUpdated(ModuleMainWindowLayoutContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowCatalogBuilding(ModuleAuxiliaryWindowCatalogContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowOpening(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowOpened(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowClosing(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowClosed(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnPeerModuleLoaded(ModulePeerNotificationContext<ModuleDiscoveryContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeServiceRegistration(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context)
+        {
+        }
+
+        public void OnPeerModuleRegisteringServices(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterServiceRegistration(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeServiceProviderBuild(ModulePeerNotificationContext<ModuleServiceProviderBuildContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterServiceProviderBuild(ModulePeerNotificationContext<ModuleServiceProviderContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeMainWindowCreation(ModulePeerNotificationContext<ModuleMainWindowCreationContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterMainWindowCreation(ModulePeerNotificationContext<ModuleMainWindowContext> context)
+        {
+        }
+
+        public void OnPeerModuleMainWindowShown(ModulePeerNotificationContext<ModuleMainWindowLifecycleContext> context)
+        {
+        }
+
+        public void OnPeerModuleMainWindowClosing(ModulePeerNotificationContext<ModuleMainWindowLifecycleContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsLoading(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsLoaded(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsSaving(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsSaved(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleAppRunStarting(ModulePeerNotificationContext<ModuleAppRunContext> context)
+        {
+        }
+
+        public void OnPeerModuleAppRunCompleted(ModulePeerNotificationContext<ModuleAppRunContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeAppShutdown(ModulePeerNotificationContext<ModuleAppShutdownContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterAppShutdown(ModulePeerNotificationContext<ModuleAppShutdownContext> context)
+        {
+        }
+
+        public void OnPeerModuleUnhandledException(ModulePeerNotificationContext<ModuleExceptionContext> context)
+        {
+        }
+    }
+
+    internal sealed class AfkSoundCancelHandler : IAfkWarningHandler
+    {
+        private readonly IAppSettings _settings;
+        private readonly IEventLogger _logger;
+
+        public AfkSoundCancelHandler(IAppSettings settings, IEventLogger logger)
+        {
+            _settings = settings;
+            _logger = logger;
+        }
+
+        public Task<bool> HandleAsync(AfkWarningContext context, CancellationToken cancellationToken)
+        {
+            if (!_settings.AfkSoundCancelEnabled)
+            {
+                return Task.FromResult(false);
+            }
+
+            var idleSeconds = context?.IdleSeconds ?? 0d;
+            _logger.LogEvent("AfkSoundCancel", $"AFK sound suppressed at {idleSeconds:F1} seconds.", LogEventLevel.Information);
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/Modules/AfkSoundCancelModule/AfkSoundCancelModule.csproj
+++ b/Modules/AfkSoundCancelModule/AfkSoundCancelModule.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)..\..\</SolutionDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ToNRoundCounter.csproj" />
+    <Reference Include="Rug.Osc">
+      <HintPath>..\..\packages\Rug.Osc.1.2.5\lib\Rug.Osc.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+  </ItemGroup>
+
+  <Target Name="CopyModuleToOutput" AfterTargets="Build">
+    <MakeDir Directories="$(SolutionDir)Modules" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)Modules" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/Modules/OscRepeaterDisablerModule/OscRepeaterDisablerModule.cs
+++ b/Modules/OscRepeaterDisablerModule/OscRepeaterDisablerModule.cs
@@ -1,0 +1,345 @@
+using System.Windows.Forms;
+using Microsoft.Extensions.DependencyInjection;
+using ToNRoundCounter.Application;
+
+namespace ToNRoundCounter.Modules.OscRepeaterDisabler
+{
+    public sealed class OscRepeaterDisablerModule : IModule
+    {
+        public void OnModuleLoaded(ModuleDiscoveryContext context)
+        {
+        }
+
+        public void OnBeforeServiceRegistration(ModuleServiceRegistrationContext context)
+        {
+        }
+
+        public void RegisterServices(IServiceCollection services)
+        {
+            services.AddSingleton<IOscRepeaterPolicy, OscRepeaterDisablePolicy>();
+        }
+
+        public void OnAfterServiceRegistration(ModuleServiceRegistrationContext context)
+        {
+        }
+
+        public void OnBeforeServiceProviderBuild(ModuleServiceProviderBuildContext context)
+        {
+        }
+
+        public void OnAfterServiceProviderBuild(ModuleServiceProviderContext context)
+        {
+        }
+
+        public void OnBeforeMainWindowCreation(ModuleMainWindowCreationContext context)
+        {
+        }
+
+        public void OnAfterMainWindowCreation(ModuleMainWindowContext context)
+        {
+        }
+
+        public void OnMainWindowShown(ModuleMainWindowLifecycleContext context)
+        {
+        }
+
+        public void OnMainWindowClosing(ModuleMainWindowLifecycleContext context)
+        {
+        }
+
+        public void OnSettingsLoading(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsLoaded(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsSaving(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsSaved(ModuleSettingsContext context)
+        {
+        }
+
+        public void OnSettingsViewBuilding(ModuleSettingsViewBuildContext context)
+        {
+            if (context == null)
+            {
+                return;
+            }
+
+            var group = context.AddSettingsGroup("OSCRepeater無効化");
+            var description = new Label
+            {
+                AutoSize = true,
+                Text = "OSCRepeater.exe を起動しません。OSCポートは未変更なら 9001 を使用します。"
+            };
+
+            group.Controls.Add(description);
+        }
+
+        public void OnSettingsViewOpened(ModuleSettingsViewLifecycleContext context)
+        {
+        }
+
+        public void OnSettingsViewApplying(ModuleSettingsViewLifecycleContext context)
+        {
+        }
+
+        public void OnSettingsViewClosing(ModuleSettingsViewLifecycleContext context)
+        {
+        }
+
+        public void OnSettingsViewClosed(ModuleSettingsViewLifecycleContext context)
+        {
+        }
+
+        public void OnAppRunStarting(ModuleAppRunContext context)
+        {
+        }
+
+        public void OnAppRunCompleted(ModuleAppRunContext context)
+        {
+        }
+
+        public void OnBeforeAppShutdown(ModuleAppShutdownContext context)
+        {
+        }
+
+        public void OnAfterAppShutdown(ModuleAppShutdownContext context)
+        {
+        }
+
+        public void OnUnhandledException(ModuleExceptionContext context)
+        {
+        }
+
+        public void OnWebSocketConnecting(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketConnected(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketDisconnected(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketReconnecting(ModuleWebSocketConnectionContext context)
+        {
+        }
+
+        public void OnWebSocketMessageReceived(ModuleWebSocketMessageContext context)
+        {
+        }
+
+        public void OnOscConnecting(ModuleOscConnectionContext context)
+        {
+        }
+
+        public void OnOscConnected(ModuleOscConnectionContext context)
+        {
+        }
+
+        public void OnOscDisconnected(ModuleOscConnectionContext context)
+        {
+        }
+
+        public void OnOscMessageReceived(ModuleOscMessageContext context)
+        {
+        }
+
+        public void OnBeforeSettingsValidation(ModuleSettingsValidationContext context)
+        {
+        }
+
+        public void OnSettingsValidated(ModuleSettingsValidationContext context)
+        {
+        }
+
+        public void OnSettingsValidationFailed(ModuleSettingsValidationContext context)
+        {
+        }
+
+        public void OnAutoSuicideRulesPrepared(ModuleAutoSuicideRuleContext context)
+        {
+        }
+
+        public void OnAutoSuicideDecisionEvaluated(ModuleAutoSuicideDecisionContext context)
+        {
+        }
+
+        public void OnAutoSuicideScheduled(ModuleAutoSuicideScheduleContext context)
+        {
+        }
+
+        public void OnAutoSuicideCancelled(ModuleAutoSuicideScheduleContext context)
+        {
+        }
+
+        public void OnAutoSuicideTriggered(ModuleAutoSuicideTriggerContext context)
+        {
+        }
+
+        public void OnAutoLaunchEvaluating(ModuleAutoLaunchEvaluationContext context)
+        {
+        }
+
+        public void OnAutoLaunchStarting(ModuleAutoLaunchExecutionContext context)
+        {
+        }
+
+        public void OnAutoLaunchFailed(ModuleAutoLaunchFailureContext context)
+        {
+        }
+
+        public void OnAutoLaunchCompleted(ModuleAutoLaunchExecutionContext context)
+        {
+        }
+
+        public void OnThemeCatalogBuilding(ModuleThemeCatalogContext context)
+        {
+        }
+
+        public void OnMainWindowMenuBuilding(ModuleMainWindowMenuContext context)
+        {
+        }
+
+        public void OnMainWindowUiComposed(ModuleMainWindowUiContext context)
+        {
+        }
+
+        public void OnMainWindowThemeChanged(ModuleMainWindowThemeContext context)
+        {
+        }
+
+        public void OnMainWindowLayoutUpdated(ModuleMainWindowLayoutContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowCatalogBuilding(ModuleAuxiliaryWindowCatalogContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowOpening(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowOpened(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowClosing(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnAuxiliaryWindowClosed(ModuleAuxiliaryWindowLifecycleContext context)
+        {
+        }
+
+        public void OnPeerModuleLoaded(ModulePeerNotificationContext<ModuleDiscoveryContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeServiceRegistration(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context)
+        {
+        }
+
+        public void OnPeerModuleRegisteringServices(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterServiceRegistration(ModulePeerNotificationContext<ModuleServiceRegistrationContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeServiceProviderBuild(ModulePeerNotificationContext<ModuleServiceProviderBuildContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterServiceProviderBuild(ModulePeerNotificationContext<ModuleServiceProviderContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeMainWindowCreation(ModulePeerNotificationContext<ModuleMainWindowCreationContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterMainWindowCreation(ModulePeerNotificationContext<ModuleMainWindowContext> context)
+        {
+        }
+
+        public void OnPeerModuleMainWindowShown(ModulePeerNotificationContext<ModuleMainWindowLifecycleContext> context)
+        {
+        }
+
+        public void OnPeerModuleMainWindowClosing(ModulePeerNotificationContext<ModuleMainWindowLifecycleContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsLoading(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsLoaded(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsSaving(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleSettingsSaved(ModulePeerNotificationContext<ModuleSettingsContext> context)
+        {
+        }
+
+        public void OnPeerModuleAppRunStarting(ModulePeerNotificationContext<ModuleAppRunContext> context)
+        {
+        }
+
+        public void OnPeerModuleAppRunCompleted(ModulePeerNotificationContext<ModuleAppRunContext> context)
+        {
+        }
+
+        public void OnPeerModuleBeforeAppShutdown(ModulePeerNotificationContext<ModuleAppShutdownContext> context)
+        {
+        }
+
+        public void OnPeerModuleAfterAppShutdown(ModulePeerNotificationContext<ModuleAppShutdownContext> context)
+        {
+        }
+
+        public void OnPeerModuleUnhandledException(ModulePeerNotificationContext<ModuleExceptionContext> context)
+        {
+        }
+    }
+
+    internal sealed class OscRepeaterDisablePolicy : IOscRepeaterPolicy
+    {
+        private readonly IEventLogger _logger;
+
+        public OscRepeaterDisablePolicy(IEventLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public bool ShouldStartOscRepeater(IAppSettings settings)
+        {
+            if (settings == null)
+            {
+                return false;
+            }
+
+            if (!settings.OSCPortChanged)
+            {
+                settings.OSCPort = 9001;
+            }
+
+            _logger.LogEvent("OscRepeaterDisabler", "Preventing OSC repeater startup.");
+            return false;
+        }
+    }
+}

--- a/Modules/OscRepeaterDisablerModule/OscRepeaterDisablerModule.csproj
+++ b/Modules/OscRepeaterDisablerModule/OscRepeaterDisablerModule.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)..\..\</SolutionDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ToNRoundCounter.csproj" />
+    <Reference Include="Rug.Osc">
+      <HintPath>..\..\packages\Rug.Osc.1.2.5\lib\Rug.Osc.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+  </ItemGroup>
+
+  <Target Name="CopyModuleToOutput" AfterTargets="Build">
+    <MakeDir Directories="$(SolutionDir)Modules" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)Modules" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/Program.cs
+++ b/Program.cs
@@ -86,6 +86,7 @@ namespace ToNRoundCounter
                 sp.GetRequiredService<IInputSender>(),
                 sp.GetRequiredService<IUiDispatcher>(),
                 sp.GetServices<IAfkWarningHandler>(),
+                sp.GetServices<IOscRepeaterPolicy>(),
                 sp.GetRequiredService<ModuleHost>()));
 
             eventLogger.LogEvent("Bootstrap", "Building service provider (pre-build notifications).");

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Application\IOSCListener.cs" />
     <Compile Include="Application\IAppSettings.cs" />
     <Compile Include="Application\IInputSender.cs" />
+    <Compile Include="Application\IOscRepeaterPolicy.cs" />
     <Compile Include="Application\IAfkWarningHandler.cs" />
     <Compile Include="Application\IErrorReporter.cs" />
     <Compile Include="Application\IUiDispatcher.cs" />

--- a/ToNRoundCounter.sln
+++ b/ToNRoundCounter.sln
@@ -11,6 +11,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToNRoundCounter.Tests", "To
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AfkJumpModule", "Modules\AfkJumpModule\AfkJumpModule.csproj", "{884DDD21-B2B5-465D-AE30-24A2CB1D6934}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AfkSoundCancelModule", "Modules\AfkSoundCancelModule\AfkSoundCancelModule.csproj", "{3855206C-05B3-4B1C-8122-D3A8FA790AC2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OscRepeaterDisablerModule", "Modules\OscRepeaterDisablerModule\OscRepeaterDisablerModule.csproj", "{FB5D658A-F2A8-43CC-BBF0-261DD49B34D6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,10 +52,26 @@ Global
 		{884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Debug|x64.Build.0 = Debug|Any CPU
 		{884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|Any CPU.Build.0 = Release|Any CPU
-		{884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|x64.ActiveCfg = Release|Any CPU
-		{884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|x64.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|Any CPU.Build.0 = Release|Any CPU
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|x64.ActiveCfg = Release|Any CPU
+                {884DDD21-B2B5-465D-AE30-24A2CB1D6934}.Release|x64.Build.0 = Release|Any CPU
+                {3855206C-05B3-4B1C-8122-D3A8FA790AC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3855206C-05B3-4B1C-8122-D3A8FA790AC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3855206C-05B3-4B1C-8122-D3A8FA790AC2}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {3855206C-05B3-4B1C-8122-D3A8FA790AC2}.Debug|x64.Build.0 = Debug|Any CPU
+                {3855206C-05B3-4B1C-8122-D3A8FA790AC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3855206C-05B3-4B1C-8122-D3A8FA790AC2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3855206C-05B3-4B1C-8122-D3A8FA790AC2}.Release|x64.ActiveCfg = Release|Any CPU
+                {3855206C-05B3-4B1C-8122-D3A8FA790AC2}.Release|x64.Build.0 = Release|Any CPU
+                {FB5D658A-F2A8-43CC-BBF0-261DD49B34D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {FB5D658A-F2A8-43CC-BBF0-261DD49B34D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {FB5D658A-F2A8-43CC-BBF0-261DD49B34D6}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {FB5D658A-F2A8-43CC-BBF0-261DD49B34D6}.Debug|x64.Build.0 = Debug|Any CPU
+                {FB5D658A-F2A8-43CC-BBF0-261DD49B34D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {FB5D658A-F2A8-43CC-BBF0-261DD49B34D6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {FB5D658A-F2A8-43CC-BBF0-261DD49B34D6}.Release|x64.ActiveCfg = Release|Any CPU
+                {FB5D658A-F2A8-43CC-BBF0-261DD49B34D6}.Release|x64.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add an IOscRepeaterPolicy hook and update MainForm so modules can veto OSC repeater startup
- add an AFK sound cancel setting plus module UI/handler to suppress AFK warning audio when enabled
- add an OSC repeater disabler module that always blocks the repeater and keeps the default port when unchanged

## Testing
- dotnet build ToNRoundCounter.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d622a724288329a16d21b34887048a