### PR TITLE
Handle Mark-of-the-Web blocks when loading modules

### DIFF
--- a/Infrastructure/ModuleLoader.cs
+++ b/Infrastructure/ModuleLoader.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
 using ToNRoundCounter.Application;
 
@@ -31,7 +32,7 @@ namespace ToNRoundCounter.Infrastructure
             {
                 try
                 {
-                    var asm = Assembly.LoadFrom(file);
+                    var asm = LoadAssemblySafely(file, logger);
                     var modules = asm.GetTypes()
                         .Where(t => typeof(IModule).IsAssignableFrom(t) && !t.IsAbstract);
                     logger.LogEvent("ModuleLoader", $"Loaded assembly '{Path.GetFileName(file)}'. Discovering modules.");
@@ -52,6 +53,13 @@ namespace ToNRoundCounter.Infrastructure
                 }
                 catch (Exception ex)
                 {
+                    if (IsPotentialMarkOfTheWebBlock(ex))
+                    {
+                        logger.LogEvent(
+                            "ModuleLoader",
+                            $"Assembly '{Path.GetFileName(file)}' appears to be blocked by Windows. Right-click the file, open Properties, check 'Unblock', and restart the application.",
+                            Serilog.Events.LogEventLevel.Warning);
+                    }
                     logger.LogEvent("ModuleLoad", "Failed to load module " + file + ": " + ex.Message, Serilog.Events.LogEventLevel.Error);
                     bus.Publish(new ModuleLoadFailed(file, ex));
                 }
@@ -60,5 +68,94 @@ namespace ToNRoundCounter.Infrastructure
             host.NotifyDiscoveryCompleted();
             logger.LogEvent("ModuleLoader", "Module discovery notifications completed.");
         }
+
+        private static Assembly LoadAssemblySafely(string file, IEventLogger logger)
+        {
+            try
+            {
+                return Assembly.LoadFrom(file);
+            }
+            catch (FileLoadException ex) when (IsPotentialMarkOfTheWebBlock(ex) && TryRemoveMarkOfTheWeb(file, logger))
+            {
+                logger.LogEvent(
+                    "ModuleLoader",
+                    $"Removed Mark-of-the-Web from '{Path.GetFileName(file)}' and retrying assembly load.");
+                return Assembly.LoadFrom(file);
+            }
+        }
+
+        private static bool TryRemoveMarkOfTheWeb(string file, IEventLogger logger)
+        {
+            if (!IsWindows())
+            {
+                return false;
+            }
+
+            var zoneIdentifierStream = file + ":Zone.Identifier";
+
+            try
+            {
+                if (!DeleteFile(zoneIdentifierStream))
+                {
+                    var error = Marshal.GetLastWin32Error();
+
+                    // The stream does not exist (2 = ERROR_FILE_NOT_FOUND, 3 = ERROR_PATH_NOT_FOUND).
+                    if (error == 2 || error == 3)
+                    {
+                        return false;
+                    }
+
+                    logger.LogEvent(
+                        "ModuleLoader",
+                        $"Failed to remove Mark-of-the-Web from '{Path.GetFileName(file)}'. Win32 error code: {error}.",
+                        Serilog.Events.LogEventLevel.Debug);
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogEvent(
+                    "ModuleLoader",
+                    $"Unexpected error while removing Mark-of-the-Web from '{Path.GetFileName(file)}': {ex.Message}",
+                    Serilog.Events.LogEventLevel.Debug);
+                return false;
+            }
+        }
+
+        private static bool IsPotentialMarkOfTheWebBlock(Exception ex)
+        {
+            if (!IsWindows())
+            {
+                return false;
+            }
+
+            if (ex is FileLoadException fileLoadException)
+            {
+                var hresult = Marshal.GetHRForException(fileLoadException);
+                if (hresult == unchecked((int)0x80131515))
+                {
+                    return true;
+                }
+
+                if (fileLoadException.InnerException is NotSupportedException)
+                {
+                    return true;
+                }
+
+                if (fileLoadException.Message.IndexOf("operation is not supported", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsWindows() => Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool DeleteFile(string lpFileName);
     }
 }


### PR DESCRIPTION
## Summary
- detect when module assemblies fail to load because Windows blocked the file with Mark-of-the-Web metadata
- attempt to remove the Zone.Identifier stream automatically and retry loading the assembly
- surface guidance to manually unblock the DLL when automatic recovery is not possible

## Testing
- not run (project targets .NET Framework 4.8 and requires Windows tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d64d3eba5c832988b66a2e0d2c498c