### PR TITLE
Fix build errors after API changes

### DIFF
--- a/Infrastructure/ModuleHost.cs
+++ b/Infrastructure/ModuleHost.cs
@@ -381,7 +381,7 @@ namespace ToNRoundCounter.Infrastructure
 
         public void NotifyMainWindowCreating(ModuleMainWindowCreationContext context)
         {
-            LogHostEvent(nameof(NotifyMainWindowCreating), $"Creating main window '{context.MainWindowType.FullName}'.");
+            LogHostEvent(nameof(NotifyMainWindowCreating), $"Creating main window '{context.WindowType.FullName}'.");
             MainWindowCreating?.Invoke(this, context);
             _bus.Publish(new MainWindowCreating(context));
             foreach (var module in _modules)

--- a/UI/MainForm.Sound.cs
+++ b/UI/MainForm.Sound.cs
@@ -59,7 +59,8 @@ namespace ToNRoundCounter.UI
                 itemMusicLoopRequested = true;
                 itemMusicActive = true;
                 PlayFromStart(itemMusicPlayer);
-                LogUi($"Item music started for '{entry.DisplayName}'.");
+                var displayName = string.IsNullOrWhiteSpace(entry.ItemName) ? "Unknown Item" : entry.ItemName;
+                LogUi($"Item music started for '{displayName}'.");
             }
         }
 

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -241,6 +241,7 @@ namespace ToNRoundCounter.UI
             int margin = 10;
             int currentY = mainMenuStrip.Bottom + margin;
             int contentWidth = this.ClientSize.Width - 2 * margin;
+            bool useCustomPanelColors = string.Equals(_settings.ThemeKey, Theme.DefaultThemeKey, StringComparison.OrdinalIgnoreCase);
 
             // WebSocket接続状況
             lblStatus = new Label();
@@ -291,7 +292,7 @@ namespace ToNRoundCounter.UI
 
             // 情報表示パネル
             InfoPanel = new InfoPanel();
-            InfoPanel.BackColor = _settings.BackgroundColor_InfoPanel;
+            InfoPanel.BackColor = useCustomPanelColors ? _settings.BackgroundColor_InfoPanel : Theme.Current.PanelBackground;
             InfoPanel.Location = new Point(margin, currentY);
             InfoPanel.Width = contentWidth;
             this.Controls.Add(InfoPanel);


### PR DESCRIPTION
## Summary
- update the module host to use the renamed main window type property
- initialize theme-dependent flags before building the main form UI
- guard item music logging against missing item names instead of using the removed DisplayName property

## Testing
- dotnet build *(fails: command not found in CI runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d62e30f2888329b618ec6969320109