### PR TITLE
Fix nullable reference warnings across project

### DIFF
--- a/Application/MainPresenter.cs
+++ b/Application/MainPresenter.cs
@@ -105,7 +105,7 @@ namespace ToNRoundCounter.Application
 
             static string FormatInline(string? value, string fallback)
             {
-                var text = string.IsNullOrWhiteSpace(value) ? fallback : value;
+                var text = string.IsNullOrWhiteSpace(value) ? fallback : value!;
                 return text.Replace("`", "\\`");
             }
 

--- a/Domain/AutoSuicideRule.cs
+++ b/Domain/AutoSuicideRule.cs
@@ -45,15 +45,19 @@ namespace ToNRoundCounter.Domain
             bool roundNeg = false;
             if (!string.IsNullOrEmpty(roundExpr))
             {
-                roundNeg = StripNegation(ref roundExpr);
-                if (!string.IsNullOrEmpty(roundExpr) && !ValidateExpression(roundExpr)) return false;
+                string? normalizedRoundExpr = roundExpr;
+                roundNeg = StripNegation(ref normalizedRoundExpr);
+                roundExpr = normalizedRoundExpr;
+                if (!string.IsNullOrEmpty(roundExpr) && !ValidateExpression(roundExpr!)) return false;
             }
 
             bool terrorNeg = false;
             if (!string.IsNullOrEmpty(terrorExpr))
             {
-                terrorNeg = StripNegation(ref terrorExpr);
-                if (!string.IsNullOrEmpty(terrorExpr) && !ValidateExpression(terrorExpr)) return false;
+                string? normalizedTerrorExpr = terrorExpr;
+                terrorNeg = StripNegation(ref normalizedTerrorExpr);
+                terrorExpr = normalizedTerrorExpr;
+                if (!string.IsNullOrEmpty(terrorExpr) && !ValidateExpression(terrorExpr!)) return false;
             }
 
             rule = new AutoSuicideRule
@@ -109,8 +113,10 @@ namespace ToNRoundCounter.Domain
             bool roundNeg = false;
             if (!string.IsNullOrEmpty(roundExpr))
             {
-                roundNeg = StripNegation(ref roundExpr);
-                if (!string.IsNullOrEmpty(roundExpr) && !ValidateExpression(roundExpr))
+                string? normalizedRoundExpr = roundExpr;
+                roundNeg = StripNegation(ref normalizedRoundExpr);
+                roundExpr = normalizedRoundExpr;
+                if (!string.IsNullOrEmpty(roundExpr) && !ValidateExpression(roundExpr!))
                 {
                     error = "括弧の不整合や演算子の誤用";
                     return false;
@@ -120,8 +126,10 @@ namespace ToNRoundCounter.Domain
             bool terrorNeg = false;
             if (!string.IsNullOrEmpty(terrorExpr))
             {
-                terrorNeg = StripNegation(ref terrorExpr);
-                if (!string.IsNullOrEmpty(terrorExpr) && !ValidateExpression(terrorExpr))
+                string? normalizedTerrorExpr = terrorExpr;
+                terrorNeg = StripNegation(ref normalizedTerrorExpr);
+                terrorExpr = normalizedTerrorExpr;
+                if (!string.IsNullOrEmpty(terrorExpr) && !ValidateExpression(terrorExpr!))
                 {
                     error = "括弧の不整合や演算子の誤用";
                     return false;
@@ -222,7 +230,7 @@ namespace ToNRoundCounter.Domain
         private static List<string>? GetSimpleTerms(string? expr)
         {
             if (string.IsNullOrWhiteSpace(expr)) return null;
-            string working = expr.Trim();
+            string working = expr!.Trim();
             if (working.StartsWith("(") && MatchingParen(working) == working.Length - 1)
                 working = working.Substring(1, working.Length - 2);
             var parts = SplitTopLevel(working, "||").ToList();
@@ -238,7 +246,7 @@ namespace ToNRoundCounter.Domain
             if (string.IsNullOrWhiteSpace(expr))
                 return false;
 
-            expr = expr.Trim();
+            expr = expr!.Trim();
             if (!expr.StartsWith("!")) return false;
             string candidate = expr.Substring(1).Trim();
             if (candidate.StartsWith("(") && MatchingParen(candidate) == candidate.Length - 1)
@@ -360,7 +368,8 @@ namespace ToNRoundCounter.Domain
         private static bool IsSimple(string? expr)
         {
             if (string.IsNullOrEmpty(expr)) return false;
-            return !(expr.Contains("&&") || expr.Contains("||") || expr.Contains("!") || expr.Contains("(") || expr.Contains(")"));
+            string nonNullExpr = expr!;
+            return !(nonNullExpr.Contains("&&") || nonNullExpr.Contains("||") || nonNullExpr.Contains("!") || nonNullExpr.Contains("(") || nonNullExpr.Contains(")"));
         }
 
         private static List<string> SplitEscaped(string line)

--- a/Modules/AfkSoundCancelModule/AfkSoundCancelModule.cs
+++ b/Modules/AfkSoundCancelModule/AfkSoundCancelModule.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Serilog.Events;
 using ToNRoundCounter.Application;
 
+#nullable enable
+
 namespace ToNRoundCounter.Modules.AfkSoundCancel
 {
     public sealed class AfkSoundCancelModule : IModule

--- a/ToNRoundCounter.Tests/AutoSuicideCancelTests.cs
+++ b/ToNRoundCounter.Tests/AutoSuicideCancelTests.cs
@@ -21,7 +21,7 @@ namespace ToNRoundCounter.Tests
                 Assert.IsType<AutoSuicideRule>(rule2)
             };
 
-            int ShouldAutoSuicide(string roundType, string terrorName)
+            int ShouldAutoSuicide(string roundType, string? terrorName)
             {
                 for (int i = rules.Count - 1; i >= 0; i--)
                 {

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -789,7 +789,7 @@ namespace ToNRoundCounter.UI
                 string eventType = json.Value<string>("Type") ?? json.Value<string>("TYPE") ?? "Unknown";
                 _logger.LogEvent(eventType, message);
                 int command = -1;
-                if (json.TryGetValue("Command", out JToken commandToken))
+                if (json.TryGetValue("Command", out JToken? commandToken))
                 {
                     command = commandToken.Value<int>();
                 }
@@ -1506,7 +1506,7 @@ namespace ToNRoundCounter.UI
                 AppendLine(rtbStatsDisplay, roundLine, Theme.Current.Foreground);
 
                 // テラーのフィルター
-                if (_settings.Filter_Terror && stateService.TryGetTerrorAggregates(roundType, out var terrorDict))
+                if (_settings.Filter_Terror && stateService.TryGetTerrorAggregates(roundType, out var terrorDict) && terrorDict != null)
                 {
                     foreach (var terrorKvp in terrorDict)
                     {
@@ -1702,7 +1702,7 @@ namespace ToNRoundCounter.UI
                 {
                     string checkType = roundForAutoCheck.RoundType ?? string.Empty;
                     string? terror = roundForAutoCheck.TerrorKey;
-                    if (checkType == "ブラッドバス" && !string.IsNullOrEmpty(terror) && terror.Contains("LVL 3"))
+                    if (checkType == "ブラッドバス" && !string.IsNullOrEmpty(terror) && terror!.Contains("LVL 3"))
                     {
                         checkType = "EX";
                     }
@@ -1958,7 +1958,7 @@ namespace ToNRoundCounter.UI
                     var terrorKeyValue = currentRound?.TerrorKey;
                     if (!string.IsNullOrEmpty(terrorKeyValue))
                     {
-                        terrorColors[terrorKeyValue] = color;
+                        terrorColors[terrorKeyValue!] = color;
                     }
                     UpdateTerrorInfoPanel(expanded);
                     currentTerrorBaseText = InfoPanel.TerrorValue.Text;

--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -474,7 +474,7 @@ namespace ToNRoundCounter.UI
                     if (string.IsNullOrEmpty(rw.Round))
                         continue;
 
-                    var roundName = rw.Round;
+                    var roundName = rw.Round!;
                     var baseValue = rw.Value;
                     var relatedDetails = detailRules.Where(d => d.Round == roundName).ToList();
                     var exceptions = relatedDetails.Where(d => d.Value != baseValue || d.TerrorNegate).ToList();
@@ -557,7 +557,7 @@ namespace ToNRoundCounter.UI
                         {
                             rounds = string.IsNullOrEmpty(rule.RoundExpression)
                                 ? new List<string>()
-                                : new List<string> { rule.RoundExpression };
+                                : new List<string> { rule.RoundExpression! };
                         }
 
                         var terrors = rule.GetTerrorTerms();
@@ -565,7 +565,7 @@ namespace ToNRoundCounter.UI
                         {
                             terrors = string.IsNullOrEmpty(rule.TerrorExpression)
                                 ? new List<string>()
-                                : new List<string> { rule.TerrorExpression };
+                                : new List<string> { rule.TerrorExpression! };
                         }
                         bool roundBullet = ShouldBullet(rounds);
                         bool terrorBullet = ShouldBullet(terrors);
@@ -598,7 +598,7 @@ namespace ToNRoundCounter.UI
                     if (string.IsNullOrEmpty(rg.Key))
                         continue;
 
-                    var roundKey = rg.Key;
+                    var roundKey = rg.Key!;
                     if (roundsWithHeader.Add(roundKey))
                         sb.AppendLine($"{roundKey}では以下の設定が適用されています");
                     foreach (var ag in rg.GroupBy(r => r.Value))
@@ -625,7 +625,7 @@ namespace ToNRoundCounter.UI
                     if (string.IsNullOrEmpty(cg.Key))
                         continue;
 
-                    var roundKey = cg.Key;
+                    var roundKey = cg.Key!;
                     if (roundsWithHeader.Add(roundKey))
                         sb.AppendLine($"{roundKey}では以下の設定が適用されています");
                     foreach (var rule in cg)


### PR DESCRIPTION
## Summary
- normalize auto-suicide rule parsing so expression validation runs on non-null values
- guard presenter and UI helpers against null inputs when composing strings and lookups
- enable nullable annotations in modules and tests to align with nullable reference types

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6383eaeb48329bee6a9e2193d7f13