### PR TITLE
Fix overlay round history build errors on older targets

### DIFF
--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -138,6 +138,9 @@
     <Compile Include="UI\OverlayAngleForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="UI\OverlayRoundHistoryForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="UI\OverlayShortcutForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -369,8 +369,10 @@ namespace ToNRoundCounter.UI
 
             bool isVrChatForeground = WindowUtilities.IsProcessInForeground("VRChat");
 
-            foreach (var (section, form) in overlayForms.ToList())
+            foreach (var kvp in overlayForms.ToList())
             {
+                var section = kvp.Key;
+                var form = kvp.Value;
                 if (form.IsDisposed)
                 {
                     overlayForms.Remove(section);
@@ -546,8 +548,10 @@ namespace ToNRoundCounter.UI
             _settings.OverlayPositions ??= new Dictionary<string, Point>();
             _settings.OverlayScaleFactors ??= new Dictionary<string, float>();
 
-            foreach (var (section, form) in overlayForms)
+            foreach (var kvp in overlayForms)
             {
+                var section = kvp.Key;
+                var form = kvp.Value;
                 if (form.IsDisposed)
                 {
                     continue;
@@ -1912,7 +1916,7 @@ namespace ToNRoundCounter.UI
 
             if (overlayRoundHistory.Count > 0)
             {
-                var last = overlayRoundHistory[^1];
+                var last = overlayRoundHistory[overlayRoundHistory.Count - 1];
                 if (last.Label == label && last.Status == status)
                 {
                     return;


### PR DESCRIPTION
## Summary
- include the overlay round history form in the project build
- replace newer tuple and index syntax with .NET Framework compatible alternatives

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7766beae48329b4b84d91778f9303