### PR TITLE
Remember overlay resize scale factors

### DIFF
--- a/Application/IAppSettings.cs
+++ b/Application/IAppSettings.cs
@@ -23,6 +23,19 @@ namespace ToNRoundCounter.Application
         bool Filter_Survival { get; set; }
         bool Filter_Death { get; set; }
         bool Filter_SurvivalRate { get; set; }
+        bool OverlayShowVelocity { get; set; }
+        bool OverlayShowTerror { get; set; }
+        bool OverlayShowDamage { get; set; }
+        bool OverlayShowNextRound { get; set; }
+        bool OverlayShowRoundStatus { get; set; }
+        bool OverlayShowRoundHistory { get; set; }
+        bool OverlayShowTerrorInfo { get; set; }
+        bool OverlayShowShortcuts { get; set; }
+        bool OverlayShowAngle { get; set; }
+        bool OverlayShowUnboundTerrorDetails { get; set; }
+        int OverlayRoundHistoryLength { get; set; }
+        Dictionary<string, Point> OverlayPositions { get; set; }
+        Dictionary<string, float> OverlayScaleFactors { get; set; }
         List<string> AutoSuicideRoundTypes { get; set; }
         Dictionary<string, AutoSuicidePreset> AutoSuicidePresets { get; set; }
         List<string> AutoSuicideDetailCustom { get; set; }
@@ -47,6 +60,7 @@ namespace ToNRoundCounter.Application
         string DiscordWebhookUrl { get; set; }
         string LastSaveCode { get; set; }
         bool AfkSoundCancelEnabled { get; set; }
+        bool CoordinatedAutoSuicideBrainEnabled { get; set; }
         void Load();
         Task SaveAsync();
     }

--- a/Infrastructure/AppSettings.cs
+++ b/Infrastructure/AppSettings.cs
@@ -39,6 +39,19 @@ namespace ToNRoundCounter.Infrastructure
         public bool Filter_Survival { get; set; } = true;
         public bool Filter_Death { get; set; } = true;
         public bool Filter_SurvivalRate { get; set; } = true;
+        public bool OverlayShowVelocity { get; set; } = true;
+        public bool OverlayShowTerror { get; set; } = true;
+        public bool OverlayShowDamage { get; set; } = true;
+        public bool OverlayShowNextRound { get; set; } = true;
+        public bool OverlayShowRoundStatus { get; set; } = true;
+        public bool OverlayShowRoundHistory { get; set; } = true;
+        public bool OverlayShowTerrorInfo { get; set; } = true;
+        public bool OverlayShowShortcuts { get; set; } = true;
+        public bool OverlayShowAngle { get; set; } = true;
+        public bool OverlayShowUnboundTerrorDetails { get; set; } = true;
+        public int OverlayRoundHistoryLength { get; set; } = 3;
+        public Dictionary<string, Point> OverlayPositions { get; set; } = new Dictionary<string, Point>();
+        public Dictionary<string, float> OverlayScaleFactors { get; set; } = new Dictionary<string, float>();
         public List<string> AutoSuicideRoundTypes { get; set; } = new List<string>();
         public Dictionary<string, AutoSuicidePreset> AutoSuicidePresets { get; set; } = new Dictionary<string, AutoSuicidePreset>();
         public List<string> AutoSuicideDetailCustom { get; set; } = new List<string>();
@@ -68,6 +81,7 @@ namespace ToNRoundCounter.Infrastructure
         public string DiscordWebhookUrl { get; set; } = string.Empty;
         public string LastSaveCode { get; set; } = string.Empty;
         public bool AfkSoundCancelEnabled { get; set; } = true;
+        public bool CoordinatedAutoSuicideBrainEnabled { get; set; } = true;
 
         public void Load()
         {
@@ -123,6 +137,12 @@ namespace ToNRoundCounter.Infrastructure
                     _bus.Publish(new SettingsValidated(this));
                 }
 
+                OverlayPositions ??= new Dictionary<string, Point>();
+                OverlayScaleFactors ??= new Dictionary<string, float>();
+                if (OverlayRoundHistoryLength <= 0)
+                {
+                    OverlayRoundHistoryLength = 3;
+                }
                 AutoLaunchExecutablePath ??= string.Empty;
                 AutoLaunchArguments ??= string.Empty;
                 ItemMusicItemName ??= string.Empty;
@@ -298,6 +318,18 @@ namespace ToNRoundCounter.Infrastructure
                 Filter_Survival = Filter_Survival,
                 Filter_Death = Filter_Death,
                 Filter_SurvivalRate = Filter_SurvivalRate,
+                OverlayShowVelocity = OverlayShowVelocity,
+                OverlayShowTerror = OverlayShowTerror,
+                OverlayShowDamage = OverlayShowDamage,
+                OverlayShowNextRound = OverlayShowNextRound,
+                OverlayShowRoundStatus = OverlayShowRoundStatus,
+                OverlayShowRoundHistory = OverlayShowRoundHistory,
+                OverlayShowTerrorInfo = OverlayShowTerrorInfo,
+                OverlayShowShortcuts = OverlayShowShortcuts,
+                OverlayShowAngle = OverlayShowAngle,
+                OverlayRoundHistoryLength = OverlayRoundHistoryLength,
+                OverlayPositions = OverlayPositions,
+                OverlayScaleFactors = OverlayScaleFactors,
                 RoundTypeStats = RoundTypeStats,
                 AutoSuicideEnabled = AutoSuicideEnabled,
                 AutoSuicideRoundTypes = AutoSuicideRoundTypes,
@@ -315,7 +347,8 @@ namespace ToNRoundCounter.Infrastructure
                 ItemMusicEntries = ItemMusicEntries,
                 DiscordWebhookUrl = DiscordWebhookUrl,
                 LastSaveCode = LastSaveCode,
-                AfkSoundCancelEnabled = AfkSoundCancelEnabled
+                AfkSoundCancelEnabled = AfkSoundCancelEnabled,
+                CoordinatedAutoSuicideBrainEnabled = CoordinatedAutoSuicideBrainEnabled
             };
 
             string json = JsonConvert.SerializeObject(settings, Formatting.Indented);
@@ -362,6 +395,18 @@ namespace ToNRoundCounter.Infrastructure
         public bool Filter_Survival { get; set; }
         public bool Filter_Death { get; set; }
         public bool Filter_SurvivalRate { get; set; }
+        public bool OverlayShowVelocity { get; set; }
+        public bool OverlayShowTerror { get; set; }
+        public bool OverlayShowDamage { get; set; }
+        public bool OverlayShowNextRound { get; set; }
+        public bool OverlayShowRoundStatus { get; set; }
+        public bool OverlayShowRoundHistory { get; set; }
+        public bool OverlayShowTerrorInfo { get; set; }
+        public bool OverlayShowShortcuts { get; set; }
+        public bool OverlayShowAngle { get; set; }
+        public int OverlayRoundHistoryLength { get; set; }
+        public Dictionary<string, Point> OverlayPositions { get; set; } = new Dictionary<string, Point>();
+        public Dictionary<string, float> OverlayScaleFactors { get; set; } = new Dictionary<string, float>();
         public List<string> RoundTypeStats { get; set; } = new List<string>();
         public bool AutoSuicideEnabled { get; set; }
         public List<string> AutoSuicideRoundTypes { get; set; } = new List<string>();
@@ -380,5 +425,6 @@ namespace ToNRoundCounter.Infrastructure
         public string DiscordWebhookUrl { get; set; } = string.Empty;
         public string LastSaveCode { get; set; } = string.Empty;
         public bool AfkSoundCancelEnabled { get; set; } = true;
+        public bool CoordinatedAutoSuicideBrainEnabled { get; set; } = true;
     }
 }

--- a/Infrastructure/Interop/WindowUtilities.cs
+++ b/Infrastructure/Interop/WindowUtilities.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace ToNRoundCounter.Infrastructure.Interop
+{
+    public static class WindowUtilities
+    {
+        public static bool IsProcessInForeground(string processName)
+        {
+            if (string.IsNullOrWhiteSpace(processName))
+            {
+                return false;
+            }
+
+            IntPtr foregroundWindow = GetForegroundWindow();
+            if (foregroundWindow == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            _ = GetWindowThreadProcessId(foregroundWindow, out uint processId);
+            if (processId == 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                using Process process = Process.GetProcessById((int)processId);
+                string? name = null;
+                try
+                {
+                    name = process.MainModule?.ModuleName;
+                }
+                catch
+                {
+                    name = process.ProcessName;
+                }
+
+                if (string.IsNullOrEmpty(name))
+                {
+                    return false;
+                }
+
+                string normalizedProcess = System.IO.Path.GetFileNameWithoutExtension(name);
+                return string.Equals(normalizedProcess, processName, StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static bool TryFocusProcessWindow(string processName)
+        {
+            if (string.IsNullOrWhiteSpace(processName))
+            {
+                return false;
+            }
+
+            try
+            {
+                foreach (var process in Process.GetProcessesByName(processName))
+                {
+                    using (process)
+                    {
+                        try
+                        {
+                            IntPtr handle = process.MainWindowHandle;
+                            if (handle == IntPtr.Zero)
+                            {
+                                continue;
+                            }
+
+                            if (IsIconic(handle))
+                            {
+                                _ = ShowWindow(handle, SW_RESTORE);
+                            }
+
+                            if (SetForegroundWindow(handle))
+                            {
+                                return true;
+                            }
+                        }
+                        catch
+                        {
+                        }
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+
+        public static bool TryFocusProcessWindowIfAltNotPressed(string processName)
+        {
+            if (IsAltPressed())
+            {
+                return false;
+            }
+
+            return TryFocusProcessWindow(processName);
+        }
+
+        public static bool IsAltPressed()
+        {
+            return (GetAsyncKeyState(VK_MENU) & KeyPressedFlag) != 0;
+        }
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        [DllImport("user32.dll")]
+        private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+        [DllImport("user32.dll")]
+        private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        private static extern bool IsIconic(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int vKey);
+
+        private const int SW_RESTORE = 9;
+        private const int VK_MENU = 0x12;
+        private const int KeyPressedFlag = 0x8000;
+    }
+}

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -132,6 +132,15 @@
     <Compile Include="UI\MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="UI\OverlaySectionForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\OverlayAngleForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\OverlayShortcutForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="IsExternalInit.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/UI/MainForm.Designer.cs
+++ b/UI/MainForm.Designer.cs
@@ -20,6 +20,23 @@
                 velocityTimer?.Dispose();
                 oscListener?.Stop();
                 _cancellation.Cancel();
+                overlayVisibilityTimer?.Stop();
+                overlayVisibilityTimer?.Dispose();
+                foreach (var form in overlayForms.Values)
+                {
+                    if (form == null)
+                    {
+                        continue;
+                    }
+
+                    if (!form.IsDisposed)
+                    {
+                        form.Hide();
+                        form.Close();
+                    }
+                    form.Dispose();
+                }
+                overlayForms.Clear();
                 components?.Dispose();
             }
             base.Dispose(disposing);

--- a/UI/OverlayAngleForm.cs
+++ b/UI/OverlayAngleForm.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Windows.Forms;
+
+namespace ToNRoundCounter.UI
+{
+    public class OverlayAngleForm : OverlaySectionForm
+    {
+        private readonly AngleOverlayPanel anglePanel;
+
+        public OverlayAngleForm(string title)
+            : base(title, new AngleOverlayPanel())
+        {
+            anglePanel = (AngleOverlayPanel)ContentControl;
+            MinimumSize = new Size(220, 240);
+        }
+
+        public override void SetValue(string value)
+        {
+            anglePanel.DisplayText = value ?? string.Empty;
+            AdjustSizeToContent();
+        }
+
+        public void SetAngle(float angleDegrees)
+        {
+            anglePanel.Angle = angleDegrees;
+        }
+
+        private sealed class AngleOverlayPanel : TableLayoutPanel
+        {
+            private readonly Label valueLabel;
+            private readonly AngleIndicatorControl indicator;
+
+            public AngleOverlayPanel()
+            {
+                ColumnCount = 1;
+                RowCount = 2;
+                AutoSize = true;
+                AutoSizeMode = AutoSizeMode.GrowAndShrink;
+                BackColor = Color.Transparent;
+                Margin = new Padding(0);
+                Padding = new Padding(0);
+
+                ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
+
+                RowStyles.Add(new RowStyle(SizeType.AutoSize));
+                RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+                valueLabel = new Label
+                {
+                    AutoSize = true,
+                    Font = new Font(SystemFonts.DefaultFont.FontFamily, 16f, FontStyle.Bold),
+                    ForeColor = Color.White,
+                    TextAlign = ContentAlignment.MiddleCenter,
+                    Dock = DockStyle.Top,
+                    BackColor = Color.Transparent,
+                    Margin = new Padding(0, 0, 0, 8),
+                };
+                valueLabel.Anchor = AnchorStyles.Top;
+
+                indicator = new AngleIndicatorControl
+                {
+                    Dock = DockStyle.Top,
+                    Margin = new Padding(0),
+                };
+                indicator.Anchor = AnchorStyles.Top;
+
+                Controls.Add(valueLabel, 0, 0);
+                Controls.Add(indicator, 0, 1);
+            }
+
+            public string DisplayText
+            {
+                get => valueLabel.Text;
+                set => valueLabel.Text = value ?? string.Empty;
+            }
+
+            public float Angle
+            {
+                get => indicator.Angle;
+                set => indicator.Angle = value;
+            }
+        }
+
+        private sealed class AngleIndicatorControl : Control
+        {
+            private float angle;
+
+            public AngleIndicatorControl()
+            {
+                SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer | ControlStyles.ResizeRedraw | ControlStyles.UserPaint, true);
+                BackColor = Color.Transparent;
+                Size = new Size(180, 180);
+                MinimumSize = new Size(140, 140);
+            }
+
+            public float Angle
+            {
+                get => angle;
+                set
+                {
+                    angle = value % 360f;
+                    if (angle < 0)
+                    {
+                        angle += 360f;
+                    }
+                    Invalidate();
+                }
+            }
+
+            protected override void OnPaint(PaintEventArgs e)
+            {
+                base.OnPaint(e);
+
+                Graphics g = e.Graphics;
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+
+                Rectangle rect = ClientRectangle;
+                float centerX = rect.Width / 2f;
+                float centerY = rect.Height / 2f;
+                float radius = Math.Min(rect.Width, rect.Height) / 2f - 10f;
+                if (radius <= 0)
+                {
+                    return;
+                }
+
+                using (var tickPen = new Pen(Color.FromArgb(200, Color.White), 2f))
+                {
+                    tickPen.StartCap = LineCap.Round;
+                    tickPen.EndCap = LineCap.Round;
+                    for (int i = 0; i < 12; i++)
+                    {
+                        float tickAngle = (float)(i * 30f * Math.PI / 180f);
+                        float inner = radius - 14f;
+                        float outer = radius;
+                        var innerPoint = new PointF(
+                            centerX + inner * (float)Math.Sin(tickAngle),
+                            centerY - inner * (float)Math.Cos(tickAngle));
+                        var outerPoint = new PointF(
+                            centerX + outer * (float)Math.Sin(tickAngle),
+                            centerY - outer * (float)Math.Cos(tickAngle));
+                        g.DrawLine(tickPen, innerPoint, outerPoint);
+                    }
+                }
+
+                using var crossPen = new Pen(Color.FromArgb(255, 255, 170, 60), 8f)
+                {
+                    StartCap = LineCap.Round,
+                    EndCap = LineCap.Round
+                };
+                using var pointerPen = new Pen(Color.White, 4f)
+                {
+                    StartCap = LineCap.Round,
+                    EndCap = LineCap.Round
+                };
+
+                var state = g.Save();
+                g.TranslateTransform(centerX, centerY);
+                g.RotateTransform(angle);
+                g.RotateTransform(45f);
+
+                float crossLength = radius * 0.85f;
+                g.DrawLine(crossPen, -crossLength, 0, crossLength, 0);
+                g.DrawLine(crossPen, 0, -crossLength, 0, crossLength);
+
+                g.RotateTransform(-45f);
+                float pointerLength = radius * 0.9f;
+                g.DrawLine(pointerPen, 0, 0, 0, -pointerLength);
+
+                g.Restore(state);
+
+                using var centerBrush = new SolidBrush(Color.White);
+                float hubSize = 8f;
+                g.FillEllipse(centerBrush, centerX - hubSize / 2f, centerY - hubSize / 2f, hubSize, hubSize);
+            }
+        }
+    }
+}

--- a/UI/OverlayRoundHistoryForm.cs
+++ b/UI/OverlayRoundHistoryForm.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ToNRoundCounter.UI
+{
+    public class OverlayRoundHistoryForm : OverlaySectionForm
+    {
+        private readonly TableLayoutPanel historyLayout;
+
+        public OverlayRoundHistoryForm(string title)
+            : base(title, CreateLayout())
+        {
+            historyLayout = (TableLayoutPanel)ContentControl;
+        }
+
+        private static TableLayoutPanel CreateLayout()
+        {
+            var layout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Top,
+                ColumnCount = 0,
+                RowCount = 2,
+                BackColor = Color.Transparent,
+                Padding = new Padding(0, 4, 0, 0),
+                Margin = new Padding(0),
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            };
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            return layout;
+        }
+
+        public void SetHistory(IReadOnlyList<(string Label, string Status)> entries)
+        {
+            historyLayout.SuspendLayout();
+            historyLayout.Controls.Clear();
+            historyLayout.ColumnStyles.Clear();
+            historyLayout.ColumnCount = Math.Max(entries.Count, 1);
+
+            if (entries.Count == 0)
+            {
+                historyLayout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+                var emptyLabel = CreateTypeLabel(string.Empty);
+                historyLayout.Controls.Add(emptyLabel, 0, 0);
+                var emptyStatus = CreateStatusLabel(string.Empty);
+                historyLayout.Controls.Add(emptyStatus, 0, 1);
+            }
+            else
+            {
+                for (int i = 0; i < entries.Count; i++)
+                {
+                    historyLayout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+                    var (label, status) = entries[i];
+                    var typeLabel = CreateTypeLabel(label);
+                    historyLayout.Controls.Add(typeLabel, i, 0);
+                    RegisterDragEventsRecursive(typeLabel);
+
+                    var statusLabel = CreateStatusLabel(status);
+                    historyLayout.Controls.Add(statusLabel, i, 1);
+                    RegisterDragEventsRecursive(statusLabel);
+                }
+            }
+
+            historyLayout.ResumeLayout(true);
+            AdjustSizeToContent();
+        }
+
+        private static Label CreateTypeLabel(string text)
+        {
+            return new Label
+            {
+                Text = text,
+                Dock = DockStyle.Top,
+                TextAlign = ContentAlignment.MiddleCenter,
+                ForeColor = Color.White,
+                BackColor = Color.Transparent,
+                AutoSize = true,
+                Margin = new Padding(4, 0, 4, 0),
+                Font = new Font(SystemFonts.DefaultFont.FontFamily, 15f, FontStyle.Regular),
+            };
+        }
+
+        private static Label CreateStatusLabel(string text)
+        {
+            return new Label
+            {
+                Text = text,
+                Dock = DockStyle.Top,
+                TextAlign = ContentAlignment.TopCenter,
+                ForeColor = Color.White,
+                BackColor = Color.Transparent,
+                Margin = new Padding(4, 6, 4, 0),
+                AutoSize = true,
+                Font = new Font(SystemFonts.DefaultFont.FontFamily, 12f, FontStyle.Bold),
+            };
+        }
+
+        private void RegisterDragEventsRecursive(Control control)
+        {
+            RegisterDragEvents(control);
+            foreach (Control child in control.Controls)
+            {
+                RegisterDragEventsRecursive(child);
+            }
+        }
+    }
+}

--- a/UI/OverlaySectionForm.cs
+++ b/UI/OverlaySectionForm.cs
@@ -1,0 +1,353 @@
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using ToNRoundCounter.Infrastructure.Interop;
+
+namespace ToNRoundCounter.UI
+{
+    public class OverlaySectionForm : Form
+    {
+        protected Control ContentControl { get; }
+
+        private readonly Label? valueLabel;
+        private readonly TableLayoutPanel layout;
+        private Size baseContentSize;
+        private double aspectRatio;
+        private float currentScaleFactor = 1f;
+        private float pendingScaleFactor = 1f;
+        private bool isUserResizing;
+
+        public OverlaySectionForm(string title)
+            : this(title, null)
+        {
+        }
+
+        protected OverlaySectionForm(string title, Control? content)
+        {
+            FormBorderStyle = FormBorderStyle.None;
+            ShowInTaskbar = false;
+            TopMost = false;
+            DoubleBuffered = true;
+            BackColor = Color.FromArgb(180, 30, 30, 30);
+            ForeColor = Color.White;
+            Opacity = 0.95;
+            Padding = new Padding(12);
+            MinimumSize = new Size(180, 100);
+            ClientSize = new Size(220, 120);
+            ResizeRedraw = true;
+
+            layout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 1,
+                RowCount = 2,
+                BackColor = Color.Transparent,
+                Margin = new Padding(0),
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            };
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            Controls.Add(layout);
+
+            var titleLabel = new Label
+            {
+                Text = title,
+                Dock = DockStyle.Top,
+                Font = new Font(Font.FontFamily, 11f, FontStyle.Bold),
+                ForeColor = Color.White,
+                AutoSize = true,
+                TextAlign = ContentAlignment.MiddleLeft,
+                BackColor = Color.Transparent,
+                Margin = new Padding(0, 0, 0, 6),
+            };
+            RegisterDragEvents(titleLabel);
+            layout.Controls.Add(titleLabel, 0, 0);
+
+            if (content == null)
+            {
+                valueLabel = new Label
+                {
+                    Dock = DockStyle.Top,
+                    ForeColor = Color.White,
+                    Font = new Font(Font.FontFamily, 16f, FontStyle.Regular),
+                    AutoSize = true,
+                    MaximumSize = new Size(600, 0),
+                    TextAlign = ContentAlignment.TopLeft,
+                    BackColor = Color.Transparent,
+                    Margin = new Padding(0),
+                };
+                content = valueLabel;
+            }
+
+            ContentControl = content;
+            RegisterDragEvents(ContentControl);
+            ContentControl.Dock = DockStyle.Top;
+            layout.Controls.Add(ContentControl, 0, 1);
+
+            RegisterDragEvents(this);
+            RegisterDragEvents(layout);
+            AdjustSizeToContent();
+            baseContentSize = Size;
+            aspectRatio = Size.Height == 0 ? 1d : (double)Size.Width / Size.Height;
+        }
+
+        public virtual void SetValue(string value)
+        {
+            if (valueLabel != null)
+            {
+                valueLabel.Text = value ?? string.Empty;
+            }
+
+            AdjustSizeToContent();
+        }
+
+        public float ScaleFactor
+        {
+            get => currentScaleFactor;
+            set => SetScaleFactor(value);
+        }
+
+        public void EnsureTopMost() => SetTopMostState(true);
+
+        public void SetTopMostState(bool shouldBeTopMost)
+        {
+            if (TopMost == shouldBeTopMost)
+            {
+                return;
+            }
+
+            TopMost = shouldBeTopMost;
+
+            if (shouldBeTopMost && Visible)
+            {
+                BringToFront();
+            }
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            using var pen = new Pen(Color.FromArgb(200, 255, 255, 255), 1);
+            var rect = new Rectangle(0, 0, Width - 1, Height - 1);
+            e.Graphics.DrawRectangle(pen, rect);
+            var gripRect = new Rectangle(Width - ResizeGripSize - 2, Height - ResizeGripSize - 2, ResizeGripSize, ResizeGripSize);
+            ControlPaint.DrawSizeGrip(e.Graphics, Color.Transparent, gripRect);
+        }
+
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+            EnsureTopMost();
+        }
+
+        protected void AdjustSizeToContent()
+        {
+            if (layout == null)
+            {
+                return;
+            }
+
+            layout.PerformLayout();
+            Size preferred = layout.GetPreferredSize(Size.Empty);
+            int contentWidth = Math.Max(preferred.Width, MinimumSize.Width - Padding.Horizontal);
+            int contentHeight = Math.Max(preferred.Height, MinimumSize.Height - Padding.Vertical);
+
+            Size scaledSize = new Size(contentWidth + Padding.Horizontal, contentHeight + Padding.Vertical);
+            UpdateBaseContentSize(scaledSize);
+            ApplyScaledSize();
+        }
+
+        protected void RegisterDragEvents(Control control)
+        {
+            control.MouseDown += (s, e) =>
+            {
+                if (e.Button == MouseButtons.Left && !IsInResizeGrip(control, e.Location))
+                {
+                    ReleaseCapture();
+                    _ = SendMessage(Handle, WM_NCLBUTTONDOWN, HTCAPTION, 0);
+                }
+            };
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            switch (m.Msg)
+            {
+                case WM_NCHITTEST:
+                    base.WndProc(ref m);
+                    if ((int)m.Result == HTCLIENT)
+                    {
+                        var cursorPos = PointToClient(Cursor.Position);
+                        if (cursorPos.X >= Width - ResizeGripSize && cursorPos.Y >= Height - ResizeGripSize)
+                        {
+                            m.Result = (IntPtr)HTBOTTOMRIGHT;
+                            return;
+                        }
+                    }
+                    return;
+                case WM_ENTERSIZEMOVE:
+                    isUserResizing = true;
+                    pendingScaleFactor = currentScaleFactor;
+                    break;
+                case WM_EXITSIZEMOVE:
+                    if (isUserResizing)
+                    {
+                        isUserResizing = false;
+                        SetScaleFactor(pendingScaleFactor);
+                        WindowUtilities.TryFocusProcessWindowIfAltNotPressed("VRChat");
+                    }
+                    break;
+                case WM_SIZING:
+                    if (isUserResizing)
+                    {
+                        var rect = Marshal.PtrToStructure<RECT>(m.LParam);
+                        AdjustSizingRectangle(ref rect);
+                        Marshal.StructureToPtr(rect, m.LParam, true);
+                        m.Result = IntPtr.Zero;
+                        return;
+                    }
+                    break;
+            }
+
+            base.WndProc(ref m);
+        }
+
+        private void AdjustSizingRectangle(ref RECT rect)
+        {
+            if (baseContentSize.Width <= 0 || baseContentSize.Height <= 0)
+            {
+                baseContentSize = new Size(Math.Max(Width, MinimumSize.Width), Math.Max(Height, MinimumSize.Height));
+                aspectRatio = baseContentSize.Height == 0 ? 1d : (double)baseContentSize.Width / baseContentSize.Height;
+            }
+
+            double ratio = aspectRatio <= 0 ? 1d : aspectRatio;
+            int width = rect.Right - rect.Left;
+            int clampedWidth = ClampWidthToScale(width);
+            int height = (int)Math.Round(clampedWidth / ratio);
+            rect.Right = rect.Left + clampedWidth;
+            rect.Bottom = rect.Top + height;
+
+            if (baseContentSize.Width > 0)
+            {
+                pendingScaleFactor = Math.Max(MinScaleFactor, Math.Min(MaxScaleFactor, clampedWidth / (float)baseContentSize.Width));
+            }
+        }
+
+        private int ClampWidthToScale(int width)
+        {
+            int minWidth = (int)Math.Round(baseContentSize.Width * MinScaleFactor);
+            int maxWidth = (int)Math.Round(baseContentSize.Width * MaxScaleFactor);
+            if (minWidth <= 0)
+            {
+                minWidth = baseContentSize.Width;
+            }
+            if (maxWidth <= 0)
+            {
+                maxWidth = baseContentSize.Width;
+            }
+            return Math.Max(minWidth, Math.Min(width, maxWidth));
+        }
+
+        private void UpdateBaseContentSize(Size scaledSize)
+        {
+            if (scaledSize.Width <= 0 || scaledSize.Height <= 0)
+            {
+                return;
+            }
+
+            int baseWidth = (int)Math.Round(scaledSize.Width / currentScaleFactor);
+            int baseHeight = (int)Math.Round(scaledSize.Height / currentScaleFactor);
+            baseWidth = Math.Max(baseWidth, MinimumSize.Width);
+            baseHeight = Math.Max(baseHeight, MinimumSize.Height);
+            baseContentSize = new Size(baseWidth, baseHeight);
+            aspectRatio = baseHeight == 0 ? 1d : (double)baseWidth / baseHeight;
+        }
+
+        private void ApplyScaledSize()
+        {
+            if (baseContentSize.Width <= 0 || baseContentSize.Height <= 0)
+            {
+                return;
+            }
+
+            int targetWidth = (int)Math.Round(baseContentSize.Width * currentScaleFactor);
+            int targetHeight = (int)Math.Round(baseContentSize.Height * currentScaleFactor);
+            targetWidth = Math.Max(targetWidth, MinimumSize.Width);
+            targetHeight = Math.Max(targetHeight, MinimumSize.Height);
+
+            if (Size.Width == targetWidth && Size.Height == targetHeight)
+            {
+                return;
+            }
+
+            Size = new Size(targetWidth, targetHeight);
+        }
+
+        private void SetScaleFactor(float scale)
+        {
+            scale = Math.Max(MinScaleFactor, Math.Min(MaxScaleFactor, scale));
+            if (Math.Abs(scale - currentScaleFactor) < 0.01f)
+            {
+                ApplyScaledSize();
+                return;
+            }
+
+            float relativeScale = currentScaleFactor == 0f ? scale : scale / currentScaleFactor;
+            currentScaleFactor = scale;
+
+            if (Math.Abs(relativeScale - 1f) > 0.01f)
+            {
+                Scale(new SizeF(relativeScale, relativeScale));
+                layout.PerformLayout();
+                Size preferred = layout.GetPreferredSize(Size.Empty);
+                int contentWidth = Math.Max(preferred.Width, MinimumSize.Width - Padding.Horizontal);
+                int contentHeight = Math.Max(preferred.Height, MinimumSize.Height - Padding.Vertical);
+                Size scaledSize = new Size(contentWidth + Padding.Horizontal, contentHeight + Padding.Vertical);
+                UpdateBaseContentSize(scaledSize);
+            }
+
+            ApplyScaledSize();
+        }
+
+        private bool IsInResizeGrip(Control control, Point location)
+        {
+            if (control == null)
+            {
+                return false;
+            }
+
+            Point screenPoint = control.PointToScreen(location);
+            Point formPoint = PointToClient(screenPoint);
+            return formPoint.X >= Width - ResizeGripSize && formPoint.Y >= Height - ResizeGripSize;
+        }
+
+        private const int WM_NCLBUTTONDOWN = 0x00A1;
+        private const int HTCAPTION = 2;
+        private const int WM_NCHITTEST = 0x0084;
+        private const int WM_SIZING = 0x0214;
+        private const int WM_ENTERSIZEMOVE = 0x0231;
+        private const int WM_EXITSIZEMOVE = 0x0232;
+        private const int HTCLIENT = 1;
+        private const int HTBOTTOMRIGHT = 17;
+        private const int ResizeGripSize = 16;
+        private const float MinScaleFactor = 0.6f;
+        private const float MaxScaleFactor = 2.5f;
+
+        [DllImport("user32.dll")]
+        private static extern bool ReleaseCapture();
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RECT
+        {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+        }
+    }
+}

--- a/UI/OverlayShortcutForm.cs
+++ b/UI/OverlayShortcutForm.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Windows.Forms;
+
+namespace ToNRoundCounter.UI
+{
+    public class OverlayShortcutForm : OverlaySectionForm
+    {
+        private readonly Dictionary<ShortcutButton, Button> buttons = new();
+        private readonly Color overlayBaseColor;
+        private readonly Color overlayTextColor = Color.White;
+        private readonly Color activeBackgroundColor = Color.White;
+        private readonly Dictionary<ShortcutButton, bool> toggleStates = new();
+
+        public OverlayShortcutForm(string title)
+            : base(title, CreateLayout())
+        {
+            overlayBaseColor = MakeOpaque(BackColor);
+
+            if (ContentControl is TableLayoutPanel layout)
+            {
+                layout.ColumnCount = 4;
+                layout.RowCount = 2;
+                layout.AutoSize = true;
+                layout.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+                layout.Dock = DockStyle.Fill;
+                layout.Margin = new Padding(0);
+                layout.Padding = new Padding(0);
+                layout.ColumnStyles.Clear();
+                layout.RowStyles.Clear();
+                for (int i = 0; i < 4; i++)
+                {
+                    layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+                }
+                for (int i = 0; i < 2; i++)
+                {
+                    layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+                }
+
+                AddButton(layout, ShortcutButton.AutoSuicideToggle, "自動自殺\nオン/オフ");
+                AddButton(layout, ShortcutButton.AutoSuicideCancel, "自動自殺\nキャンセル");
+                AddButton(layout, ShortcutButton.AutoSuicideDelay, "自動自殺\n遅延化");
+                AddButton(layout, ShortcutButton.ManualSuicide, "手動自殺");
+                AddButton(layout, ShortcutButton.AllRoundsModeToggle, "全ラウンド\n自殺モード");
+                AddButton(layout, ShortcutButton.CoordinatedBrainToggle, "統率された\n自爆脳");
+                AddButton(layout, ShortcutButton.AfkDetectionToggle, "AFK検知");
+                AddButton(layout, ShortcutButton.HideUntilRoundEnd, "ラウンド終わる\nまで隠す");
+            }
+
+            MinimumSize = new Size(520, 260);
+        }
+
+        public event EventHandler<ShortcutButtonEventArgs>? ShortcutClicked;
+
+        public void SetToggleState(ShortcutButton button, bool active)
+        {
+            toggleStates[button] = active;
+            ApplyButtonVisuals(button);
+        }
+
+        public void SetButtonEnabled(ShortcutButton button, bool enabled)
+        {
+            if (!buttons.TryGetValue(button, out var btn))
+            {
+                return;
+            }
+
+            btn.Enabled = enabled;
+            ApplyButtonVisuals(button);
+        }
+
+        private static TableLayoutPanel CreateLayout()
+        {
+            return new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                BackColor = Color.Transparent,
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Margin = new Padding(0),
+                Padding = new Padding(0)
+            };
+        }
+
+        private void AddButton(TableLayoutPanel layout, ShortcutButton id, string text)
+        {
+            var button = new Button
+            {
+                Text = text,
+                Dock = DockStyle.Fill,
+                FlatStyle = FlatStyle.Flat,
+                BackColor = overlayBaseColor,
+                ForeColor = overlayTextColor,
+                Font = new Font(SystemFonts.DefaultFont.FontFamily, 11f, FontStyle.Bold),
+                Margin = new Padding(8),
+                Padding = new Padding(6),
+                AutoSize = false,
+                MinimumSize = new Size(110, 110),
+                Tag = id,
+                UseVisualStyleBackColor = false,
+            };
+            button.FlatAppearance.BorderSize = 2;
+            button.FlatAppearance.BorderColor = overlayTextColor;
+            button.Click += Button_Click;
+            button.Resize += (_, _) => UpdateButtonRegion(button);
+            layout.Controls.Add(button);
+            buttons[id] = button;
+            toggleStates[id] = false;
+            UpdateButtonRegion(button);
+            ApplyButtonVisuals(id);
+        }
+
+        private void UpdateButtonRegion(Button button)
+        {
+            int diameter = Math.Min(button.Width, button.Height);
+            if (diameter <= 0)
+            {
+                return;
+            }
+
+            var bounds = new Rectangle((button.Width - diameter) / 2, (button.Height - diameter) / 2, diameter, diameter);
+            using var path = new GraphicsPath();
+            path.AddEllipse(bounds);
+            button.Region?.Dispose();
+            button.Region = new Region(path);
+        }
+
+        private void Button_Click(object? sender, EventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not ShortcutButton id)
+            {
+                return;
+            }
+
+            ShortcutClicked?.Invoke(this, new ShortcutButtonEventArgs(id));
+        }
+
+        private void ApplyButtonVisuals(ShortcutButton id)
+        {
+            if (!buttons.TryGetValue(id, out var button))
+            {
+                return;
+            }
+
+            bool isActive = toggleStates.TryGetValue(id, out var active) && active;
+            Color backgroundColor = isActive ? activeBackgroundColor : overlayBaseColor;
+            Color textColor = isActive ? overlayBaseColor : overlayTextColor;
+
+            if (!button.Enabled)
+            {
+                Color disabledBlendTarget = isActive ? overlayBaseColor : overlayTextColor;
+                backgroundColor = Blend(backgroundColor, disabledBlendTarget, 0.35f);
+                textColor = Blend(textColor, overlayTextColor, 0.4f);
+            }
+
+            button.BackColor = backgroundColor;
+            button.ForeColor = textColor;
+            button.FlatAppearance.BorderColor = textColor;
+            button.FlatAppearance.MouseOverBackColor = Blend(backgroundColor, textColor, 0.15f);
+            button.FlatAppearance.MouseDownBackColor = Blend(backgroundColor, textColor, 0.3f);
+        }
+
+        public void ResetButtons(params ShortcutButton[] buttonIds)
+        {
+            foreach (var buttonId in buttonIds)
+            {
+                if (!toggleStates.ContainsKey(buttonId))
+                {
+                    continue;
+                }
+
+                toggleStates[buttonId] = false;
+                ApplyButtonVisuals(buttonId);
+            }
+        }
+
+        private static Color Blend(Color from, Color to, float amount)
+        {
+            amount = Math.Max(0f, Math.Min(1f, amount));
+            int r = (int)Math.Round(from.R + (to.R - from.R) * amount);
+            int g = (int)Math.Round(from.G + (to.G - from.G) * amount);
+            int b = (int)Math.Round(from.B + (to.B - from.B) * amount);
+            return Color.FromArgb(255, r, g, b);
+        }
+
+        private static Color MakeOpaque(Color color)
+        {
+            return Color.FromArgb(255, color.R, color.G, color.B);
+        }
+
+        public enum ShortcutButton
+        {
+            AutoSuicideToggle,
+            AutoSuicideCancel,
+            AutoSuicideDelay,
+            ManualSuicide,
+            AllRoundsModeToggle,
+            CoordinatedBrainToggle,
+            AfkDetectionToggle,
+            HideUntilRoundEnd,
+        }
+
+        public sealed class ShortcutButtonEventArgs : EventArgs
+        {
+            public ShortcutButtonEventArgs(ShortcutButton button)
+            {
+                Button = button;
+            }
+
+            public ShortcutButton Button { get; }
+        }
+    }
+}

--- a/UI/SettingsForm.cs
+++ b/UI/SettingsForm.cs
@@ -21,7 +21,7 @@ namespace ToNRoundCounter.UI
             _settings = settings;
 
             this.Text = LanguageManager.Translate("設定");
-            this.Size = new Size(1150, 1000);
+            this.Size = new Size(1850, 1000);
             this.StartPosition = FormStartPosition.CenterParent;
             InitializeComponent();
         }

--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -34,6 +34,19 @@ namespace ToNRoundCounter.UI
         public CheckBox DeathCountCheckBox { get; private set; } = null!;
         public CheckBox SurvivalRateCheckBox { get; private set; } = null!;
 
+        // オーバーレイ表示切替
+        public CheckBox OverlayVelocityCheckBox { get; private set; } = null!;
+        public CheckBox OverlayTerrorCheckBox { get; private set; } = null!;
+        public CheckBox OverlayDamageCheckBox { get; private set; } = null!;
+        public CheckBox OverlayAngleCheckBox { get; private set; } = null!;
+        public CheckBox OverlayNextRoundCheckBox { get; private set; } = null!;
+        public CheckBox OverlayRoundStatusCheckBox { get; private set; } = null!;
+        public CheckBox OverlayRoundHistoryCheckBox { get; private set; } = null!;
+        public NumericUpDown OverlayRoundHistoryCountNumeric { get; private set; } = null!;
+        public CheckBox OverlayTerrorInfoCheckBox { get; private set; } = null!;
+        public CheckBox OverlayShortcutsCheckBox { get; private set; } = null!;
+        public CheckBox OverlayUnboundTerrorDetailsCheckBox { get; private set; } = null!;
+
         // ラウンドログ表示切替チェックボックス
         public CheckBox ToggleRoundLogCheckBox { get; private set; } = null!;
 
@@ -102,11 +115,13 @@ namespace ToNRoundCounter.UI
 
             int margin = 10;
             int columnWidth = 540;
-            int totalWidth = columnWidth * 2 + margin * 3;
+            int totalWidth = columnWidth * 3 + margin * 4;
             this.Size = new Size(totalWidth, 1100);
 
             int currentY = margin;
             int rightColumnY = margin;
+            int thirdColumnY = margin;
+            int thirdColumnX = margin * 3 + columnWidth * 2;
             int innerMargin = 10;
 
             Label themeLabel = new Label();
@@ -703,6 +718,114 @@ namespace ToNRoundCounter.UI
 
             rightColumnY = grpAutoSuicide.Bottom + margin;
 
+            GroupBox grpOverlay = new GroupBox();
+            grpOverlay.Text = LanguageManager.Translate("オーバーレイ設定");
+            grpOverlay.Location = new Point(thirdColumnX, thirdColumnY);
+            grpOverlay.Size = new Size(columnWidth, 230);
+            this.Controls.Add(grpOverlay);
+
+            int overlayInnerMargin = 10;
+            int overlayInnerY = 25;
+
+            OverlayVelocityCheckBox = new CheckBox();
+            OverlayVelocityCheckBox.Text = LanguageManager.Translate("速度を表示");
+            OverlayVelocityCheckBox.AutoSize = true;
+            OverlayVelocityCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayVelocityCheckBox);
+
+            overlayInnerY = OverlayVelocityCheckBox.Bottom + 8;
+
+            OverlayAngleCheckBox = new CheckBox();
+            OverlayAngleCheckBox.Text = LanguageManager.Translate("角度を表示");
+            OverlayAngleCheckBox.AutoSize = true;
+            OverlayAngleCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayAngleCheckBox);
+
+            overlayInnerY = OverlayAngleCheckBox.Bottom + 8;
+
+            OverlayTerrorCheckBox = new CheckBox();
+            OverlayTerrorCheckBox.Text = LanguageManager.Translate("テラーを表示");
+            OverlayTerrorCheckBox.AutoSize = true;
+            OverlayTerrorCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayTerrorCheckBox);
+
+            overlayInnerY = OverlayTerrorCheckBox.Bottom + 4;
+
+            OverlayUnboundTerrorDetailsCheckBox = new CheckBox();
+            OverlayUnboundTerrorDetailsCheckBox.Text = LanguageManager.Translate("アンバウンドのテラー内容を表示");
+            OverlayUnboundTerrorDetailsCheckBox.AutoSize = true;
+            OverlayUnboundTerrorDetailsCheckBox.Location = new Point(overlayInnerMargin + 20, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayUnboundTerrorDetailsCheckBox);
+
+            overlayInnerY = OverlayUnboundTerrorDetailsCheckBox.Bottom + 8;
+
+            OverlayDamageCheckBox = new CheckBox();
+            OverlayDamageCheckBox.Text = LanguageManager.Translate("ダメージを表示");
+            OverlayDamageCheckBox.AutoSize = true;
+            OverlayDamageCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayDamageCheckBox);
+
+            overlayInnerY = OverlayDamageCheckBox.Bottom + 8;
+
+            OverlayNextRoundCheckBox = new CheckBox();
+            OverlayNextRoundCheckBox.Text = LanguageManager.Translate("次ラウンド予測を表示");
+            OverlayNextRoundCheckBox.AutoSize = true;
+            OverlayNextRoundCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayNextRoundCheckBox);
+
+            overlayInnerY = OverlayNextRoundCheckBox.Bottom + 8;
+
+            OverlayRoundStatusCheckBox = new CheckBox();
+            OverlayRoundStatusCheckBox.Text = LanguageManager.Translate("ラウンド状況を表示");
+            OverlayRoundStatusCheckBox.AutoSize = true;
+            OverlayRoundStatusCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayRoundStatusCheckBox);
+
+            overlayInnerY = OverlayRoundStatusCheckBox.Bottom + 8;
+
+            OverlayRoundHistoryCheckBox = new CheckBox();
+            OverlayRoundHistoryCheckBox.Text = LanguageManager.Translate("ラウンドタイプ推移を表示");
+            OverlayRoundHistoryCheckBox.AutoSize = true;
+            OverlayRoundHistoryCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayRoundHistoryCheckBox);
+
+            overlayInnerY = OverlayRoundHistoryCheckBox.Bottom + 8;
+
+            var overlayHistoryCountLabel = new Label();
+            overlayHistoryCountLabel.Text = LanguageManager.Translate("履歴表示数:");
+            overlayHistoryCountLabel.AutoSize = true;
+            overlayHistoryCountLabel.Location = new Point(overlayInnerMargin + 4, overlayInnerY + 4);
+            grpOverlay.Controls.Add(overlayHistoryCountLabel);
+
+            OverlayRoundHistoryCountNumeric = new NumericUpDown();
+            OverlayRoundHistoryCountNumeric.Minimum = 1;
+            OverlayRoundHistoryCountNumeric.Maximum = 10;
+            OverlayRoundHistoryCountNumeric.Value = 3;
+            OverlayRoundHistoryCountNumeric.Location = new Point(overlayHistoryCountLabel.Right + 10, overlayInnerY);
+            OverlayRoundHistoryCountNumeric.Width = 60;
+            grpOverlay.Controls.Add(OverlayRoundHistoryCountNumeric);
+
+            overlayInnerY = OverlayRoundHistoryCountNumeric.Bottom + 8;
+
+            OverlayTerrorInfoCheckBox = new CheckBox();
+            OverlayTerrorInfoCheckBox.Text = LanguageManager.Translate("テラー詳細情報を表示");
+            OverlayTerrorInfoCheckBox.AutoSize = true;
+            OverlayTerrorInfoCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayTerrorInfoCheckBox);
+
+            overlayInnerY = OverlayTerrorInfoCheckBox.Bottom + 8;
+
+            OverlayShortcutsCheckBox = new CheckBox();
+            OverlayShortcutsCheckBox.Text = LanguageManager.Translate("ショートカットを表示");
+            OverlayShortcutsCheckBox.AutoSize = true;
+            OverlayShortcutsCheckBox.Location = new Point(overlayInnerMargin, overlayInnerY);
+            grpOverlay.Controls.Add(OverlayShortcutsCheckBox);
+
+            overlayInnerY = OverlayShortcutsCheckBox.Bottom + 8;
+
+            grpOverlay.Height = overlayInnerY + 7;
+            thirdColumnY = grpOverlay.Bottom + margin;
+
             currentY = currentY + grpOsc.Bottom + margin;
 
             // 表示設定グループ
@@ -1239,12 +1362,12 @@ namespace ToNRoundCounter.UI
             {
                 ModuleExtensionsPanel.Width = columnWidth;
                 currentY = Math.Max(currentY, ModuleExtensionsPanel.Bottom);
-                this.Height = Math.Max(Math.Max(currentY, rightColumnY), ModuleExtensionsPanel.Bottom) + moduleMargin;
+                this.Height = Math.Max(Math.Max(currentY, rightColumnY), Math.Max(thirdColumnY, ModuleExtensionsPanel.Bottom)) + moduleMargin;
             };
 
             // 最後に、パネルの高さを調整
             this.Width = totalWidth;
-            this.Height = Math.Max(currentY, rightColumnY) + margin;
+            this.Height = Math.Max(Math.Max(currentY, rightColumnY), thirdColumnY) + margin;
 
         }
 


### PR DESCRIPTION
## Summary
- persist overlay scaling ratios for each overlay window alongside their positions
- restore saved scale factors when initializing overlays and capture user resizing updates

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d7204d376c8329b36d21250dd773d1