### PR TITLE
Enable nullable context in OSC repeater module

### DIFF
--- a/Modules/OscRepeaterDisablerModule/OscRepeaterDisablerModule.cs
+++ b/Modules/OscRepeaterDisablerModule/OscRepeaterDisablerModule.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Serilog.Events;
 using ToNRoundCounter.Application;
 
+#nullable enable
+
 namespace ToNRoundCounter.Modules.OscRepeaterDisabler
 {
     public sealed class OscRepeaterDisablerModule : IModule


### PR DESCRIPTION
## Summary
- enable the nullable reference type context in the OSC repeater disabler module so existing nullable annotations compile without warnings

## Testing
- dotnet build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d77ca7bd50832996a4b42e327d0770