### PR TITLE
Split overlay into individual windows

### DIFF
--- a/Application/IAppSettings.cs
+++ b/Application/IAppSettings.cs
@@ -23,6 +23,11 @@ namespace ToNRoundCounter.Application
         bool Filter_Survival { get; set; }
         bool Filter_Death { get; set; }
         bool Filter_SurvivalRate { get; set; }
+        bool OverlayShowVelocity { get; set; }
+        bool OverlayShowTerror { get; set; }
+        bool OverlayShowDamage { get; set; }
+        bool OverlayShowNextRound { get; set; }
+        bool OverlayShowRoundStatus { get; set; }
         List<string> AutoSuicideRoundTypes { get; set; }
         Dictionary<string, AutoSuicidePreset> AutoSuicidePresets { get; set; }
         List<string> AutoSuicideDetailCustom { get; set; }

--- a/Infrastructure/AppSettings.cs
+++ b/Infrastructure/AppSettings.cs
@@ -39,6 +39,11 @@ namespace ToNRoundCounter.Infrastructure
         public bool Filter_Survival { get; set; } = true;
         public bool Filter_Death { get; set; } = true;
         public bool Filter_SurvivalRate { get; set; } = true;
+        public bool OverlayShowVelocity { get; set; } = true;
+        public bool OverlayShowTerror { get; set; } = true;
+        public bool OverlayShowDamage { get; set; } = true;
+        public bool OverlayShowNextRound { get; set; } = true;
+        public bool OverlayShowRoundStatus { get; set; } = true;
         public List<string> AutoSuicideRoundTypes { get; set; } = new List<string>();
         public Dictionary<string, AutoSuicidePreset> AutoSuicidePresets { get; set; } = new Dictionary<string, AutoSuicidePreset>();
         public List<string> AutoSuicideDetailCustom { get; set; } = new List<string>();
@@ -298,6 +303,11 @@ namespace ToNRoundCounter.Infrastructure
                 Filter_Survival = Filter_Survival,
                 Filter_Death = Filter_Death,
                 Filter_SurvivalRate = Filter_SurvivalRate,
+                OverlayShowVelocity = OverlayShowVelocity,
+                OverlayShowTerror = OverlayShowTerror,
+                OverlayShowDamage = OverlayShowDamage,
+                OverlayShowNextRound = OverlayShowNextRound,
+                OverlayShowRoundStatus = OverlayShowRoundStatus,
                 RoundTypeStats = RoundTypeStats,
                 AutoSuicideEnabled = AutoSuicideEnabled,
                 AutoSuicideRoundTypes = AutoSuicideRoundTypes,
@@ -362,6 +372,11 @@ namespace ToNRoundCounter.Infrastructure
         public bool Filter_Survival { get; set; }
         public bool Filter_Death { get; set; }
         public bool Filter_SurvivalRate { get; set; }
+        public bool OverlayShowVelocity { get; set; }
+        public bool OverlayShowTerror { get; set; }
+        public bool OverlayShowDamage { get; set; }
+        public bool OverlayShowNextRound { get; set; }
+        public bool OverlayShowRoundStatus { get; set; }
         public List<string> RoundTypeStats { get; set; } = new List<string>();
         public bool AutoSuicideEnabled { get; set; }
         public List<string> AutoSuicideRoundTypes { get; set; } = new List<string>();

--- a/Infrastructure/Interop/WindowUtilities.cs
+++ b/Infrastructure/Interop/WindowUtilities.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace ToNRoundCounter.Infrastructure.Interop
+{
+    public static class WindowUtilities
+    {
+        public static bool IsProcessInForeground(string processName)
+        {
+            if (string.IsNullOrWhiteSpace(processName))
+            {
+                return false;
+            }
+
+            IntPtr foregroundWindow = GetForegroundWindow();
+            if (foregroundWindow == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            _ = GetWindowThreadProcessId(foregroundWindow, out uint processId);
+            if (processId == 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                using Process process = Process.GetProcessById((int)processId);
+                string? name = null;
+                try
+                {
+                    name = process.MainModule?.ModuleName;
+                }
+                catch
+                {
+                    name = process.ProcessName;
+                }
+
+                if (string.IsNullOrEmpty(name))
+                {
+                    return false;
+                }
+
+                string normalizedProcess = System.IO.Path.GetFileNameWithoutExtension(name);
+                return string.Equals(normalizedProcess, processName, StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        [DllImport("user32.dll")]
+        private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+    }
+}

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -132,6 +132,9 @@
     <Compile Include="UI\MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="UI\OverlaySectionForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="IsExternalInit.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/UI/MainForm.Designer.cs
+++ b/UI/MainForm.Designer.cs
@@ -20,6 +20,23 @@
                 velocityTimer?.Dispose();
                 oscListener?.Stop();
                 _cancellation.Cancel();
+                overlayVisibilityTimer?.Stop();
+                overlayVisibilityTimer?.Dispose();
+                foreach (var form in overlayForms.Values)
+                {
+                    if (form == null)
+                    {
+                        continue;
+                    }
+
+                    if (!form.IsDisposed)
+                    {
+                        form.Hide();
+                        form.Close();
+                    }
+                    form.Dispose();
+                }
+                overlayForms.Clear();
                 components?.Dispose();
             }
             base.Dispose(disposing);

--- a/UI/MainForm.OSC.cs
+++ b/UI/MainForm.OSC.cs
@@ -320,6 +320,7 @@ namespace ToNRoundCounter.UI
             _dispatcher.Invoke(() =>
             {
                 lblDebugInfo.Text = $"VelocityMagnitude: {currentVelocity:F2}  Members: {connected}";
+                UpdateOverlay(OverlaySection.Velocity, form => form.SetValue($"{currentVelocity:F2}"));
             });
         }
 

--- a/UI/OverlaySectionForm.cs
+++ b/UI/OverlaySectionForm.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace ToNRoundCounter.UI
+{
+    public class OverlaySectionForm : Form
+    {
+        private readonly Label valueLabel;
+
+        public OverlaySectionForm(string title)
+        {
+            FormBorderStyle = FormBorderStyle.None;
+            ShowInTaskbar = false;
+            TopMost = true;
+            DoubleBuffered = true;
+            BackColor = Color.FromArgb(180, 30, 30, 30);
+            ForeColor = Color.White;
+            Opacity = 0.95;
+            Padding = new Padding(12);
+            MinimumSize = new Size(240, 100);
+            ClientSize = new Size(260, 120);
+
+            var layout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 1,
+                RowCount = 2,
+                BackColor = Color.Transparent,
+            };
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            layout.RowStyles.Add(new RowStyle(SizeType.Percent, 100f));
+            Controls.Add(layout);
+
+            var titleLabel = new Label
+            {
+                Text = title,
+                Dock = DockStyle.Fill,
+                Font = new Font(Font.FontFamily, 11f, FontStyle.Bold),
+                ForeColor = Color.White,
+                Height = 28,
+                TextAlign = ContentAlignment.MiddleLeft,
+                BackColor = Color.Transparent,
+            };
+            RegisterDragEvents(titleLabel);
+            layout.Controls.Add(titleLabel, 0, 0);
+
+            valueLabel = new Label
+            {
+                Dock = DockStyle.Fill,
+                ForeColor = Color.White,
+                Font = new Font(Font.FontFamily, 16f, FontStyle.Regular),
+                AutoSize = false,
+                TextAlign = ContentAlignment.TopLeft,
+                BackColor = Color.Transparent,
+            };
+            RegisterDragEvents(valueLabel);
+            layout.Controls.Add(valueLabel, 0, 1);
+
+            RegisterDragEvents(this);
+            RegisterDragEvents(layout);
+        }
+
+        public void SetValue(string value)
+        {
+            valueLabel.Text = value ?? string.Empty;
+        }
+
+        public void EnsureTopMost()
+        {
+            if (!TopMost)
+            {
+                TopMost = true;
+            }
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            using var pen = new Pen(Color.FromArgb(200, 255, 255, 255), 1);
+            var rect = new Rectangle(0, 0, Width - 1, Height - 1);
+            e.Graphics.DrawRectangle(pen, rect);
+        }
+
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+            EnsureTopMost();
+        }
+
+        private void RegisterDragEvents(Control control)
+        {
+            control.MouseDown += (s, e) =>
+            {
+                if (e.Button == MouseButtons.Left)
+                {
+                    ReleaseCapture();
+                    _ = SendMessage(Handle, WM_NCLBUTTONDOWN, HTCAPTION, 0);
+                }
+            };
+        }
+
+        private const int WM_NCLBUTTONDOWN = 0x00A1;
+        private const int HTCAPTION = 2;
+
+        [DllImport("user32.dll")]
+        private static extern bool ReleaseCapture();
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
+    }
+}

--- a/UI/SettingsForm.cs
+++ b/UI/SettingsForm.cs
@@ -21,7 +21,7 @@ namespace ToNRoundCounter.UI
             _settings = settings;
 
             this.Text = LanguageManager.Translate("設定");
-            this.Size = new Size(1150, 1000);
+            this.Size = new Size(1850, 1000);
             this.StartPosition = FormStartPosition.CenterParent;
             InitializeComponent();
         }

--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -34,6 +34,13 @@ namespace ToNRoundCounter.UI
         public CheckBox DeathCountCheckBox { get; private set; } = null!;
         public CheckBox SurvivalRateCheckBox { get; private set; } = null!;
 
+        // オーバーレイ表示切替
+        public CheckBox OverlayVelocityCheckBox { get; private set; } = null!;
+        public CheckBox OverlayTerrorCheckBox { get; private set; } = null!;
+        public CheckBox OverlayDamageCheckBox { get; private set; } = null!;
+        public CheckBox OverlayNextRoundCheckBox { get; private set; } = null!;
+        public CheckBox OverlayRoundStatusCheckBox { get; private set; } = null!;
+
         // ラウンドログ表示切替チェックボックス
         public CheckBox ToggleRoundLogCheckBox { get; private set; } = null!;
 
@@ -102,11 +109,13 @@ namespace ToNRoundCounter.UI
 
             int margin = 10;
             int columnWidth = 540;
-            int totalWidth = columnWidth * 2 + margin * 3;
+            int totalWidth = columnWidth * 3 + margin * 4;
             this.Size = new Size(totalWidth, 1100);
 
             int currentY = margin;
             int rightColumnY = margin;
+            int thirdColumnY = margin;
+            int thirdColumnX = margin * 3 + columnWidth * 2;
             int innerMargin = 10;
 
             Label themeLabel = new Label();
@@ -703,6 +712,56 @@ namespace ToNRoundCounter.UI
 
             rightColumnY = grpAutoSuicide.Bottom + margin;
 
+            GroupBox grpOverlay = new GroupBox();
+            grpOverlay.Text = LanguageManager.Translate("オーバーレイ設定");
+            grpOverlay.Location = new Point(thirdColumnX, thirdColumnY);
+            grpOverlay.Size = new Size(columnWidth, 170);
+            this.Controls.Add(grpOverlay);
+
+            int overlayInnerMargin = 10;
+            int overlayInnerY = 25;
+
+            OverlayVelocityCheckBox = new CheckBox();
+            OverlayVelocityCheckBox.Text = LanguageManager.Translate("速度を表示");
+            OverlayVelocityCheckBox.AutoSize = true;
+            OverlayVelocityCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayVelocityCheckBox);
+
+            overlayInnerY = OverlayVelocityCheckBox.Bottom + 8;
+
+            OverlayTerrorCheckBox = new CheckBox();
+            OverlayTerrorCheckBox.Text = LanguageManager.Translate("テラーを表示");
+            OverlayTerrorCheckBox.AutoSize = true;
+            OverlayTerrorCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayTerrorCheckBox);
+
+            overlayInnerY = OverlayTerrorCheckBox.Bottom + 8;
+
+            OverlayDamageCheckBox = new CheckBox();
+            OverlayDamageCheckBox.Text = LanguageManager.Translate("ダメージを表示");
+            OverlayDamageCheckBox.AutoSize = true;
+            OverlayDamageCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayDamageCheckBox);
+
+            overlayInnerY = OverlayDamageCheckBox.Bottom + 8;
+
+            OverlayNextRoundCheckBox = new CheckBox();
+            OverlayNextRoundCheckBox.Text = LanguageManager.Translate("次ラウンド予測を表示");
+            OverlayNextRoundCheckBox.AutoSize = true;
+            OverlayNextRoundCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayNextRoundCheckBox);
+
+            overlayInnerY = OverlayNextRoundCheckBox.Bottom + 8;
+
+            OverlayRoundStatusCheckBox = new CheckBox();
+            OverlayRoundStatusCheckBox.Text = LanguageManager.Translate("ラウンド状況を表示");
+            OverlayRoundStatusCheckBox.AutoSize = true;
+            OverlayRoundStatusCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayRoundStatusCheckBox);
+
+            grpOverlay.Height = OverlayRoundStatusCheckBox.Bottom + 15;
+            thirdColumnY = grpOverlay.Bottom + margin;
+
             currentY = currentY + grpOsc.Bottom + margin;
 
             // 表示設定グループ
@@ -1239,12 +1298,12 @@ namespace ToNRoundCounter.UI
             {
                 ModuleExtensionsPanel.Width = columnWidth;
                 currentY = Math.Max(currentY, ModuleExtensionsPanel.Bottom);
-                this.Height = Math.Max(Math.Max(currentY, rightColumnY), ModuleExtensionsPanel.Bottom) + moduleMargin;
+                this.Height = Math.Max(Math.Max(currentY, rightColumnY), Math.Max(thirdColumnY, ModuleExtensionsPanel.Bottom)) + moduleMargin;
             };
 
             // 最後に、パネルの高さを調整
             this.Width = totalWidth;
-            this.Height = Math.Max(currentY, rightColumnY) + margin;
+            this.Height = Math.Max(Math.Max(currentY, rightColumnY), thirdColumnY) + margin;
 
         }
 


### PR DESCRIPTION
## Summary
- create a reusable overlay section form and register it in the project so each statistic can render in its own window
- update the main form to spin up, position, and toggle individual overlay windows based on VRChat focus and user settings
- route overlay updates (including velocity) to the corresponding window instead of a combined form

## Testing
- `dotnet build` *(fails: dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7204d376c8329b36d21250dd773d1