### PR TITLE
Keep overlay visible when focused

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -380,7 +380,8 @@ namespace ToNRoundCounter.UI
                 }
 
                 bool enabled = IsOverlaySectionEnabled(section);
-                bool shouldShow = enabled && isVrChatForeground && !overlayTemporarilyHidden;
+                bool overlayHasFocus = form.ContainsFocus;
+                bool shouldShow = enabled && (isVrChatForeground || overlayHasFocus) && !overlayTemporarilyHidden;
 
                 if (shouldShow)
                 {


### PR DESCRIPTION
## Summary
- prevent overlay forms from being hidden when they currently have focus even if VRChat loses focus

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f4e4f5348329acc202b9a86626d5