### PR TITLE
Fix SharpDX type references for overlays

### DIFF
--- a/UI/DirectX/DirectXDeviceManager.cs
+++ b/UI/DirectX/DirectXDeviceManager.cs
@@ -1,6 +1,8 @@
 using System;
 using SharpDX.Direct2D1;
 using SharpDX.DirectWrite;
+using D2DFactory1 = SharpDX.Direct2D1.Factory1;
+using DWFactory = SharpDX.DirectWrite.Factory;
 
 namespace ToNRoundCounter.UI.DirectX
 {
@@ -14,13 +16,13 @@ namespace ToNRoundCounter.UI.DirectX
 
         private DirectXDeviceManager()
         {
-            Direct2DFactory = new Factory1(FactoryType.SingleThreaded);
-            DirectWriteFactory = new Factory();
+            Direct2DFactory = new D2DFactory1(FactoryType.SingleThreaded);
+            DirectWriteFactory = new DWFactory();
         }
 
-        public Factory1 Direct2DFactory { get; }
+        public D2DFactory1 Direct2DFactory { get; }
 
-        public Factory DirectWriteFactory { get; }
+        public DWFactory DirectWriteFactory { get; }
 
         public void Dispose()
         {

--- a/UI/DirectX/DirectXOverlaySurface.cs
+++ b/UI/DirectX/DirectXOverlaySurface.cs
@@ -4,11 +4,12 @@ using System.Windows.Forms;
 using SharpDX;
 using SharpDX.Direct2D1;
 using SharpDX.Mathematics.Interop;
+using DrawingColor = System.Drawing.Color;
 namespace ToNRoundCounter.UI.DirectX
 {
     internal interface IDirectXOverlaySurface
     {
-        void SetBackgroundColor(Color color);
+        void SetBackgroundColor(DrawingColor color);
 
         bool HandlesChrome { get; }
     }
@@ -114,13 +115,13 @@ namespace ToNRoundCounter.UI.DirectX
             return preferredSize;
         }
 
-        public void SetBackgroundColor(Color color)
+        public void SetBackgroundColor(DrawingColor color)
         {
             backgroundColor = ToRawColor(color);
             Invalidate();
         }
 
-        protected void SetBorderColor(Color color)
+        protected void SetBorderColor(DrawingColor color)
         {
             borderColor = ToRawColor(color);
             Invalidate();
@@ -318,7 +319,7 @@ namespace ToNRoundCounter.UI.DirectX
             renderTarget = null;
         }
 
-        protected static RawColor4 ToRawColor(Color color)
+        protected static RawColor4 ToRawColor(DrawingColor color)
         {
             const float inverse = 1f / 255f;
             return new RawColor4(color.R * inverse, color.G * inverse, color.B * inverse, color.A * inverse);

--- a/UI/OverlayClockForm.cs
+++ b/UI/OverlayClockForm.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms;
+using SharpDX.Direct2D1;
 using SharpDX.DirectWrite;
 using SharpDX.Mathematics.Interop;
 using ToNRoundCounter.UI.DirectX;

--- a/UI/OverlayVelocityForm.cs
+++ b/UI/OverlayVelocityForm.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms;
+using SharpDX.Direct2D1;
 using SharpDX.DirectWrite;
 using SharpDX.Mathematics.Interop;
 using ToNRoundCounter.UI.DirectX;


### PR DESCRIPTION
## Summary
- add the missing Direct2D imports needed by the overlay renderers
- disambiguate SharpDX and System.Drawing color usage in the shared overlay base class
- alias the Direct2D and DirectWrite factories to prevent type name collisions

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d86b23d25083299cc8ef8576d97e33