### PR TITLE
Enable transparent overlay form backgrounds

### DIFF
--- a/UI/OverlayAngleForm.cs
+++ b/UI/OverlayAngleForm.cs
@@ -89,7 +89,13 @@ namespace ToNRoundCounter.UI
 
             public AngleIndicatorControl()
             {
-                SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer | ControlStyles.ResizeRedraw | ControlStyles.UserPaint, true);
+                SetStyle(
+                    ControlStyles.AllPaintingInWmPaint |
+                    ControlStyles.OptimizedDoubleBuffer |
+                    ControlStyles.ResizeRedraw |
+                    ControlStyles.UserPaint |
+                    ControlStyles.SupportsTransparentBackColor,
+                    true);
                 BackColor = Color.Transparent;
                 Size = new Size(180, 180);
                 MinimumSize = new Size(140, 140);

--- a/UI/OverlaySectionForm.cs
+++ b/UI/OverlaySectionForm.cs
@@ -25,6 +25,8 @@ namespace ToNRoundCounter.UI
 
         protected OverlaySectionForm(string title, Control? content)
         {
+            SetStyle(ControlStyles.SupportsTransparentBackColor, true);
+
             FormBorderStyle = FormBorderStyle.None;
             ShowInTaskbar = false;
             TopMost = false;


### PR DESCRIPTION
## Summary
- allow overlay section forms to support transparent backcolors by enabling the control style before assigning the color

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7f17309f48329b6f9c6b7cb58a772