### PR TITLE
Avoid auto suicide simple rules when detail enabled

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1718,10 +1718,13 @@ namespace ToNRoundCounter.UI
         {
             autoSuicideRules = new List<AutoSuicideRule>();
             var lines = new List<string>();
-            foreach (var round in AllRoundTypes)
+            if (!_settings.AutoSuicideUseDetail)
             {
-                bool enabled = _settings.AutoSuicideRoundTypes.Contains(round);
-                lines.Add($"{round}::{(enabled ? 1 : 0)}");
+                foreach (var round in AllRoundTypes)
+                {
+                    bool enabled = _settings.AutoSuicideRoundTypes.Contains(round);
+                    lines.Add($"{round}::{(enabled ? 1 : 0)}");
+                }
             }
             if (_settings.AutoSuicideDetailCustom != null)
                 lines.AddRange(_settings.AutoSuicideDetailCustom);


### PR DESCRIPTION
## Summary
- avoid mixing the simple auto-suicide round configuration when detailed rules are enabled so that only the detailed rules are applied

## Testing
- Not Run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d629470e5883299957f90dbbef0dd5