### PR TITLE
Adjust release workflow conditional logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build-release:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'release ')
     runs-on: windows-latest
     permissions:
       contents: write
@@ -55,15 +54,15 @@ jobs:
       - name: Package
         run: Compress-Archive -Path .\bin\x64\Release\* -DestinationPath ToNRoundCounter_latest.zip
       - name: Extract version
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name == 'push' && contains(github.event.head_commit.message, 'release')
         id: get_version
         shell: bash
         run: |
           MESSAGE="${{ github.event.head_commit.message }}"
-          VERSION="${MESSAGE#release }"
+          VERSION=$(echo "$MESSAGE" | sed -n 's/.*release[[:space:]]\+//p' | head -n 1)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Create Release
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name == 'push' && contains(github.event.head_commit.message, 'release')
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
## Summary
- allow the Windows workflow to run for every push so non-release commits still build
- guard release-specific steps so they only execute when the commit message contains "release"
- improve version extraction to pull the value that follows the keyword regardless of its position in the message

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d774695c30832984e9838f5b6055af