### PR TITLE
Rebuild overlays with DirectX rendering

### DIFF
--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -101,6 +101,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="SharpDX" Version="4.2.0" />
+    <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />
+    <PackageReference Include="SharpDX.DirectWrite" Version="4.2.0" />
+    <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
     <PackageReference Include="Rug.Osc" Version="1.2.5" />
     <PackageReference Include="Serilog" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
@@ -144,6 +148,15 @@
     <Compile Include="UI\OverlayShortcutForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="UI\OverlayClockForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\OverlayVelocityForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\DirectX\DirectXDeviceManager.cs" />
+    <Compile Include="UI\DirectX\DirectXOverlaySurface.cs" />
+    <Compile Include="UI\DirectX\DirectXSegmentRenderer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="IsExternalInit.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/UI/DirectX/DirectXDeviceManager.cs
+++ b/UI/DirectX/DirectXDeviceManager.cs
@@ -1,0 +1,37 @@
+using System;
+using SharpDX.Direct2D1;
+using SharpDX.DirectWrite;
+
+namespace ToNRoundCounter.UI.DirectX
+{
+    internal sealed class DirectXDeviceManager : IDisposable
+    {
+        private static readonly Lazy<DirectXDeviceManager> InstanceFactory = new(() => new DirectXDeviceManager());
+
+        public static DirectXDeviceManager Instance => InstanceFactory.Value;
+
+        private bool disposed;
+
+        private DirectXDeviceManager()
+        {
+            Direct2DFactory = new Factory1(FactoryType.SingleThreaded);
+            DirectWriteFactory = new Factory();
+        }
+
+        public Factory1 Direct2DFactory { get; }
+
+        public Factory DirectWriteFactory { get; }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            DirectWriteFactory.Dispose();
+            Direct2DFactory.Dispose();
+        }
+    }
+}

--- a/UI/DirectX/DirectXOverlaySurface.cs
+++ b/UI/DirectX/DirectXOverlaySurface.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using SharpDX;
+using SharpDX.Direct2D1;
+using SharpDX.Mathematics.Interop;
+namespace ToNRoundCounter.UI.DirectX
+{
+    internal interface IDirectXOverlaySurface
+    {
+        void SetBackgroundColor(Color color);
+
+        bool HandlesChrome { get; }
+    }
+
+    internal abstract class DirectXOverlaySurface : Control, IDirectXOverlaySurface
+    {
+        private WindowRenderTarget? renderTarget;
+        private SolidColorBrush? backgroundBrush;
+        private SolidColorBrush? borderBrush;
+        private SolidColorBrush? gripBrush;
+        private RawColor4 backgroundColor = new RawColor4(0f, 0f, 0f, 0.6f);
+        private RawColor4 borderColor = new RawColor4(1f, 1f, 1f, 0.62f);
+        private Size preferredSize = new Size(220, 120);
+        private bool deviceResourcesLost;
+
+        protected DirectXOverlaySurface()
+        {
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.Opaque | ControlStyles.ResizeRedraw | ControlStyles.UserPaint, true);
+            UpdateStyles();
+            Margin = new Padding(0);
+            DoubleBuffered = false;
+        }
+
+        public Padding ContentPadding { get; set; } = new Padding(12, 10, 12, 12);
+
+        public bool HandlesChrome => true;
+
+        protected Factory1 Direct2DFactory => DirectXDeviceManager.Instance.Direct2DFactory;
+
+        protected SharpDX.DirectWrite.Factory DirectWriteFactory => DirectXDeviceManager.Instance.DirectWriteFactory;
+
+        protected WindowRenderTarget? RenderTarget => renderTarget;
+
+        protected RawRectangleF ContentRectangle
+        {
+            get
+            {
+                float left = ContentPadding.Left;
+                float top = ContentPadding.Top;
+                float right = Math.Max(left, Width - ContentPadding.Right);
+                float bottom = Math.Max(top, Height - ContentPadding.Bottom);
+                return new RawRectangleF(left, top, right, bottom);
+            }
+        }
+
+        protected virtual float CornerRadius => 14f;
+
+        protected virtual float BorderThickness => 1f;
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            deviceResourcesLost = true;
+        }
+
+        protected override void OnHandleDestroyed(EventArgs e)
+        {
+            ReleaseDeviceResources();
+            base.OnHandleDestroyed(e);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                ReleaseDeviceResources();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        protected override void OnPaintBackground(PaintEventArgs pevent)
+        {
+            // Suppress default background painting to avoid flicker.
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            Render();
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            if (renderTarget != null && !renderTarget.IsDisposed)
+            {
+                try
+                {
+                    renderTarget.Resize(new Size2(Math.Max(Width, 1), Math.Max(Height, 1)));
+                }
+                catch (SharpDXException)
+                {
+                    deviceResourcesLost = true;
+                }
+            }
+
+            Invalidate();
+        }
+
+        public override Size GetPreferredSize(Size proposedSize)
+        {
+            return preferredSize;
+        }
+
+        public void SetBackgroundColor(Color color)
+        {
+            backgroundColor = ToRawColor(color);
+            Invalidate();
+        }
+
+        protected void SetBorderColor(Color color)
+        {
+            borderColor = ToRawColor(color);
+            Invalidate();
+        }
+
+        protected void UpdatePreferredSize(Size size)
+        {
+            preferredSize = size;
+            if (AutoSize)
+            {
+                Size = preferredSize;
+            }
+        }
+
+        protected abstract void RenderOverlay(WindowRenderTarget target);
+
+        protected virtual void RenderAfterOverlay(WindowRenderTarget target)
+        {
+            // Derived classes can override if they need post overlay rendering.
+        }
+
+        protected SolidColorBrush GetBrush(ref SolidColorBrush? brush, RawColor4 color)
+        {
+            if (renderTarget == null)
+            {
+                throw new InvalidOperationException("Render target is not initialized.");
+            }
+
+            if (brush == null || brush.IsDisposed)
+            {
+                brush?.Dispose();
+                brush = new SolidColorBrush(renderTarget, color);
+            }
+            else
+            {
+                brush.Color = color;
+            }
+
+            return brush;
+        }
+
+        private void Render()
+        {
+            if (!EnsureRenderTarget())
+            {
+                return;
+            }
+
+            if (renderTarget == null)
+            {
+                return;
+            }
+
+            try
+            {
+                renderTarget.BeginDraw();
+                renderTarget.AntialiasMode = AntialiasMode.PerPrimitive;
+                renderTarget.Clear(new RawColor4(0f, 0f, 0f, 0f));
+
+                var bounds = new RawRectangleF(0f, 0f, Math.Max(0, Width), Math.Max(0, Height));
+                var rounded = new RoundedRectangle
+                {
+                    Rect = bounds,
+                    RadiusX = CornerRadius,
+                    RadiusY = CornerRadius,
+                };
+
+                SolidColorBrush background = GetBrush(ref backgroundBrush, backgroundColor);
+                renderTarget.FillRoundedRectangle(rounded, background);
+
+                RenderOverlay(renderTarget);
+
+                SolidColorBrush border = GetBrush(ref borderBrush, borderColor);
+                renderTarget.DrawRoundedRectangle(rounded, border, BorderThickness);
+
+                DrawResizeGrip(renderTarget);
+
+                RenderAfterOverlay(renderTarget);
+
+                Result result = renderTarget.EndDraw();
+                if (result.Failure)
+                {
+                    if (result == Result.RecreateTarget)
+                    {
+                        deviceResourcesLost = true;
+                    }
+                }
+                else
+                {
+                    deviceResourcesLost = false;
+                }
+            }
+            catch (SharpDXException ex)
+            {
+                if (ex.ResultCode == ResultCode.RecreateTarget || ex.ResultCode == ResultCode.DeviceRemoved)
+                {
+                    deviceResourcesLost = true;
+                }
+                else
+                {
+                    throw;
+                }
+            }
+            finally
+            {
+                if (deviceResourcesLost)
+                {
+                    ReleaseDeviceResources();
+                }
+            }
+        }
+
+        private bool EnsureRenderTarget()
+        {
+            if (renderTarget != null && !renderTarget.IsDisposed && !deviceResourcesLost)
+            {
+                return true;
+            }
+
+            ReleaseDeviceResources();
+
+            if (!IsHandleCreated)
+            {
+                return false;
+            }
+
+            var renderProps = new RenderTargetProperties(new PixelFormat(SharpDX.DXGI.Format.B8G8R8A8_UNorm, AlphaMode.Premultiplied))
+            {
+                Usage = RenderTargetUsage.None,
+            };
+
+            var hwndProps = new HwndRenderTargetProperties
+            {
+                Hwnd = Handle,
+                PixelSize = new Size2(Math.Max(Width, 1), Math.Max(Height, 1)),
+                PresentOptions = PresentOptions.Immediately,
+            };
+
+            renderTarget = new WindowRenderTarget(Direct2DFactory, renderProps, hwndProps)
+            {
+                TextAntialiasMode = TextAntialiasMode.Grayscale,
+            };
+
+            deviceResourcesLost = false;
+            return true;
+        }
+
+        private void DrawResizeGrip(WindowRenderTarget target)
+        {
+            if (Width < 4 || Height < 4)
+            {
+                return;
+            }
+
+            const float lineSpacing = 4f;
+            int lines = Math.Min(3, (int)Math.Max(0, ResizeGripSize / lineSpacing) + 1);
+            if (lines <= 0)
+            {
+                return;
+            }
+
+            SolidColorBrush brush = GetBrush(ref gripBrush, new RawColor4(1f, 1f, 1f, 0.6f));
+
+            for (int i = 0; i < lines; i++)
+            {
+                float offset = 1f + (i * lineSpacing);
+                float startX = Width - 2f - offset;
+                float startY = Height - 2f;
+                float endX = Width - 2f;
+                float endY = Height - 2f - offset;
+
+                if (startX < 0f || endY < 0f)
+                {
+                    continue;
+                }
+
+                var start = new RawVector2(startX, startY);
+                var end = new RawVector2(endX, endY);
+                target.DrawLine(start, end, brush, 1f);
+            }
+        }
+
+        private void ReleaseDeviceResources()
+        {
+            gripBrush?.Dispose();
+            gripBrush = null;
+
+            borderBrush?.Dispose();
+            borderBrush = null;
+
+            backgroundBrush?.Dispose();
+            backgroundBrush = null;
+
+            renderTarget?.Dispose();
+            renderTarget = null;
+        }
+
+        protected static RawColor4 ToRawColor(Color color)
+        {
+            const float inverse = 1f / 255f;
+            return new RawColor4(color.R * inverse, color.G * inverse, color.B * inverse, color.A * inverse);
+        }
+
+        protected const int ResizeGripSize = 16;
+    }
+}

--- a/UI/DirectX/DirectXSegmentRenderer.cs
+++ b/UI/DirectX/DirectXSegmentRenderer.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using SharpDX.Direct2D1;
+using SharpDX.Mathematics.Interop;
+
+namespace ToNRoundCounter.UI.DirectX
+{
+    internal static class DirectXSegmentRenderer
+    {
+        [Flags]
+        private enum SegmentFlags
+        {
+            None = 0,
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
+            Decimal = 1 << 7,
+        }
+
+        private struct Glyph
+        {
+            public char Symbol { get; set; }
+
+            public bool IncludeDecimal { get; set; }
+        }
+
+        private static readonly Dictionary<char, SegmentFlags> SegmentMap = new()
+        {
+            ['0'] = SegmentFlags.A | SegmentFlags.B | SegmentFlags.C | SegmentFlags.D | SegmentFlags.E | SegmentFlags.F,
+            ['1'] = SegmentFlags.B | SegmentFlags.C,
+            ['2'] = SegmentFlags.A | SegmentFlags.B | SegmentFlags.D | SegmentFlags.E | SegmentFlags.G,
+            ['3'] = SegmentFlags.A | SegmentFlags.B | SegmentFlags.C | SegmentFlags.D | SegmentFlags.G,
+            ['4'] = SegmentFlags.B | SegmentFlags.C | SegmentFlags.F | SegmentFlags.G,
+            ['5'] = SegmentFlags.A | SegmentFlags.C | SegmentFlags.D | SegmentFlags.F | SegmentFlags.G,
+            ['6'] = SegmentFlags.A | SegmentFlags.C | SegmentFlags.D | SegmentFlags.E | SegmentFlags.F | SegmentFlags.G,
+            ['7'] = SegmentFlags.A | SegmentFlags.B | SegmentFlags.C,
+            ['8'] = SegmentFlags.A | SegmentFlags.B | SegmentFlags.C | SegmentFlags.D | SegmentFlags.E | SegmentFlags.F | SegmentFlags.G,
+            ['9'] = SegmentFlags.A | SegmentFlags.B | SegmentFlags.C | SegmentFlags.D | SegmentFlags.F | SegmentFlags.G,
+            ['-'] = SegmentFlags.G,
+            [' '] = SegmentFlags.None,
+        };
+
+        private const float ColonWidthFactor = 0.4f;
+
+        public static float Measure(string text, float digitWidth, float digitSpacing)
+        {
+            var glyphs = BuildGlyphs(text);
+            if (glyphs.Count == 0)
+            {
+                return digitWidth;
+            }
+
+            float width = 0f;
+            foreach (var glyph in glyphs)
+            {
+                width += glyph.Symbol == ':' ? GetColonWidth(digitWidth) : digitWidth;
+                width += digitSpacing;
+            }
+
+            if (width > 0f)
+            {
+                width -= digitSpacing;
+            }
+
+            return width;
+        }
+
+        public static void Draw(WindowRenderTarget target, string text, RawVector2 origin, float digitWidth, float digitHeight, float digitSpacing, SolidColorBrush onBrush, SolidColorBrush offBrush)
+        {
+            var glyphs = BuildGlyphs(text);
+            if (glyphs.Count == 0)
+            {
+                return;
+            }
+
+            float x = origin.X;
+            float y = origin.Y;
+            foreach (var glyph in glyphs)
+            {
+                if (glyph.Symbol == ':')
+                {
+                    DrawColon(target, x, y, digitWidth, digitHeight, onBrush);
+                    x += GetColonWidth(digitWidth) + digitSpacing;
+                    continue;
+                }
+
+                SegmentFlags segments = GetSegmentsForSymbol(glyph.Symbol);
+                if (glyph.IncludeDecimal)
+                {
+                    segments |= SegmentFlags.Decimal;
+                }
+
+                DrawSegments(target, x, y, digitWidth, digitHeight, segments, onBrush, offBrush);
+                x += digitWidth + digitSpacing;
+            }
+        }
+
+        private static void DrawSegments(WindowRenderTarget target, float offsetX, float offsetY, float digitWidth, float digitHeight, SegmentFlags segments, SolidColorBrush onBrush, SolidColorBrush offBrush)
+        {
+            float thickness = Math.Max(2f, Math.Min(digitWidth, digitHeight) / 6f);
+            float halfThickness = thickness / 2f;
+            float horizontalLength = digitWidth - thickness;
+            float verticalLength = (digitHeight - (3f * thickness)) / 2f;
+            float middleY = offsetY + thickness + verticalLength;
+
+            var segmentA = new RawRectangleF(offsetX + halfThickness, offsetY, offsetX + halfThickness + horizontalLength, offsetY + thickness);
+            var segmentB = new RawRectangleF(offsetX + digitWidth - thickness, offsetY + thickness, offsetX + digitWidth, offsetY + thickness + verticalLength);
+            var segmentC = new RawRectangleF(offsetX + digitWidth - thickness, middleY + thickness, offsetX + digitWidth, middleY + thickness + verticalLength);
+            var segmentD = new RawRectangleF(offsetX + halfThickness, offsetY + digitHeight - thickness, offsetX + halfThickness + horizontalLength, offsetY + digitHeight);
+            var segmentE = new RawRectangleF(offsetX, middleY + thickness, offsetX + thickness, middleY + thickness + verticalLength);
+            var segmentF = new RawRectangleF(offsetX, offsetY + thickness, offsetX + thickness, offsetY + thickness + verticalLength);
+            var segmentG = new RawRectangleF(offsetX + halfThickness, middleY, offsetX + halfThickness + horizontalLength, middleY + thickness);
+            var decimalRect = new RawRectangleF(offsetX + digitWidth - thickness, offsetY + digitHeight - thickness, offsetX + digitWidth, offsetY + digitHeight);
+
+            FillSegment(target, segmentA, segments.HasFlag(SegmentFlags.A), onBrush, offBrush);
+            FillSegment(target, segmentB, segments.HasFlag(SegmentFlags.B), onBrush, offBrush);
+            FillSegment(target, segmentC, segments.HasFlag(SegmentFlags.C), onBrush, offBrush);
+            FillSegment(target, segmentD, segments.HasFlag(SegmentFlags.D), onBrush, offBrush);
+            FillSegment(target, segmentE, segments.HasFlag(SegmentFlags.E), onBrush, offBrush);
+            FillSegment(target, segmentF, segments.HasFlag(SegmentFlags.F), onBrush, offBrush);
+            FillSegment(target, segmentG, segments.HasFlag(SegmentFlags.G), onBrush, offBrush);
+
+            if (segments.HasFlag(SegmentFlags.Decimal))
+            {
+                target.FillEllipse(new Ellipse(new RawVector2(decimalRect.Right - ((decimalRect.Right - decimalRect.Left) / 2f), decimalRect.Bottom - ((decimalRect.Bottom - decimalRect.Top) / 2f)), (decimalRect.Right - decimalRect.Left) / 2f, (decimalRect.Bottom - decimalRect.Top) / 2f), onBrush);
+            }
+        }
+
+        private static void FillSegment(WindowRenderTarget target, RawRectangleF rect, bool active, SolidColorBrush onBrush, SolidColorBrush offBrush)
+        {
+            target.FillRectangle(rect, offBrush);
+            if (active)
+            {
+                target.FillRectangle(rect, onBrush);
+            }
+        }
+
+        private static void DrawColon(WindowRenderTarget target, float offsetX, float offsetY, float digitWidth, float digitHeight, SolidColorBrush brush)
+        {
+            float colonWidth = GetColonWidth(digitWidth);
+            float colonHeight = digitHeight;
+            float dotRadius = Math.Max(2f, Math.Min(colonWidth, colonHeight) / 6f);
+            float centerX = offsetX + colonWidth / 2f;
+            float topY = offsetY + digitHeight / 3f;
+            float bottomY = offsetY + (2f * digitHeight / 3f);
+
+            var topDot = new Ellipse(new RawVector2(centerX, topY), dotRadius, dotRadius);
+            var bottomDot = new Ellipse(new RawVector2(centerX, bottomY), dotRadius, dotRadius);
+
+            target.FillEllipse(topDot, brush);
+            target.FillEllipse(bottomDot, brush);
+        }
+
+        private static SegmentFlags GetSegmentsForSymbol(char symbol)
+        {
+            if (SegmentMap.TryGetValue(symbol, out SegmentFlags value))
+            {
+                return value;
+            }
+
+            return SegmentFlags.None;
+        }
+
+        private static List<Glyph> BuildGlyphs(string text)
+        {
+            var glyphs = new List<Glyph>(text?.Length ?? 0);
+            if (string.IsNullOrEmpty(text))
+            {
+                return glyphs;
+            }
+
+            foreach (char c in text)
+            {
+                if (c == '.')
+                {
+                    if (glyphs.Count > 0)
+                    {
+                        Glyph previous = glyphs[^1];
+                        previous.IncludeDecimal = true;
+                        glyphs[^1] = previous;
+                    }
+
+                    continue;
+                }
+
+                glyphs.Add(new Glyph { Symbol = c });
+            }
+
+            return glyphs;
+        }
+
+        private static float GetColonWidth(float digitWidth) => digitWidth * ColonWidthFactor;
+    }
+}

--- a/UI/MainForm.OSC.cs
+++ b/UI/MainForm.OSC.cs
@@ -26,6 +26,7 @@ namespace ToNRoundCounter.UI
         private bool hasFacingAngleMeasurement = false;
         private bool afkSoundPlayed = false;
         private bool punishSoundPlayed = false;
+        private double lastIdleSeconds = 0d;
 
         private async Task InitializeOSCRepeater()
         {
@@ -366,7 +367,7 @@ namespace ToNRoundCounter.UI
             {
                 string angleText = GetOverlayAngleDisplayText();
                 lblDebugInfo.Text = $"VelocityMagnitude: {currentVelocity:F2} (Angle: {angleText})  Members: {connected}";
-                UpdateOverlay(OverlaySection.Velocity, form => form.SetValue($"{currentVelocity:F2}"));
+                UpdateVelocityOverlay();
                 UpdateOverlay(OverlaySection.Angle, form =>
                 {
                     if (form is OverlayAngleForm angleForm)

--- a/UI/OverlayClockForm.cs
+++ b/UI/OverlayClockForm.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Drawing;
+using System.Globalization;
+using System.Windows.Forms;
+using SharpDX.DirectWrite;
+using SharpDX.Mathematics.Interop;
+using ToNRoundCounter.UI.DirectX;
+
+namespace ToNRoundCounter.UI
+{
+    public sealed class OverlayClockForm : OverlaySectionForm
+    {
+        private readonly ClockOverlaySurface clockSurface;
+
+        public OverlayClockForm(string title)
+            : base(title, new ClockOverlaySurface())
+        {
+            clockSurface = (ClockOverlaySurface)ContentControl;
+            clockSurface.Margin = new Padding(0);
+        }
+
+        public void UpdateTime(DateTimeOffset timestamp, CultureInfo culture)
+        {
+            string dayName = GetDayName(timestamp, culture);
+            string dateText = $"{timestamp:yyyy:MM:dd} ({dayName})";
+            string timeText = timestamp.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
+            clockSurface.SetClockText(dateText, timeText);
+        }
+
+        private static string GetDayName(DateTimeOffset timestamp, CultureInfo culture)
+        {
+            string dayName = culture.DateTimeFormat.GetDayName(timestamp.DayOfWeek);
+            if (dayName.EndsWith("曜日", StringComparison.Ordinal))
+            {
+                int trimmedLength = Math.Max(0, dayName.Length - 2);
+                dayName = trimmedLength > 0 ? dayName.Substring(0, trimmedLength) : dayName;
+            }
+
+            if (string.IsNullOrEmpty(dayName))
+            {
+                dayName = culture.DateTimeFormat.GetAbbreviatedDayName(timestamp.DayOfWeek);
+            }
+
+            return dayName;
+        }
+
+        private sealed class ClockOverlaySurface : DirectXOverlaySurface
+        {
+            private readonly Color dateColor = Color.White;
+            private readonly Color timeOnColor = Color.FromArgb(255, 120, 200, 255);
+            private readonly Color timeOffColor = Color.FromArgb(60, 40, 70, 90);
+            private readonly float digitWidth = 34f;
+            private readonly float digitHeight = 58f;
+            private readonly float digitSpacing = 8f;
+            private readonly float rowSpacing = 6f;
+
+            private string dateText = string.Empty;
+            private string timeText = "00:00:00";
+            private float dateTextWidth;
+            private float dateTextHeight;
+
+            private TextFormat? dateFormat;
+            private SolidColorBrush? dateBrush;
+            private SolidColorBrush? segmentOnBrush;
+            private SolidColorBrush? segmentOffBrush;
+
+            public ClockOverlaySurface()
+            {
+                AutoSize = true;
+                ContentPadding = new Padding(12, 10, 12, 12);
+                EnsureTextFormat();
+                RecalculatePreferredSize();
+            }
+
+            public void SetClockText(string date, string time)
+            {
+                dateText = date ?? string.Empty;
+                timeText = time ?? string.Empty;
+                RecalculatePreferredSize();
+                Invalidate();
+            }
+
+            protected override void OnFontChanged(EventArgs e)
+            {
+                base.OnFontChanged(e);
+                EnsureTextFormat();
+                RecalculatePreferredSize();
+            }
+
+            protected override void RenderOverlay(WindowRenderTarget target)
+            {
+                if (dateFormat == null)
+                {
+                    EnsureTextFormat();
+                }
+
+                var textBrush = GetBrush(ref dateBrush, ToRawColor(dateColor));
+                var onBrush = GetBrush(ref segmentOnBrush, ToRawColor(timeOnColor));
+                var offBrush = GetBrush(ref segmentOffBrush, ToRawColor(timeOffColor));
+
+                float x = ContentPadding.Left;
+                float y = ContentPadding.Top;
+                float availableWidth = Math.Max(0f, Width - ContentPadding.Horizontal);
+
+                if (!string.IsNullOrEmpty(dateText) && dateFormat != null && dateTextHeight > 0f)
+                {
+                    var textRect = new RawRectangleF(x, y, x + availableWidth, y + dateTextHeight);
+                    target.DrawText(dateText, dateFormat, textRect, textBrush, DrawTextOptions.None, MeasuringMode.Natural);
+                    y += dateTextHeight + rowSpacing;
+                }
+
+                DirectXSegmentRenderer.Draw(target, timeText, new RawVector2(x, y), digitWidth, digitHeight, digitSpacing, onBrush, offBrush);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    dateBrush?.Dispose();
+                    dateBrush = null;
+
+                    segmentOnBrush?.Dispose();
+                    segmentOnBrush = null;
+
+                    segmentOffBrush?.Dispose();
+                    segmentOffBrush = null;
+
+                    dateFormat?.Dispose();
+                    dateFormat = null;
+                }
+
+                base.Dispose(disposing);
+            }
+
+            private void EnsureTextFormat()
+            {
+                dateFormat?.Dispose();
+                string fontFamily = Font?.FontFamily?.Name ?? "Segoe UI";
+                dateFormat = new TextFormat(DirectWriteFactory, fontFamily, FontWeight.Regular, FontStyle.Normal, FontStretch.Normal, 12f)
+                {
+                    TextAlignment = TextAlignment.Leading,
+                    ParagraphAlignment = ParagraphAlignment.Near,
+                };
+            }
+
+            private void RecalculatePreferredSize()
+            {
+                dateTextWidth = 0f;
+                dateTextHeight = 0f;
+
+                if (dateFormat != null && !string.IsNullOrEmpty(dateText))
+                {
+                    using var layout = new TextLayout(DirectWriteFactory, dateText, dateFormat, float.MaxValue, float.MaxValue);
+                    var metrics = layout.Metrics;
+                    dateTextWidth = metrics.WidthIncludingTrailingWhitespace;
+                    dateTextHeight = metrics.Height;
+                }
+
+                float timeWidth = DirectXSegmentRenderer.Measure(timeText, digitWidth, digitSpacing);
+                float contentWidth = Math.Max(dateTextWidth, timeWidth);
+                float contentHeight = digitHeight;
+                if (dateTextHeight > 0f)
+                {
+                    contentHeight = dateTextHeight + rowSpacing + digitHeight;
+                }
+
+                int width = (int)Math.Ceiling(contentWidth + ContentPadding.Horizontal);
+                int height = (int)Math.Ceiling(contentHeight + ContentPadding.Vertical);
+                UpdatePreferredSize(new Size(width, height));
+            }
+        }
+    }
+}

--- a/UI/OverlayVelocityForm.cs
+++ b/UI/OverlayVelocityForm.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Drawing;
+using System.Globalization;
+using System.Windows.Forms;
+using SharpDX.DirectWrite;
+using SharpDX.Mathematics.Interop;
+using ToNRoundCounter.UI.DirectX;
+
+namespace ToNRoundCounter.UI
+{
+    public sealed class OverlayVelocityForm : OverlaySectionForm
+    {
+        private readonly VelocityOverlaySurface velocitySurface;
+
+        public OverlayVelocityForm(string title)
+            : base(title, new VelocityOverlaySurface())
+        {
+            velocitySurface = (VelocityOverlaySurface)ContentControl;
+            velocitySurface.Margin = new Padding(0);
+        }
+
+        public void UpdateReadings(double velocity, double idleSeconds)
+        {
+            double clampedIdle = idleSeconds < 0 ? 0 : idleSeconds;
+            string speedText = velocity.ToString("F2", CultureInfo.InvariantCulture);
+            string afkText = $"AFK: {clampedIdle:F1}秒";
+            velocitySurface.SetVelocityText(speedText, afkText);
+        }
+
+        private sealed class VelocityOverlaySurface : DirectXOverlaySurface
+        {
+            private readonly Color speedOnColor = Color.FromArgb(255, 255, 180, 70);
+            private readonly Color speedOffColor = Color.FromArgb(70, 120, 70, 20);
+            private readonly Color afkColor = Color.White;
+            private readonly float digitWidth = 34f;
+            private readonly float digitHeight = 58f;
+            private readonly float digitSpacing = 8f;
+            private readonly float rowSpacing = 6f;
+            private readonly float afkFontSize = 10.5f;
+
+            private string speedText = "0.00";
+            private string afkText = string.Empty;
+            private float afkTextWidth;
+            private float afkTextHeight;
+
+            private TextFormat? afkFormat;
+            private SolidColorBrush? speedOnBrush;
+            private SolidColorBrush? speedOffBrush;
+            private SolidColorBrush? afkBrush;
+
+            public VelocityOverlaySurface()
+            {
+                AutoSize = true;
+                ContentPadding = new Padding(12, 10, 12, 12);
+                EnsureTextFormat();
+                RecalculatePreferredSize();
+            }
+
+            public void SetVelocityText(string speed, string afk)
+            {
+                speedText = speed ?? string.Empty;
+                afkText = afk ?? string.Empty;
+                RecalculatePreferredSize();
+                Invalidate();
+            }
+
+            protected override void OnFontChanged(EventArgs e)
+            {
+                base.OnFontChanged(e);
+                EnsureTextFormat();
+                RecalculatePreferredSize();
+            }
+
+            protected override void RenderOverlay(WindowRenderTarget target)
+            {
+                if (afkFormat == null)
+                {
+                    EnsureTextFormat();
+                }
+
+                var onBrush = GetBrush(ref speedOnBrush, ToRawColor(speedOnColor));
+                var offBrush = GetBrush(ref speedOffBrush, ToRawColor(speedOffColor));
+                var afkTextBrush = GetBrush(ref afkBrush, ToRawColor(afkColor));
+
+                float x = ContentPadding.Left;
+                float y = ContentPadding.Top;
+                float availableWidth = Math.Max(0f, Width - ContentPadding.Horizontal);
+
+                DirectXSegmentRenderer.Draw(target, speedText, new RawVector2(x, y), digitWidth, digitHeight, digitSpacing, onBrush, offBrush);
+
+                if (!string.IsNullOrEmpty(afkText) && afkFormat != null && afkTextHeight > 0f)
+                {
+                    y += digitHeight + rowSpacing;
+                    var textRect = new RawRectangleF(x, y, x + availableWidth, y + afkTextHeight);
+                    target.DrawText(afkText, afkFormat, textRect, afkTextBrush, DrawTextOptions.None, MeasuringMode.Natural);
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    speedOnBrush?.Dispose();
+                    speedOnBrush = null;
+
+                    speedOffBrush?.Dispose();
+                    speedOffBrush = null;
+
+                    afkBrush?.Dispose();
+                    afkBrush = null;
+
+                    afkFormat?.Dispose();
+                    afkFormat = null;
+                }
+
+                base.Dispose(disposing);
+            }
+
+            private void EnsureTextFormat()
+            {
+                afkFormat?.Dispose();
+                string fontFamily = Font?.FontFamily?.Name ?? "Segoe UI";
+                afkFormat = new TextFormat(DirectWriteFactory, fontFamily, FontWeight.Regular, FontStyle.Normal, FontStretch.Normal, afkFontSize)
+                {
+                    TextAlignment = TextAlignment.Leading,
+                    ParagraphAlignment = ParagraphAlignment.Near,
+                };
+            }
+
+            private void RecalculatePreferredSize()
+            {
+                afkTextWidth = 0f;
+                afkTextHeight = 0f;
+
+                if (afkFormat != null && !string.IsNullOrEmpty(afkText))
+                {
+                    using var layout = new TextLayout(DirectWriteFactory, afkText, afkFormat, float.MaxValue, float.MaxValue);
+                    var metrics = layout.Metrics;
+                    afkTextWidth = metrics.WidthIncludingTrailingWhitespace;
+                    afkTextHeight = metrics.Height;
+                }
+
+                float speedWidth = DirectXSegmentRenderer.Measure(speedText, digitWidth, digitSpacing);
+                float contentWidth = Math.Max(speedWidth, afkTextWidth);
+                float contentHeight = digitHeight;
+                if (afkTextHeight > 0f)
+                {
+                    contentHeight += rowSpacing + afkTextHeight;
+                }
+
+                int width = (int)Math.Ceiling(contentWidth + ContentPadding.Horizontal);
+                int height = (int)Math.Ceiling(contentHeight + ContentPadding.Vertical);
+                UpdatePreferredSize(new Size(width, height));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SharpDX dependencies and a shared DirectX device manager with reusable overlay rendering infrastructure
- update the overlay base form to pass background opacity into DirectX surfaces while letting them handle drawing chrome
- rebuild the clock and velocity overlays to render their digital displays and text directly with Direct2D

## Testing
- dotnet build *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d80a08d760832993a45f3280083b32