### PR TITLE
Include interop utilities and fix timer ambiguity

### DIFF
--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Infrastructure\CancellationProvider.cs" />
     <Compile Include="Infrastructure\LanguageManager.cs" />
     <Compile Include="Infrastructure\NativeInputSender.cs" />
+    <Compile Include="Infrastructure\Interop\WindowUtilities.cs" />
     <Compile Include="Infrastructure\ErrorReporter.cs" />
     <Compile Include="Infrastructure\WinFormsDispatcher.cs" />
     <Compile Include="Infrastructure\ChannelReaderExtensions.cs" />

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -122,7 +122,7 @@ namespace ToNRoundCounter.UI
         private int terrorCountdownLastDisplayedSeconds = -1;
         private readonly Dictionary<OverlaySection, OverlaySectionForm> overlayForms = new();
         private readonly List<(string Label, string Status)> overlayRoundHistory = new();
-        private Timer? overlayVisibilityTimer;
+        private System.Windows.Forms.Timer? overlayVisibilityTimer;
         private OverlayShortcutForm? shortcutOverlayForm;
         private bool overlayTemporarilyHidden;
 
@@ -346,7 +346,7 @@ namespace ToNRoundCounter.UI
 
             ApplyOverlayRoundHistorySettings();
 
-            overlayVisibilityTimer = new Timer
+            overlayVisibilityTimer = new System.Windows.Forms.Timer
             {
                 Interval = 500
             };


### PR DESCRIPTION
## Summary
- include the interop WindowUtilities source file in the project so its namespace is available to UI code
- fully qualify the overlay visibility timer type to ensure the Windows Forms timer is used

## Testing
- not run (dotnet CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d77538770c8329b58146a1220c0ad3