### PR TITLE
Remove redundant SharpDX.DirectWrite reference

### DIFF
--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -103,7 +103,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />
-    <PackageReference Include="SharpDX.DirectWrite" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
     <PackageReference Include="Rug.Osc" Version="1.2.5" />
     <PackageReference Include="Serilog" Version="4.0.0" />


### PR DESCRIPTION
## Summary
- remove the direct SharpDX.DirectWrite package reference because it ships with SharpDX

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d86a385ea08329bd9c0937d0c47869