### PR TITLE
Align module builds with x64 host

### DIFF
--- a/Modules/AfkJumpModule/AfkJumpModule.csproj
+++ b/Modules/AfkJumpModule/AfkJumpModule.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Modules/AfkSoundCancelModule/AfkSoundCancelModule.csproj
+++ b/Modules/AfkSoundCancelModule/AfkSoundCancelModule.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Modules/OscRepeaterDisablerModule/OscRepeaterDisablerModule.csproj
+++ b/Modules/OscRepeaterDisablerModule/OscRepeaterDisablerModule.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- set all module projects to target x64 to match the main application's architecture

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63a6958e08329bb244b9e881eb922