### PR TITLE
Ensure release workflow only triggers on release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,20 +60,27 @@ jobs:
           path: |
             ToNRoundCounter_latest.zip
             ModulesPackage/**/*
-      - name: Extract version
-        if: github.event_name == 'push' && contains(github.event.head_commit.message, 'release')
-        id: get_version
+      - name: Determine release eligibility
+        if: github.event_name == 'push'
+        id: release_info
         shell: bash
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          MESSAGE="${{ github.event.head_commit.message }}"
-          VERSION=$(echo "$MESSAGE" | sed -n 's/.*release[[:space:]]\+//p' | head -n 1)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          MESSAGE="$COMMIT_MESSAGE"
+          if [[ "$MESSAGE" =~ ^release[[:space:]]+([0-9]+(\.[0-9]+)*)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Create Release
-        if: github.event_name == 'push' && contains(github.event.head_commit.message, 'release')
+        if: github.event_name == 'push' && steps.release_info.outputs.should_release == 'true'
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.get_version.outputs.version }}
-          name: ${{ steps.get_version.outputs.version }}
+          tag_name: ${{ steps.release_info.outputs.version }}
+          name: ${{ steps.release_info.outputs.version }}
           files: |
             ToNRoundCounter_latest.zip
             ModulesPackage/**/*


### PR DESCRIPTION
## Summary
- add a guard step that validates the head commit message before creating a release
- only create GitHub releases when the commit message matches `release <version>` and reuse the parsed version for tags and names

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d7dd6ee96483299881b6695237f1ce