### PR TITLE
Fix SharpDX build issues

### DIFF
--- a/UI/DirectX/DirectXDeviceManager.cs
+++ b/UI/DirectX/DirectXDeviceManager.cs
@@ -16,7 +16,7 @@ namespace ToNRoundCounter.UI.DirectX
 
         private DirectXDeviceManager()
         {
-            Direct2DFactory = new D2DFactory1(FactoryType.SingleThreaded);
+            Direct2DFactory = new D2DFactory1(SharpDX.Direct2D1.FactoryType.SingleThreaded);
             DirectWriteFactory = new DWFactory();
         }
 

--- a/UI/DirectX/DirectXOverlaySurface.cs
+++ b/UI/DirectX/DirectXOverlaySurface.cs
@@ -201,22 +201,13 @@ namespace ToNRoundCounter.UI.DirectX
 
                 RenderAfterOverlay(renderTarget);
 
-                Result result = renderTarget.EndDraw();
-                if (result.Failure)
-                {
-                    if (result == Result.RecreateTarget)
-                    {
-                        deviceResourcesLost = true;
-                    }
-                }
-                else
-                {
-                    deviceResourcesLost = false;
-                }
+                renderTarget.EndDraw();
+                deviceResourcesLost = false;
             }
             catch (SharpDXException ex)
             {
-                if (ex.ResultCode == ResultCode.RecreateTarget || ex.ResultCode == ResultCode.DeviceRemoved)
+                if (ex.ResultCode == SharpDX.Direct2D1.ResultCode.RecreateTarget ||
+                    ex.ResultCode == SharpDX.DXGI.ResultCode.DeviceRemoved)
                 {
                     deviceResourcesLost = true;
                 }

--- a/UI/DirectX/DirectXSegmentRenderer.cs
+++ b/UI/DirectX/DirectXSegmentRenderer.cs
@@ -179,9 +179,10 @@ namespace ToNRoundCounter.UI.DirectX
                 {
                     if (glyphs.Count > 0)
                     {
-                        Glyph previous = glyphs[^1];
+                        int previousIndex = glyphs.Count - 1;
+                        Glyph previous = glyphs[previousIndex];
                         previous.IncludeDecimal = true;
-                        glyphs[^1] = previous;
+                        glyphs[previousIndex] = previous;
                     }
 
                     continue;

--- a/UI/OverlayClockForm.cs
+++ b/UI/OverlayClockForm.cs
@@ -6,6 +6,7 @@ using SharpDX.Direct2D1;
 using SharpDX.DirectWrite;
 using SharpDX.Mathematics.Interop;
 using ToNRoundCounter.UI.DirectX;
+using DWFontStyle = SharpDX.DirectWrite.FontStyle;
 
 namespace ToNRoundCounter.UI
 {
@@ -137,7 +138,7 @@ namespace ToNRoundCounter.UI
             {
                 dateFormat?.Dispose();
                 string fontFamily = Font?.FontFamily?.Name ?? "Segoe UI";
-                dateFormat = new TextFormat(DirectWriteFactory, fontFamily, FontWeight.Regular, FontStyle.Normal, FontStretch.Normal, 12f)
+                dateFormat = new TextFormat(DirectWriteFactory, fontFamily, FontWeight.Regular, DWFontStyle.Normal, FontStretch.Normal, 12f)
                 {
                     TextAlignment = TextAlignment.Leading,
                     ParagraphAlignment = ParagraphAlignment.Near,

--- a/UI/OverlayVelocityForm.cs
+++ b/UI/OverlayVelocityForm.cs
@@ -6,6 +6,7 @@ using SharpDX.Direct2D1;
 using SharpDX.DirectWrite;
 using SharpDX.Mathematics.Interop;
 using ToNRoundCounter.UI.DirectX;
+using DWFontStyle = SharpDX.DirectWrite.FontStyle;
 
 namespace ToNRoundCounter.UI
 {
@@ -121,7 +122,7 @@ namespace ToNRoundCounter.UI
             {
                 afkFormat?.Dispose();
                 string fontFamily = Font?.FontFamily?.Name ?? "Segoe UI";
-                afkFormat = new TextFormat(DirectWriteFactory, fontFamily, FontWeight.Regular, FontStyle.Normal, FontStretch.Normal, afkFontSize)
+                afkFormat = new TextFormat(DirectWriteFactory, fontFamily, FontWeight.Regular, DWFontStyle.Normal, FontStretch.Normal, afkFontSize)
                 {
                     TextAlignment = TextAlignment.Leading,
                     ParagraphAlignment = ParagraphAlignment.Near,


### PR DESCRIPTION
## Summary
- update the DirectX overlay surface to handle EndDraw without relying on removed Result codes
- remove use of C# index-from-end syntax in the segment renderer for compatibility with older compilers
- disambiguate SharpDX enums and factory creation to avoid ambiguous references during build

## Testing
- not run (dotnet CLI is unavailable in CI image)


------
https://chatgpt.com/codex/tasks/task_e_68d86c4e9bc08329b9ff50b6fb12dddd