### PR TITLE
Adjust overlay visuals and disable angle gauge

### DIFF
--- a/UI/DirectX/DirectXOverlaySurface.cs
+++ b/UI/DirectX/DirectXOverlaySurface.cs
@@ -18,10 +18,8 @@ namespace ToNRoundCounter.UI.DirectX
     {
         private WindowRenderTarget? renderTarget;
         private SolidColorBrush? backgroundBrush;
-        private SolidColorBrush? borderBrush;
         private SolidColorBrush? gripBrush;
         private RawColor4 backgroundColor = new RawColor4(0f, 0f, 0f, 0.6f);
-        private RawColor4 borderColor = new RawColor4(1f, 1f, 1f, 0.62f);
         private Size preferredSize = new Size(220, 120);
         private bool deviceResourcesLost;
 
@@ -56,8 +54,6 @@ namespace ToNRoundCounter.UI.DirectX
         }
 
         protected virtual float CornerRadius => 14f;
-
-        protected virtual float BorderThickness => 1f;
 
         protected override void OnHandleCreated(EventArgs e)
         {
@@ -118,12 +114,6 @@ namespace ToNRoundCounter.UI.DirectX
         public void SetBackgroundColor(DrawingColor color)
         {
             backgroundColor = ToRawColor(color);
-            Invalidate();
-        }
-
-        protected void SetBorderColor(DrawingColor color)
-        {
-            borderColor = ToRawColor(color);
             Invalidate();
         }
 
@@ -193,9 +183,6 @@ namespace ToNRoundCounter.UI.DirectX
                 renderTarget.FillRoundedRectangle(rounded, background);
 
                 RenderOverlay(renderTarget);
-
-                SolidColorBrush border = GetBrush(ref borderBrush, borderColor);
-                renderTarget.DrawRoundedRectangle(rounded, border, BorderThickness);
 
                 DrawResizeGrip(renderTarget);
 
@@ -299,9 +286,6 @@ namespace ToNRoundCounter.UI.DirectX
         {
             gripBrush?.Dispose();
             gripBrush = null;
-
-            borderBrush?.Dispose();
-            borderBrush = null;
 
             backgroundBrush?.Dispose();
             backgroundBrush = null;

--- a/UI/MainForm.OSC.cs
+++ b/UI/MainForm.OSC.cs
@@ -352,34 +352,12 @@ namespace ToNRoundCounter.UI
             }
 
             currentVelocity = Math.Abs(receivedVelocityMagnitude);
-            float planarMagnitudeSquared = (currentVelocityX * currentVelocityX) + (currentVelocityZ * currentVelocityZ);
-            if (planarMagnitudeSquared > 0.0001f)
-            {
-                double rawAngle = Math.Atan2(currentVelocityX, currentVelocityZ) * (180.0 / Math.PI);
-                double normalizedAngle = (rawAngle + 360.0) % 360.0;
-
-                lastKnownFacingAngle = (float)normalizedAngle;
-                hasFacingAngleMeasurement = true;
-            }
-
             _logger.LogEvent("Receive: ", $"{message.Address} => Computed Velocity: {currentVelocity:F2}");
             _dispatcher.Invoke(() =>
             {
-                string angleText = GetOverlayAngleDisplayText();
-                lblDebugInfo.Text = $"VelocityMagnitude: {currentVelocity:F2} (Angle: {angleText})  Members: {connected}";
+                hasFacingAngleMeasurement = false;
+                lblDebugInfo.Text = $"VelocityMagnitude: {currentVelocity:F2}  Members: {connected}";
                 UpdateVelocityOverlay();
-                UpdateOverlay(OverlaySection.Angle, form =>
-                {
-                    if (form is OverlayAngleForm angleForm)
-                    {
-                        angleForm.SetAngle(lastKnownFacingAngle);
-                        angleForm.SetValue(angleText);
-                    }
-                    else
-                    {
-                        form.SetValue(angleText);
-                    }
-                });
             });
         }
 

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -269,8 +269,7 @@ namespace ToNRoundCounter.UI
 
             var sections = new (OverlaySection Section, string Title, string InitialValue)[]
             {
-                (OverlaySection.Velocity, "速度", $"{currentVelocity:F2}"),
-                (OverlaySection.Angle, "角度", GetOverlayAngleDisplayText()),
+                (OverlaySection.Velocity, "速度", currentVelocity.ToString("00.00", CultureInfo.InvariantCulture)),
                 (OverlaySection.Terror, "テラー", GetOverlayTerrorDisplayText()),
                 (OverlaySection.Damage, "ダメージ", InfoPanel?.DamageValue?.Text ?? string.Empty),
                 (OverlaySection.NextRound, "次ラウンド予測", InfoPanel?.NextRoundType?.Text ?? string.Empty),
@@ -305,10 +304,6 @@ namespace ToNRoundCounter.UI
                     {
                         StartPosition = FormStartPosition.Manual,
                     },
-                    OverlaySection.Angle => new OverlayAngleForm(title)
-                    {
-                        StartPosition = FormStartPosition.Manual,
-                    },
                     _ => new OverlaySectionForm(title)
                     {
                         StartPosition = FormStartPosition.Manual,
@@ -339,11 +334,6 @@ namespace ToNRoundCounter.UI
                 else
                 {
                     form.SetValue(initialValue);
-                }
-
-                if (section == OverlaySection.Angle && form is OverlayAngleForm angleForm)
-                {
-                    angleForm.SetAngle(lastKnownFacingAngle);
                 }
 
                 if (_settings.OverlayScaleFactors.TryGetValue(key, out var savedScale) && savedScale > 0f)
@@ -662,7 +652,7 @@ namespace ToNRoundCounter.UI
 
         private void UpdateVelocityOverlay()
         {
-            string fallback = $"{currentVelocity:F2}\nAFK: {lastIdleSeconds:F1}秒";
+            string fallback = $"{currentVelocity.ToString("00.00", CultureInfo.InvariantCulture)}\nAFK: {lastIdleSeconds:F1}秒";
 
             UpdateOverlay(OverlaySection.Velocity, form =>
             {
@@ -768,7 +758,7 @@ namespace ToNRoundCounter.UI
             return section switch
             {
                 OverlaySection.Velocity => _settings.OverlayShowVelocity,
-                OverlaySection.Angle => _settings.OverlayShowAngle,
+                OverlaySection.Angle => false,
                 OverlaySection.Terror => _settings.OverlayShowTerror,
                 OverlaySection.Damage => _settings.OverlayShowDamage,
                 OverlaySection.NextRound => _settings.OverlayShowNextRound,
@@ -1025,7 +1015,8 @@ namespace ToNRoundCounter.UI
                 settingsForm.SettingsPanel.DeathCountCheckBox.Checked = _settings.Filter_Death;
                 settingsForm.SettingsPanel.SurvivalRateCheckBox.Checked = _settings.Filter_SurvivalRate;
                 settingsForm.SettingsPanel.OverlayVelocityCheckBox.Checked = _settings.OverlayShowVelocity;
-                settingsForm.SettingsPanel.OverlayAngleCheckBox.Checked = _settings.OverlayShowAngle;
+                settingsForm.SettingsPanel.OverlayAngleCheckBox.Checked = false;
+                settingsForm.SettingsPanel.OverlayAngleCheckBox.Enabled = false;
                 settingsForm.SettingsPanel.OverlayTerrorCheckBox.Checked = _settings.OverlayShowTerror;
                 settingsForm.SettingsPanel.OverlayUnboundTerrorDetailsCheckBox.Checked = _settings.OverlayShowUnboundTerrorDetails;
                 settingsForm.SettingsPanel.OverlayDamageCheckBox.Checked = _settings.OverlayShowDamage;
@@ -1089,7 +1080,7 @@ namespace ToNRoundCounter.UI
                     _settings.Filter_Death = settingsForm.SettingsPanel.DeathCountCheckBox.Checked;
                     _settings.Filter_SurvivalRate = settingsForm.SettingsPanel.SurvivalRateCheckBox.Checked;
                     _settings.OverlayShowVelocity = settingsForm.SettingsPanel.OverlayVelocityCheckBox.Checked;
-                    _settings.OverlayShowAngle = settingsForm.SettingsPanel.OverlayAngleCheckBox.Checked;
+                    _settings.OverlayShowAngle = false;
                     _settings.OverlayShowTerror = settingsForm.SettingsPanel.OverlayTerrorCheckBox.Checked;
                     _settings.OverlayShowUnboundTerrorDetails = settingsForm.SettingsPanel.OverlayUnboundTerrorDetailsCheckBox.Checked;
                     _settings.OverlayShowDamage = settingsForm.SettingsPanel.OverlayDamageCheckBox.Checked;

--- a/UI/OverlaySectionForm.cs
+++ b/UI/OverlaySectionForm.cs
@@ -48,8 +48,8 @@ namespace ToNRoundCounter.UI
             ShowInTaskbar = false;
             TopMost = false;
             DoubleBuffered = true;
-            baseBackgroundColor = Color.FromArgb(30, 30, 30);
-            BackColor = Color.Transparent;
+            baseBackgroundColor = Color.Black;
+            BackColor = baseBackgroundColor;
             ForeColor = Color.White;
             Padding = new Padding(12);
             MinimumSize = new Size(180, 100);
@@ -61,29 +61,14 @@ namespace ToNRoundCounter.UI
             {
                 Dock = DockStyle.Fill,
                 ColumnCount = 1,
-                RowCount = 2,
+                RowCount = 1,
                 BackColor = Color.Transparent,
                 Margin = new Padding(0),
                 AutoSize = true,
                 AutoSizeMode = AutoSizeMode.GrowAndShrink,
             };
             layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
             Controls.Add(layout);
-
-            var titleLabel = new Label
-            {
-                Text = title,
-                Dock = DockStyle.Top,
-                Font = new Font(Font.FontFamily, 11f, FontStyle.Bold),
-                ForeColor = Color.White,
-                AutoSize = true,
-                TextAlign = ContentAlignment.MiddleLeft,
-                BackColor = Color.Transparent,
-                Margin = new Padding(0, 0, 0, 6),
-            };
-            RegisterDragEvents(titleLabel);
-            layout.Controls.Add(titleLabel, 0, 0);
 
             if (content == null)
             {
@@ -104,7 +89,7 @@ namespace ToNRoundCounter.UI
             ContentControl = content;
             RegisterDragEvents(ContentControl);
             ConfigureContentControl();
-            layout.Controls.Add(ContentControl, 0, 1);
+            layout.Controls.Add(ContentControl, 0, 0);
 
             RegisterDragEvents(this);
             RegisterDragEvents(layout);
@@ -154,9 +139,8 @@ namespace ToNRoundCounter.UI
             }
 
             backgroundOpacity = clamped;
-            int alpha = (int)Math.Round(backgroundOpacity * 255d);
-            alpha = Math.Max(0, Math.Min(255, alpha));
-            Color overlayColor = Color.FromArgb(alpha, baseBackgroundColor);
+            Opacity = clamped;
+            Color overlayColor = baseBackgroundColor;
             BackColor = overlayColor;
 
             if (ContentControl is IDirectXOverlaySurface directXSurface)
@@ -200,15 +184,6 @@ namespace ToNRoundCounter.UI
             if (ContentControl is IDirectXOverlaySurface directXSurface && directXSurface.HandlesChrome)
             {
                 return;
-            }
-
-            using var pen = new Pen(Color.FromArgb(160, 255, 255, 255), 1);
-            e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
-
-            if (Width > 1 && Height > 1)
-            {
-                using GraphicsPath borderPath = CreateRoundedRectanglePath(new Rectangle(0, 0, Width - 1, Height - 1), CornerRadius);
-                e.Graphics.DrawPath(pen, borderPath);
             }
 
             DrawResizeGrip(e.Graphics);

--- a/UI/OverlayVelocityForm.cs
+++ b/UI/OverlayVelocityForm.cs
@@ -24,7 +24,7 @@ namespace ToNRoundCounter.UI
         public void UpdateReadings(double velocity, double idleSeconds)
         {
             double clampedIdle = idleSeconds < 0 ? 0 : idleSeconds;
-            string speedText = velocity.ToString("F2", CultureInfo.InvariantCulture);
+            string speedText = velocity.ToString("00.00", CultureInfo.InvariantCulture);
             string afkText = $"AFK: {clampedIdle:F1}秒";
             velocitySurface.SetVelocityText(speedText, afkText);
         }
@@ -40,7 +40,7 @@ namespace ToNRoundCounter.UI
             private readonly float rowSpacing = 6f;
             private readonly float afkFontSize = 10.5f;
 
-            private string speedText = "0.00";
+            private string speedText = "00.00";
             private string afkText = string.Empty;
             private float afkTextWidth;
             private float afkTextHeight;


### PR DESCRIPTION
## Summary
- remove overlay titles and frames while switching to a black background that honors the configured opacity
- disable the angle overlay and its OSC-facing computations while leaving the setting unavailable
- format the velocity overlay text with two integer digits and two decimal places

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d87b0f627883298bf83b478c9b463c