### PR TITLE
Fix nullable reference analysis warnings

### DIFF
--- a/Application/AutoSuicideService.cs
+++ b/Application/AutoSuicideService.cs
@@ -10,7 +10,7 @@ namespace ToNRoundCounter.Application
     public class AutoSuicideService
     {
         private readonly object _lock = new object();
-        private CancellationTokenSource _tokenSource;
+        private CancellationTokenSource? _tokenSource;
         private readonly IEventBus? _bus;
         private readonly IEventLogger? _logger;
         private DateTime? _scheduledAtUtc;
@@ -45,8 +45,8 @@ namespace ToNRoundCounter.Application
 
         public void Schedule(TimeSpan delay, bool resetStartTime, Action action)
         {
-            CancellationTokenSource oldCts;
-            CancellationTokenSource cts;
+            CancellationTokenSource? oldCts;
+            CancellationTokenSource? cts;
             lock (_lock)
             {
                 oldCts = _tokenSource;

--- a/Application/Events.cs
+++ b/Application/Events.cs
@@ -46,7 +46,7 @@ namespace ToNRoundCounter.Application
     public record AutoSuicideTriggered();
     public record AutoLaunchEvaluating(IReadOnlyList<AutoLaunchPlan> Plans, IAppSettings Settings);
     public record AutoLaunchStarting(AutoLaunchPlan Plan);
-    public record AutoLaunchFailed(AutoLaunchPlan Plan, Exception Exception);
+    public record AutoLaunchFailed(AutoLaunchPlan Plan, Exception? Exception);
     public record AutoLaunchCompleted(AutoLaunchPlan Plan);
     public record MainWindowThemeChanged(string ThemeKey, ThemeDescriptor Theme, Form Form);
     public record MainWindowLayoutUpdated(Form Form);

--- a/Application/MainPresenter.cs
+++ b/Application/MainPresenter.cs
@@ -18,7 +18,7 @@ namespace ToNRoundCounter.Application
         private readonly IAppSettings _settings;
         private readonly IEventLogger _logger;
         private readonly IHttpClient _httpClient;
-        private IMainView _view;
+        private IMainView? _view;
 
         public MainPresenter(StateService stateService, IAppSettings settings, IEventLogger logger, IHttpClient httpClient)
         {

--- a/Application/StateService.cs
+++ b/Application/StateService.cs
@@ -7,16 +7,16 @@ namespace ToNRoundCounter.Application
 {
     public class StateService
     {
-        public event Action StateChanged;
+        public event Action? StateChanged;
 
         private readonly object _sync = new object();
         private readonly IEventLogger? _logger;
 
         public string PlayerDisplayName { get; set; } = string.Empty;
-        public Round CurrentRound { get; private set; }
+        public Round? CurrentRound { get; private set; }
         private readonly Dictionary<string, RoundAggregate> _roundAggregates = new();
         private readonly TerrorAggregateCollection _terrorAggregates = new();
-        private readonly Dictionary<string, string> _roundMapNames = new();
+        private readonly Dictionary<string, string?> _roundMapNames = new();
         private readonly TerrorMapNameCollection _terrorMapNames = new();
         private readonly List<Tuple<Round, string>> _roundLogHistory = new();
         private readonly Dictionary<string, object> _stats = new();
@@ -53,7 +53,7 @@ namespace ToNRoundCounter.Application
             return $"{round.RoundType ?? "<unknown>"} (Terror: {round.TerrorKey ?? "<none>"}, Map: {round.MapName ?? "<none>"})";
         }
 
-        public void UpdateCurrentRound(Round round)
+        public void UpdateCurrentRound(Round? round)
         {
             _logger?.LogEvent("StateService", $"Updating current round to {DescribeRound(round)}.");
             lock (_sync)
@@ -95,7 +95,7 @@ namespace ToNRoundCounter.Application
             NotifyStateChanged(nameof(SetRoundCycle));
         }
 
-        public void RecordRoundResult(string roundType, string terrorType, bool survived)
+        public void RecordRoundResult(string roundType, string? terrorType, bool survived)
         {
             _logger?.LogEvent("StateService", $"Recording round result. Round: {roundType}, Terror: {terrorType ?? "<none>"}, Survived: {survived}");
             lock (_sync)
@@ -158,7 +158,7 @@ namespace ToNRoundCounter.Application
             return snapshot;
         }
 
-        public bool TryGetTerrorAggregates(string round, out Dictionary<string, TerrorAggregate> terrorDict)
+        public bool TryGetTerrorAggregates(string round, out Dictionary<string, TerrorAggregate>? terrorDict)
         {
             _logger?.LogEvent("StateService", $"Retrieving terror aggregates for round '{round}'.", LogEventLevel.Debug);
             lock (_sync)
@@ -175,18 +175,18 @@ namespace ToNRoundCounter.Application
             }
         }
 
-        public IReadOnlyDictionary<string, string> GetRoundMapNames()
+        public IReadOnlyDictionary<string, string?> GetRoundMapNames()
         {
-            Dictionary<string, string> snapshot;
+            Dictionary<string, string?> snapshot;
             lock (_sync)
             {
-                snapshot = new Dictionary<string, string>(_roundMapNames);
+                snapshot = new Dictionary<string, string?>(_roundMapNames);
             }
             _logger?.LogEvent("StateService", $"Providing round map names snapshot with {snapshot.Count} entries.", LogEventLevel.Debug);
             return snapshot;
         }
 
-        public void SetRoundMapName(string roundType, string mapName)
+        public void SetRoundMapName(string roundType, string? mapName)
         {
             _logger?.LogEvent("StateService", $"Associating map '{mapName}' with round '{roundType}'.");
             lock (_sync)
@@ -196,7 +196,7 @@ namespace ToNRoundCounter.Application
             NotifyStateChanged(nameof(SetRoundMapName));
         }
 
-        public void SetTerrorMapName(string round, string terror, string mapName)
+        public void SetTerrorMapName(string round, string terror, string? mapName)
         {
             _logger?.LogEvent("StateService", $"Associating terror map '{mapName}' with round '{round}' / terror '{terror}'.");
             lock (_sync)

--- a/Domain/AutoSuicideRule.cs
+++ b/Domain/AutoSuicideRule.cs
@@ -12,15 +12,15 @@ namespace ToNRoundCounter.Domain
     /// </summary>
     public class AutoSuicideRule
     {
-        public string Round { get; private set; }
+        public string? Round { get; private set; }
         public bool RoundNegate { get; private set; }
-        public string Terror { get; private set; }
+        public string? Terror { get; private set; }
         public bool TerrorNegate { get; private set; }
-        public string RoundExpression { get; private set; }
-        public string TerrorExpression { get; private set; }
+        public string? RoundExpression { get; private set; }
+        public string? TerrorExpression { get; private set; }
         public int Value { get; private set; }
 
-        public static bool TryParse(string line, out AutoSuicideRule rule)
+        public static bool TryParse(string line, out AutoSuicideRule? rule)
         {
             rule = null;
             if (string.IsNullOrWhiteSpace(line)) return false;
@@ -39,8 +39,8 @@ namespace ToNRoundCounter.Domain
             if (!(int.TryParse(parts[2], out var value) && (value == 0 || value == 1 || value == 2)))
                 return false;
 
-            string roundExpr = string.IsNullOrWhiteSpace(parts[0]) ? null : parts[0].Trim();
-            string terrorExpr = string.IsNullOrWhiteSpace(parts[1]) ? null : parts[1].Trim();
+            string? roundExpr = string.IsNullOrWhiteSpace(parts[0]) ? null : parts[0].Trim();
+            string? terrorExpr = string.IsNullOrWhiteSpace(parts[1]) ? null : parts[1].Trim();
 
             bool roundNeg = false;
             if (!string.IsNullOrEmpty(roundExpr))
@@ -69,7 +69,7 @@ namespace ToNRoundCounter.Domain
             return true;
         }
 
-        public static bool TryParseDetailed(string line, out AutoSuicideRule rule, out string error)
+        public static bool TryParseDetailed(string line, out AutoSuicideRule? rule, out string? error)
         {
             rule = null;
             error = null;
@@ -103,8 +103,8 @@ namespace ToNRoundCounter.Domain
                 return false;
             }
 
-            string roundExpr = string.IsNullOrWhiteSpace(parts[0]) ? null : parts[0].Trim();
-            string terrorExpr = string.IsNullOrWhiteSpace(parts[1]) ? null : parts[1].Trim();
+            string? roundExpr = string.IsNullOrWhiteSpace(parts[0]) ? null : parts[0].Trim();
+            string? terrorExpr = string.IsNullOrWhiteSpace(parts[1]) ? null : parts[1].Trim();
 
             bool roundNeg = false;
             if (!string.IsNullOrEmpty(roundExpr))
@@ -141,14 +141,14 @@ namespace ToNRoundCounter.Domain
             return true;
         }
 
-        public bool Matches(string round, string terror, Func<string, string, bool> comparer)
+        public bool Matches(string? round, string? terror, Func<string, string, bool> comparer)
         {
             bool roundMatch = RoundExpression == null ? true : (RoundNegate ? !Evaluate(RoundExpression, round, comparer) : Evaluate(RoundExpression, round, comparer));
             bool terrorMatch = TerrorExpression == null ? true : (TerrorNegate ? !Evaluate(TerrorExpression, terror, comparer) : Evaluate(TerrorExpression, terror, comparer));
             return roundMatch && terrorMatch;
         }
 
-        public bool MatchesRound(string round, Func<string, string, bool> comparer)
+        public bool MatchesRound(string? round, Func<string, string, bool> comparer)
         {
             if (RoundExpression == null)
                 return true;
@@ -205,7 +205,7 @@ namespace ToNRoundCounter.Domain
         /// ignored.  If the expression cannot be represented as such a list,
         /// null is returned.
         /// </summary>
-        public List<string> GetRoundTerms()
+        public List<string>? GetRoundTerms()
         {
             return GetSimpleTerms(RoundExpression);
         }
@@ -216,12 +216,12 @@ namespace ToNRoundCounter.Domain
         /// ignored.  If the expression cannot be represented as such a list,
         /// null is returned.
         /// </summary>
-        public List<string> GetTerrorTerms()
+        public List<string>? GetTerrorTerms()
         {
             return GetSimpleTerms(TerrorExpression);
         }
 
-        private static List<string> GetSimpleTerms(string expr)
+        private static List<string>? GetSimpleTerms(string? expr)
         {
             if (string.IsNullOrWhiteSpace(expr)) return null;
             string working = expr.Trim();
@@ -235,8 +235,11 @@ namespace ToNRoundCounter.Domain
             return null;
         }
 
-        private static bool StripNegation(ref string expr)
+        private static bool StripNegation(ref string? expr)
         {
+            if (string.IsNullOrWhiteSpace(expr))
+                return false;
+
             expr = expr.Trim();
             if (!expr.StartsWith("!")) return false;
             string candidate = expr.Substring(1).Trim();
@@ -305,7 +308,7 @@ namespace ToNRoundCounter.Domain
             return depth == 0 && !expectTerm;
         }
 
-        private static bool Evaluate(string expr, string input, Func<string, string, bool> comparer)
+        private static bool Evaluate(string expr, string? input, Func<string, string, bool> comparer)
         {
             if (string.IsNullOrWhiteSpace(expr)) return true;
             expr = expr.Trim();
@@ -356,7 +359,7 @@ namespace ToNRoundCounter.Domain
             return -1;
         }
 
-        private static bool IsSimple(string expr)
+        private static bool IsSimple(string? expr)
         {
             if (string.IsNullOrEmpty(expr)) return false;
             return !(expr.Contains("&&") || expr.Contains("||") || expr.Contains("!") || expr.Contains("(") || expr.Contains(")"));
@@ -393,7 +396,7 @@ namespace ToNRoundCounter.Domain
             return result;
         }
 
-        private static string EscapeSegment(string s)
+        private static string? EscapeSegment(string? s)
         {
             if (s == null) return null;
             var sb = new StringBuilder();

--- a/Domain/Round.cs
+++ b/Domain/Round.cs
@@ -17,10 +17,10 @@ namespace ToNRoundCounter.Domain
         public Round() : this(new RoundId(Guid.NewGuid())) { }
 
         public RoundId Id { get; }
-        public string RoundType { get; set; }
+        public string? RoundType { get; set; }
         public bool IsDeath { get; set; }
-        public string TerrorKey { get; set; }
-        public string MapName { get; set; }
+        public string? TerrorKey { get; set; }
+        public string? MapName { get; set; }
         public List<string> ItemNames { get; set; }
         public int Damage { get; set; }
         public int PageCount { get; set; }

--- a/Domain/TerrorMapNameCollection.cs
+++ b/Domain/TerrorMapNameCollection.cs
@@ -7,30 +7,30 @@ namespace ToNRoundCounter.Domain
     /// </summary>
     public class TerrorMapNameCollection
     {
-        private readonly Dictionary<string, Dictionary<string, string>> _data = new();
+        private readonly Dictionary<string, Dictionary<string, string?>> _data = new();
 
-        public string Get(string round, string terror)
+        public string? Get(string round, string terror)
         {
             if (!_data.TryGetValue(round, out var terrorDict))
             {
-                terrorDict = new Dictionary<string, string>();
+                terrorDict = new Dictionary<string, string?>();
                 _data[round] = terrorDict;
             }
             terrorDict.TryGetValue(terror, out var name);
             return name;
         }
 
-        public void Set(string round, string terror, string name)
+        public void Set(string round, string terror, string? name)
         {
             if (!_data.TryGetValue(round, out var terrorDict))
             {
-                terrorDict = new Dictionary<string, string>();
+                terrorDict = new Dictionary<string, string?>();
                 _data[round] = terrorDict;
             }
             terrorDict[terror] = name;
         }
 
-        public bool TryGetRound(string round, out Dictionary<string, string> terrorDict)
+        public bool TryGetRound(string round, out Dictionary<string, string?>? terrorDict)
             => _data.TryGetValue(round, out terrorDict);
 
         public void Clear() => _data.Clear();

--- a/Infrastructure/AppSettings.cs
+++ b/Infrastructure/AppSettings.cs
@@ -349,10 +349,10 @@ namespace ToNRoundCounter.Infrastructure
     {
         public int OSCPort { get; set; }
         public bool OSCPortChanged { get; set; }
-        public string BackgroundColor_InfoPanel { get; set; }
-        public string BackgroundColor_Stats { get; set; }
-        public string BackgroundColor_Log { get; set; }
-        public string FixedTerrorColor { get; set; }
+        public string BackgroundColor_InfoPanel { get; set; } = string.Empty;
+        public string BackgroundColor_Stats { get; set; } = string.Empty;
+        public string BackgroundColor_Log { get; set; } = string.Empty;
+        public string FixedTerrorColor { get; set; } = string.Empty;
         public bool ShowStats { get; set; }
         public bool ShowDebug { get; set; }
         public bool ShowRoundLog { get; set; }
@@ -362,17 +362,17 @@ namespace ToNRoundCounter.Infrastructure
         public bool Filter_Survival { get; set; }
         public bool Filter_Death { get; set; }
         public bool Filter_SurvivalRate { get; set; }
-        public List<string> RoundTypeStats { get; set; }
+        public List<string> RoundTypeStats { get; set; } = new List<string>();
         public bool AutoSuicideEnabled { get; set; }
-        public List<string> AutoSuicideRoundTypes { get; set; }
-        public Dictionary<string, AutoSuicidePreset> AutoSuicidePresets { get; set; }
-        public List<string> AutoSuicideDetailCustom { get; set; }
+        public List<string> AutoSuicideRoundTypes { get; set; } = new List<string>();
+        public Dictionary<string, AutoSuicidePreset> AutoSuicidePresets { get; set; } = new Dictionary<string, AutoSuicidePreset>();
+        public List<string> AutoSuicideDetailCustom { get; set; } = new List<string>();
         public bool AutoSuicideFuzzyMatch { get; set; }
         public bool AutoSuicideUseDetail { get; set; }
-        public string apikey { get; set; }
+        public string apikey { get; set; } = string.Empty;
         public string ThemeKey { get; set; } = Theme.DefaultThemeKey;
-        public string LogFilePath { get; set; }
-        public string WebSocketIp { get; set; }
+        public string LogFilePath { get; set; } = string.Empty;
+        public string WebSocketIp { get; set; } = string.Empty;
         public bool AutoLaunchEnabled { get; set; }
         public List<AutoLaunchEntry> AutoLaunchEntries { get; set; } = new List<AutoLaunchEntry>();
         public bool ItemMusicEnabled { get; set; }

--- a/Infrastructure/ModuleHost.cs
+++ b/Infrastructure/ModuleHost.cs
@@ -843,7 +843,7 @@ namespace ToNRoundCounter.Infrastructure
         private void HandleWebSocketMessageReceived(WebSocketMessageReceived message)
         {
             LogHostEvent(nameof(HandleWebSocketMessageReceived), $"Message received ({message.Message?.Length ?? 0} chars).");
-            var context = new ModuleWebSocketMessageContext(message.Message, _serviceProvider);
+            var context = new ModuleWebSocketMessageContext(message.Message!, _serviceProvider);
             WebSocketMessageReceived?.Invoke(this, context);
             foreach (var module in _modules)
             {

--- a/Infrastructure/OSCListener.cs
+++ b/Infrastructure/OSCListener.cs
@@ -18,7 +18,7 @@ namespace ToNRoundCounter.Infrastructure
         private readonly ICancellationProvider _cancellation;
         private readonly IEventLogger _logger;
         private readonly Channel<OscMessage> _channel = Channel.CreateUnbounded<OscMessage>();
-        private Task _processingTask;
+        private Task? _processingTask;
 
         public OSCListener(IEventBus bus, ICancellationProvider cancellation, IEventLogger logger)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -140,7 +140,7 @@ namespace ToNRoundCounter
 
             if (!string.IsNullOrWhiteSpace(autoLaunchPath))
             {
-                launches.Add(new AutoLaunchPlan(autoLaunchPath, autoLaunchArguments ?? string.Empty, "command line"));
+                launches.Add(new AutoLaunchPlan(autoLaunchPath!, autoLaunchArguments ?? string.Empty, "command line"));
             }
             else if (appSettings.AutoLaunchEnabled)
             {
@@ -151,7 +151,7 @@ namespace ToNRoundCounter
                         continue;
                     }
 
-                    launches.Add(new AutoLaunchPlan(entry.ExecutablePath, entry.Arguments ?? string.Empty, "settings"));
+                    launches.Add(new AutoLaunchPlan(entry.ExecutablePath!, entry.Arguments ?? string.Empty, "settings"));
                 }
             }
 

--- a/ToNRoundCounter.Tests/AutoSuicideCancelTests.cs
+++ b/ToNRoundCounter.Tests/AutoSuicideCancelTests.cs
@@ -13,9 +13,9 @@ namespace ToNRoundCounter.Tests
         public async Task TerrorRuleCancelsScheduledSuicide()
         {
             // Arrange
-            AutoSuicideRule.TryParse("クラシック::1", out var rule1);
-            AutoSuicideRule.TryParse("クラシック:Don't Touch Me:0", out var rule2);
-            var rules = new List<AutoSuicideRule> { rule1, rule2 };
+            Assert.True(AutoSuicideRule.TryParse("クラシック::1", out var rule1));
+            Assert.True(AutoSuicideRule.TryParse("クラシック:Don't Touch Me:0", out var rule2));
+            var rules = new List<AutoSuicideRule> { Assert.NotNull(rule1), Assert.NotNull(rule2) };
 
             int ShouldAutoSuicide(string roundType, string terrorName)
             {

--- a/ToNRoundCounter.Tests/AutoSuicideRuleTests.cs
+++ b/ToNRoundCounter.Tests/AutoSuicideRuleTests.cs
@@ -10,9 +10,10 @@ namespace ToNRoundCounter.Tests
         {
             var ok = AutoSuicideRule.TryParse("A:B:1", out var rule);
             Assert.True(ok);
-            Assert.Equal("A", rule.Round);
-            Assert.Equal("B", rule.Terror);
-            Assert.Equal(1, rule.Value);
+            var parsedRule = Assert.NotNull(rule);
+            Assert.Equal("A", parsedRule.Round);
+            Assert.Equal("B", parsedRule.Terror);
+            Assert.Equal(1, parsedRule.Value);
         }
 
         [Fact]
@@ -20,9 +21,10 @@ namespace ToNRoundCounter.Tests
         {
             var ok = AutoSuicideRule.TryParse("1", out var rule);
             Assert.True(ok);
-            Assert.Null(rule.RoundExpression);
-            Assert.Null(rule.TerrorExpression);
-            Assert.Equal(1, rule.Value);
+            var parsedRule = Assert.NotNull(rule);
+            Assert.Null(parsedRule.RoundExpression);
+            Assert.Null(parsedRule.TerrorExpression);
+            Assert.Equal(1, parsedRule.Value);
         }
 
         [Fact]
@@ -44,9 +46,10 @@ namespace ToNRoundCounter.Tests
         {
             var ok = AutoSuicideRule.TryParse("!(A||B)::1", out var rule);
             Assert.True(ok);
-            Assert.True(rule.Matches("C", null, (a, b) => a == b));
-            Assert.False(rule.Matches("A", null, (a, b) => a == b));
-            Assert.False(rule.Matches("B", null, (a, b) => a == b));
+            var parsedRule = Assert.NotNull(rule);
+            Assert.True(parsedRule.Matches("C", null, (a, b) => a == b));
+            Assert.False(parsedRule.Matches("A", null, (a, b) => a == b));
+            Assert.False(parsedRule.Matches("B", null, (a, b) => a == b));
         }
 
         [Fact]
@@ -54,8 +57,9 @@ namespace ToNRoundCounter.Tests
         {
             var ok = AutoSuicideRule.TryParse("!(A||B)&&C::1", out var rule);
             Assert.True(ok);
-            Assert.True(rule.Matches("C", null, (a, b) => a == b));
-            Assert.False(rule.Matches("A", null, (a, b) => a == b));
+            var parsedRule = Assert.NotNull(rule);
+            Assert.True(parsedRule.Matches("C", null, (a, b) => a == b));
+            Assert.False(parsedRule.Matches("A", null, (a, b) => a == b));
         }
 
         [Fact]
@@ -63,7 +67,8 @@ namespace ToNRoundCounter.Tests
         {
             var ok = AutoSuicideRule.TryParse("!(A||B)::1", out var rule);
             Assert.True(ok);
-            var rounds = rule.GetRoundTerms();
+            var parsedRule = Assert.NotNull(rule);
+            var rounds = parsedRule.GetRoundTerms();
             Assert.NotNull(rounds);
             Assert.Equal(new[] { "A", "B" }, rounds);
         }
@@ -73,7 +78,8 @@ namespace ToNRoundCounter.Tests
         {
             var ok = AutoSuicideRule.TryParse(":!(X||Y):2", out var rule);
             Assert.True(ok);
-            var terrors = rule.GetTerrorTerms();
+            var parsedRule = Assert.NotNull(rule);
+            var terrors = parsedRule.GetTerrorTerms();
             Assert.NotNull(terrors);
             Assert.Equal(new[] { "X", "Y" }, terrors);
         }
@@ -83,9 +89,10 @@ namespace ToNRoundCounter.Tests
         {
             var ok = AutoSuicideRule.TryParse("!((A&&B)||(!C&&D))::1", out var rule);
             Assert.True(ok);
-            Assert.True(rule.RoundNegate);
-            Assert.Equal("((A&&B)||(!C&&D))", rule.RoundExpression);
-            Assert.False(rule.Matches("D", null, (a, b) => a == b));
+            var parsedRule = Assert.NotNull(rule);
+            Assert.True(parsedRule.RoundNegate);
+            Assert.Equal("((A&&B)||(!C&&D))", parsedRule.RoundExpression);
+            Assert.False(parsedRule.Matches("D", null, (a, b) => a == b));
         }
 
         [Fact]
@@ -93,7 +100,8 @@ namespace ToNRoundCounter.Tests
         {
             var ok = AutoSuicideRule.TryParse("!(!(A||B)&&C)::1", out var rule);
             Assert.True(ok);
-            Assert.False(rule.Matches("C", null, (a, b) => a == b));
+            var parsedRule = Assert.NotNull(rule);
+            Assert.False(parsedRule.Matches("C", null, (a, b) => a == b));
         }
 
         [Fact]
@@ -101,16 +109,18 @@ namespace ToNRoundCounter.Tests
         {
             var ok = AutoSuicideRule.TryParse(@"A\:B:C\:D:1", out var rule);
             Assert.True(ok);
-            Assert.Equal("A:B", rule.Round);
-            Assert.Equal("C:D", rule.Terror);
-            Assert.Equal(1, rule.Value);
+            var parsedRule = Assert.NotNull(rule);
+            Assert.Equal("A:B", parsedRule.Round);
+            Assert.Equal("C:D", parsedRule.Terror);
+            Assert.Equal(1, parsedRule.Value);
         }
 
         [Fact]
         public void ToString_PreservesEscapes()
         {
             AutoSuicideRule.TryParse(@"A\:B:C\\D:1", out var rule);
-            Assert.Equal(@"A\:B:C\\D:1", rule.ToString());
+            var parsedRule = Assert.NotNull(rule);
+            Assert.Equal(@"A\:B:C\\D:1", parsedRule.ToString());
         }
 
         [Fact]
@@ -143,8 +153,11 @@ namespace ToNRoundCounter.Tests
             AutoSuicideRule.TryParse("A::1", out var broad);
             AutoSuicideRule.TryParse("A:B:0", out var specific);
 
-            Assert.True(broad.Covers(specific));
-            Assert.False(specific.Covers(broad));
+            var broadRule = Assert.NotNull(broad);
+            var specificRule = Assert.NotNull(specific);
+
+            Assert.True(broadRule.Covers(specificRule));
+            Assert.False(specificRule.Covers(broadRule));
         }
     }
 }

--- a/ToNRoundCounter.Tests/StateServiceTests.cs
+++ b/ToNRoundCounter.Tests/StateServiceTests.cs
@@ -18,8 +18,9 @@ namespace ToNRoundCounter.Tests
             Assert.Equal(1, roundAgg.Death);
 
             Assert.True(service.TryGetTerrorAggregates("RoundA", out var terrorDict));
-            Assert.True(terrorDict.ContainsKey("Terror1"));
-            var terrorAgg = terrorDict["Terror1"];
+            Assert.NotNull(terrorDict);
+            Assert.True(terrorDict!.ContainsKey("Terror1"));
+            var terrorAgg = terrorDict!["Terror1"];
             Assert.Equal(2, terrorAgg.Total);
             Assert.Equal(1, terrorAgg.Survival);
             Assert.Equal(1, terrorAgg.Death);

--- a/UI/MainForm.Sound.cs
+++ b/UI/MainForm.Sound.cs
@@ -44,7 +44,7 @@ namespace ToNRoundCounter.UI
             StopItemMusic();
         }
 
-        private void StartItemMusic(ItemMusicEntry entry)
+        private void StartItemMusic(ItemMusicEntry? entry)
         {
             if (!_settings.ItemMusicEnabled || entry == null || !entry.Enabled)
             {
@@ -83,7 +83,7 @@ namespace ToNRoundCounter.UI
             }
         }
 
-        private void EnsureItemMusicPlayer(ItemMusicEntry entry)
+        private void EnsureItemMusicPlayer(ItemMusicEntry? entry)
         {
             if (!_settings.ItemMusicEnabled || entry == null || !entry.Enabled)
             {
@@ -103,7 +103,7 @@ namespace ToNRoundCounter.UI
             }
         }
 
-        private void UpdateItemMusicPlayer(ItemMusicEntry entry = null)
+        private void UpdateItemMusicPlayer(ItemMusicEntry? entry = null)
         {
             try
             {

--- a/UI/MainForm.WebSocket.cs
+++ b/UI/MainForm.WebSocket.cs
@@ -14,7 +14,7 @@ namespace ToNRoundCounter.UI
 {
     public partial class MainForm
     {
-        private ClientWebSocket instanceWsConnection = null;
+        private ClientWebSocket? instanceWsConnection;
         private static readonly SemaphoreSlim sendAlertSemaphore = new SemaphoreSlim(1, 1);
         private int connected = 0;
         private bool followAutoSelfKill = false;

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -28,27 +28,27 @@ namespace ToNRoundCounter.UI
     public partial class MainForm : Form, IMainView
     {
         // 上部固定UI
-        private Label lblStatus;           // WebSocket接続状況
-        private Label lblOSCStatus;        // OSC通信接続状況
-        private Button btnToggleTopMost;   // 画面最前面固定ボタン
-        private Button btnSettings;        // 設定変更ボタン
-        private MenuStrip mainMenuStrip;
-        private ToolStripMenuItem windowsMenuItem;
+        private Label lblStatus = null!;           // WebSocket接続状況
+        private Label lblOSCStatus = null!;        // OSC通信接続状況
+        private Button btnToggleTopMost = null!;   // 画面最前面固定ボタン
+        private Button btnSettings = null!;        // 設定変更ボタン
+        private MenuStrip mainMenuStrip = null!;
+        private ToolStripMenuItem windowsMenuItem = null!;
 
         // デバッグ情報用ラベル
-        private Label lblDebugInfo;
+        private Label lblDebugInfo = null!;
 
         // 情報表示パネル
-        public InfoPanel InfoPanel { get; private set; }
-        private TerrorInfoPanel terrorInfoPanel;
-        private JObject terrorInfoData;
+        public InfoPanel InfoPanel { get; private set; } = null!;
+        private TerrorInfoPanel terrorInfoPanel = null!;
+        private JObject? terrorInfoData;
 
         // 統計情報表示およびラウンドログ表示は SplitContainer で実装（縦に並べる）
-        private SplitContainer splitContainerMain;
-        private Label lblStatsTitle;
-        private Label lblRoundLogTitle;
-        private RichTextBox rtbStatsDisplay;  // 統計情報表示欄
-        public LogPanel logPanel;             // ラウンドログパネル
+        private SplitContainer splitContainerMain = null!;
+        private Label lblStatsTitle = null!;
+        private Label lblRoundLogTitle = null!;
+        private RichTextBox rtbStatsDisplay = null!;  // 統計情報表示欄
+        public LogPanel logPanel = null!;             // ラウンドログパネル
 
         // その他のフィールド
         private readonly ICancellationProvider _cancellation;
@@ -65,15 +65,15 @@ namespace ToNRoundCounter.UI
         private readonly IReadOnlyList<IOscRepeaterPolicy> _oscRepeaterPolicies;
         private readonly ModuleHost _moduleHost;
 
-        private Action<WebSocketConnected> _wsConnectedHandler;
-        private Action<WebSocketDisconnected> _wsDisconnectedHandler;
-        private Action<OscConnected> _oscConnectedHandler;
-        private Action<OscDisconnected> _oscDisconnectedHandler;
-        private Action<WebSocketMessageReceived> _wsMessageHandler;
-        private Action<OscMessageReceived> _oscMessageHandler;
-        private Action<SettingsValidationFailed> _settingsValidationFailedHandler;
+        private Action<WebSocketConnected>? _wsConnectedHandler;
+        private Action<WebSocketDisconnected>? _wsDisconnectedHandler;
+        private Action<OscConnected>? _oscConnectedHandler;
+        private Action<OscDisconnected>? _oscDisconnectedHandler;
+        private Action<WebSocketMessageReceived>? _wsMessageHandler;
+        private Action<OscMessageReceived>? _oscMessageHandler;
+        private Action<SettingsValidationFailed>? _settingsValidationFailedHandler;
 
-        private Dictionary<string, Color> terrorColors;
+        private Dictionary<string, Color> terrorColors = new();
         private bool lastOptedIn = true;
 
         // 次ラウンド予測用：stateService.RoundCycle==0 → 通常ラウンド, ==1 → 「通常ラウンド or 特殊ラウンド」, >=2 → 特殊ラウンド
@@ -86,7 +86,7 @@ namespace ToNRoundCounter.UI
             "クラシック", "走れ！", "オルタネイト", "パニッシュ", "狂気", "サボタージュ", "霧", "ブラッドバス", "ダブルトラブル", "EX", "ミッドナイト", "ゴースト", "8ページ", "アンバウンド", "寒い夜", "ミスティックムーン", "ブラッドムーン", "トワイライト", "ソルスティス"
         };
 
-        private Process oscRepeaterProcess = null;
+        private Process? oscRepeaterProcess;
 
         private bool isNotifyActivated = false;
 
@@ -102,12 +102,12 @@ namespace ToNRoundCounter.UI
 
         private readonly AutoSuicideService autoSuicideService;
 
-        private MediaPlayer itemMusicPlayer;
+        private MediaPlayer? itemMusicPlayer;
         private bool itemMusicLoopRequested;
         private bool itemMusicActive;
         private DateTime itemMusicMatchStart = DateTime.MinValue;
         private string lastLoadedItemMusicPath = string.Empty;
-        private ItemMusicEntry activeItemMusicEntry;
+        private ItemMusicEntry? activeItemMusicEntry;
         private string currentTerrorBaseText = string.Empty;
         private bool terrorCountdownActive;
         private DateTime terrorCountdownStart = DateTime.MinValue;
@@ -157,6 +157,12 @@ namespace ToNRoundCounter.UI
             _moduleHost.NotifyMainWindowThemeChanged(new ModuleMainWindowThemeContext(this, _settings.ThemeKey, Theme.CurrentDescriptor, _moduleHost.CurrentServiceProvider));
             LoadAutoSuicideRules();
             InitializeComponents();
+            if (lblStatus == null || lblOSCStatus == null || btnToggleTopMost == null || btnSettings == null ||
+                mainMenuStrip == null || windowsMenuItem == null || InfoPanel == null || terrorInfoPanel == null ||
+                splitContainerMain == null || rtbStatsDisplay == null || logPanel == null)
+            {
+                throw new InvalidOperationException("Main form controls failed to initialize.");
+            }
             _moduleHost.NotifyMainWindowMenuBuilding(new ModuleMainWindowMenuContext(this, mainMenuStrip, _moduleHost.CurrentServiceProvider));
             BuildAuxiliaryWindowsMenu();
             _moduleHost.NotifyMainWindowUiComposed(new ModuleMainWindowUiContext(this, this.Controls, mainMenuStrip, _moduleHost.CurrentServiceProvider));
@@ -382,7 +388,7 @@ namespace ToNRoundCounter.UI
             LogUi("Theme applied to main form components.", LogEventLevel.Debug);
         }
 
-        private void MainForm_Resize(object sender, EventArgs e)
+        private void MainForm_Resize(object? sender, EventArgs? e)
         {
             LogUi($"Main form resized to {this.ClientSize.Width}x{this.ClientSize.Height}.", LogEventLevel.Debug);
             int margin = 10;
@@ -900,7 +906,7 @@ namespace ToNRoundCounter.UI
                         stateService.CurrentRound.RoundColor = displayColorInt;
                     }
 
-                    List<(string name, int count)> terrors = null;
+                    List<(string name, int count)>? terrors = null;
                     var namesArray = json.Value<JArray>("Names");
                     if (namesArray != null && namesArray.Count > 0)
                     {
@@ -1195,11 +1201,11 @@ namespace ToNRoundCounter.UI
         {
             if (stateService.CurrentRound != null)
             {
-                string roundType = stateService.CurrentRound.RoundType;
+                string roundType = stateService.CurrentRound.RoundType ?? string.Empty;
                 stateService.SetRoundMapName(roundType, stateService.CurrentRound.MapName ?? "");
                 if (!string.IsNullOrEmpty(stateService.CurrentRound.TerrorKey))
                 {
-                    string terrorKey = stateService.CurrentRound.TerrorKey;
+                    string terrorKey = stateService.CurrentRound.TerrorKey!;
                     bool survived = lastOptedIn && !stateService.CurrentRound.IsDeath;
                     stateService.RecordRoundResult(roundType, terrorKey, survived);
                     stateService.SetTerrorMapName(roundType, terrorKey, stateService.CurrentRound.MapName ?? "");
@@ -1209,12 +1215,12 @@ namespace ToNRoundCounter.UI
                     stateService.RecordRoundResult(roundType, null, !stateService.CurrentRound.IsDeath);
                 }
                 if (!string.IsNullOrEmpty(stateService.CurrentRound.MapName))
-                    stateService.SetRoundMapName(stateService.CurrentRound.RoundType, stateService.CurrentRound.MapName);
+                    stateService.SetRoundMapName(stateService.CurrentRound.RoundType ?? string.Empty, stateService.CurrentRound.MapName);
 
                 // 次ラウンド予測ロジック
                 var normalTypes = new[] { "クラシック", "Classic", "RUN", "走れ！" };
                 var overrideTypes = new HashSet<string> { "アンバウンド", "8ページ", "ゴースト", "オルタネイト" };
-                string current = stateService.CurrentRound.RoundType;
+                string current = stateService.CurrentRound.RoundType ?? string.Empty;
 
                 if (normalTypes.Any(type => current.Contains(type)))
                 {
@@ -1615,7 +1621,7 @@ namespace ToNRoundCounter.UI
             }
         }
 
-        private void UpdateTerrorInfoPanel(List<string> names)
+        private void UpdateTerrorInfoPanel(List<string>? names)
         {
             if (terrorInfoPanel == null)
                 return;
@@ -1671,10 +1677,10 @@ namespace ToNRoundCounter.UI
                     });
                 }
 
-                if (stateService.CurrentRound != null)
-                {
-                    string checkType = stateService.CurrentRound.RoundType;
-                    string terror = stateService.CurrentRound.TerrorKey;
+                    if (stateService.CurrentRound != null)
+                    {
+                        string checkType = stateService.CurrentRound.RoundType ?? string.Empty;
+                        string? terror = stateService.CurrentRound.TerrorKey;
                     if (checkType == "ブラッドバス" && !string.IsNullOrEmpty(terror) && terror.Contains("LVL 3"))
                     {
                         checkType = "EX";
@@ -1732,7 +1738,7 @@ namespace ToNRoundCounter.UI
             var temp = new List<AutoSuicideRule>();
             foreach (var line in lines)
             {
-                if (AutoSuicideRule.TryParse(line, out var r))
+                if (AutoSuicideRule.TryParse(line, out var r) && r != null)
                     temp.Add(r);
             }
             var cleaned = new List<AutoSuicideRule>();
@@ -1748,7 +1754,7 @@ namespace ToNRoundCounter.UI
             _moduleHost.NotifyAutoSuicideRulesPrepared(new ModuleAutoSuicideRuleContext(autoSuicideRules, _settings, _moduleHost.CurrentServiceProvider));
         }
 
-        private int ShouldAutoSuicide(string roundType, string terrorName, out bool hasPendingDelayed)
+        private int ShouldAutoSuicide(string roundType, string? terrorName, out bool hasPendingDelayed)
         {
             hasPendingDelayed = false;
             if (!_settings.AutoSuicideEnabled) return 0;
@@ -1784,7 +1790,7 @@ namespace ToNRoundCounter.UI
             return decisionContext.Decision;
         }
 
-        private int ShouldAutoSuicide(string roundType, string terrorName)
+        private int ShouldAutoSuicide(string roundType, string? terrorName)
         {
             return ShouldAutoSuicide(roundType, terrorName, out _);
         }
@@ -1905,7 +1911,7 @@ namespace ToNRoundCounter.UI
             }
         }
 
-        private void UpdateTerrorDisplay(string displayName, Color color, List<(string name, int count)> terrors)
+        private void UpdateTerrorDisplay(string displayName, Color color, List<(string name, int count)>? terrors)
         {
             string roundType = stateService.CurrentRound?.RoundType;
 

--- a/UI/SettingsForm.cs
+++ b/UI/SettingsForm.cs
@@ -10,9 +10,9 @@ namespace ToNRoundCounter.UI
     public class SettingsForm : Form
     {
         private readonly IAppSettings _settings;
-        private SettingsPanel settingsPanel;
-        private Button btnOK;
-        private Button btnCancel;
+        private SettingsPanel settingsPanel = null!;
+        private Button btnOK = null!;
+        private Button btnCancel = null!;
 
         public SettingsPanel SettingsPanel { get { return settingsPanel; } }
 

--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -20,70 +20,70 @@ namespace ToNRoundCounter.UI
         private readonly IAppSettings _settings;
 
 
-        public NumericUpDown oscPortNumericUpDown { get; private set; }
-        public TextBox webSocketIpTextBox { get; private set; }
+        public NumericUpDown oscPortNumericUpDown { get; private set; } = null!;
+        public TextBox webSocketIpTextBox { get; private set; } = null!;
         // 統計情報表示・デバッグ情報チェック
-        public CheckBox ShowStatsCheckBox { get; private set; }
-        public CheckBox DebugInfoCheckBox { get; private set; }
+        public CheckBox ShowStatsCheckBox { get; private set; } = null!;
+        public CheckBox DebugInfoCheckBox { get; private set; } = null!;
 
         // フィルター項目（MAPは削除）
-        public CheckBox RoundTypeCheckBox { get; private set; }
-        public CheckBox TerrorCheckBox { get; private set; }
-        public CheckBox AppearanceCountCheckBox { get; private set; }
-        public CheckBox SurvivalCountCheckBox { get; private set; }
-        public CheckBox DeathCountCheckBox { get; private set; }
-        public CheckBox SurvivalRateCheckBox { get; private set; }
+        public CheckBox RoundTypeCheckBox { get; private set; } = null!;
+        public CheckBox TerrorCheckBox { get; private set; } = null!;
+        public CheckBox AppearanceCountCheckBox { get; private set; } = null!;
+        public CheckBox SurvivalCountCheckBox { get; private set; } = null!;
+        public CheckBox DeathCountCheckBox { get; private set; } = null!;
+        public CheckBox SurvivalRateCheckBox { get; private set; } = null!;
 
         // ラウンドログ表示切替チェックボックス
-        public CheckBox ToggleRoundLogCheckBox { get; private set; }
+        public CheckBox ToggleRoundLogCheckBox { get; private set; } = null!;
 
         // 追加設定項目
-        public Label FixedTerrorColorLabel { get; private set; }
-        public Button FixedTerrorColorButton { get; private set; }
-        public Label BackgroundColorLabel { get; private set; }
-        public Button BackgroundColorButton { get; private set; }
-        public Label RoundTypeStatsLabel { get; private set; }
-        public CheckedListBox RoundTypeStatsListBox { get; private set; }
+        public Label FixedTerrorColorLabel { get; private set; } = null!;
+        public Button FixedTerrorColorButton { get; private set; } = null!;
+        public Label BackgroundColorLabel { get; private set; } = null!;
+        public Button BackgroundColorButton { get; private set; } = null!;
+        public Label RoundTypeStatsLabel { get; private set; } = null!;
+        public CheckedListBox RoundTypeStatsListBox { get; private set; } = null!;
 
         // 個別背景色設定
-        public Label InfoPanelBgLabel { get; private set; }
-        public Button InfoPanelBgButton { get; private set; }
-        public Label StatsBgLabel { get; private set; }
-        public Button StatsBgButton { get; private set; }
-        public Label LogBgLabel { get; private set; }
-        public Button LogBgButton { get; private set; }
-        public CheckedListBox autoSuicideRoundListBox { get; internal set; }
-        public CheckBox autoSuicideCheckBox { get; internal set; }
-        public Label autoSuicideRoundLabel { get; private set; }
-        public CheckBox autoSuicideUseDetailCheckBox { get; private set; }
-        public Label autoSuicidePresetLabel { get; private set; }
-        public ComboBox autoSuicidePresetComboBox { get; private set; }
-        public Button autoSuicidePresetSaveButton { get; private set; }
-        public Button autoSuicidePresetLoadButton { get; private set; }
-        public Button autoSuicidePresetExportButton { get; private set; }
-        public Button autoSuicidePresetImportButton { get; private set; }
-        public TextBox autoSuicideDetailTextBox { get; private set; }
-        public CheckBox autoSuicideFuzzyCheckBox { get; private set; }
-        public Button autoSuicideSettingsConfirmButton { get; private set; }
-        public LinkLabel autoSuicideDetailDocLink { get; private set; }
+        public Label InfoPanelBgLabel { get; private set; } = null!;
+        public Button InfoPanelBgButton { get; private set; } = null!;
+        public Label StatsBgLabel { get; private set; } = null!;
+        public Button StatsBgButton { get; private set; } = null!;
+        public Label LogBgLabel { get; private set; } = null!;
+        public Button LogBgButton { get; private set; } = null!;
+        public CheckedListBox autoSuicideRoundListBox { get; internal set; } = null!;
+        public CheckBox autoSuicideCheckBox { get; internal set; } = null!;
+        public Label autoSuicideRoundLabel { get; private set; } = null!;
+        public CheckBox autoSuicideUseDetailCheckBox { get; private set; } = null!;
+        public Label autoSuicidePresetLabel { get; private set; } = null!;
+        public ComboBox autoSuicidePresetComboBox { get; private set; } = null!;
+        public Button autoSuicidePresetSaveButton { get; private set; } = null!;
+        public Button autoSuicidePresetLoadButton { get; private set; } = null!;
+        public Button autoSuicidePresetExportButton { get; private set; } = null!;
+        public Button autoSuicidePresetImportButton { get; private set; } = null!;
+        public TextBox autoSuicideDetailTextBox { get; private set; } = null!;
+        public CheckBox autoSuicideFuzzyCheckBox { get; private set; } = null!;
+        public Button autoSuicideSettingsConfirmButton { get; private set; } = null!;
+        public LinkLabel autoSuicideDetailDocLink { get; private set; } = null!;
         private int autoSuicideAutoRuleCount = 0;
 
-        public Label apiKeyLabel { get; private set; }
-        public TextBox apiKeyTextBox { get; private set; }
+        public Label apiKeyLabel { get; private set; } = null!;
+        public TextBox apiKeyTextBox { get; private set; } = null!;
 
-        public ComboBox ThemeComboBox { get; private set; }
-        public FlowLayoutPanel ModuleExtensionsPanel { get; private set; }
-        public CheckBox AutoLaunchEnabledCheckBox { get; private set; }
-        private DataGridView autoLaunchEntriesGrid;
-        private Button autoLaunchAddButton;
-        private Button autoLaunchRemoveButton;
-        private Button autoLaunchBrowseButton;
-        public CheckBox ItemMusicEnabledCheckBox { get; private set; }
-        private DataGridView itemMusicEntriesGrid;
-        private Button itemMusicAddButton;
-        private Button itemMusicRemoveButton;
-        private Button itemMusicBrowseButton;
-        public TextBox DiscordWebhookUrlTextBox { get; private set; }
+        public ComboBox ThemeComboBox { get; private set; } = null!;
+        public FlowLayoutPanel ModuleExtensionsPanel { get; private set; } = null!;
+        public CheckBox AutoLaunchEnabledCheckBox { get; private set; } = null!;
+        private DataGridView autoLaunchEntriesGrid = null!;
+        private Button autoLaunchAddButton = null!;
+        private Button autoLaunchRemoveButton = null!;
+        private Button autoLaunchBrowseButton = null!;
+        public CheckBox ItemMusicEnabledCheckBox { get; private set; } = null!;
+        private DataGridView itemMusicEntriesGrid = null!;
+        private Button itemMusicAddButton = null!;
+        private Button itemMusicRemoveButton = null!;
+        private Button itemMusicBrowseButton = null!;
+        public TextBox DiscordWebhookUrlTextBox { get; private set; } = null!;
 
         private const string AutoLaunchEnabledColumnName = "AutoLaunchEnabled";
         private const string AutoLaunchPathColumnName = "AutoLaunchPath";
@@ -1637,7 +1637,7 @@ namespace ToNRoundCounter.UI
             var unparsedLines = new List<string>();
             foreach (var line in lines)
             {
-                if (AutoSuicideRule.TryParse(line, out var r))
+                if (AutoSuicideRule.TryParse(line, out var r) && r != null)
                 {
                     rules.Add(r);
                 }
@@ -1724,7 +1724,7 @@ namespace ToNRoundCounter.UI
             }
         }
 
-        private void AutoSuicideUseDetailCheckBox_CheckedChanged(object sender, EventArgs e)
+        private void AutoSuicideUseDetailCheckBox_CheckedChanged(object? sender, EventArgs e)
         {
             // Use the sender if available, otherwise fall back to the field. This
             // avoids a potential NullReferenceException when the handler is
@@ -1765,7 +1765,7 @@ namespace ToNRoundCounter.UI
             }
         }
 
-        private void AutoSuicideCheckBox_CheckedChanged(object sender, EventArgs e)
+        private void AutoSuicideCheckBox_CheckedChanged(object? sender, EventArgs e)
         {
             bool enabled = autoSuicideCheckBox.Checked;
             autoSuicideUseDetailCheckBox.Visible = enabled;

--- a/UI/TerrorInfoPanel.cs
+++ b/UI/TerrorInfoPanel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -46,7 +47,7 @@ namespace ToNRoundCounter.UI
             }
         }
 
-        public void UpdateInfo(List<string> names, JObject data, int width)
+        public void UpdateInfo(List<string> names, JObject? data, int width)
         {
             flow.Controls.Clear();
             this.Width = width;
@@ -94,7 +95,7 @@ namespace ToNRoundCounter.UI
 
         }
 
-        private Control CreateCell(string name, JArray infoArray)
+        private Control CreateCell(string name, JArray? infoArray)
         {
             var cell = new TableLayoutPanel();
             cell.AutoSize = true;


### PR DESCRIPTION
## Summary
- annotate domain models, services, and infrastructure for nullable awareness to eliminate compiler warnings
- initialize WinForms controls and guard UI logic against null references
- update tests and utility code to reflect nullable return values and ensure safe usage

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d62f28a7c48329aa40021f82c44e4b