### PR TITLE
Adjust overlay minimum size constraints

### DIFF
--- a/UI/OverlaySectionForm.cs
+++ b/UI/OverlaySectionForm.cs
@@ -52,8 +52,8 @@ namespace ToNRoundCounter.UI
             BackColor = baseBackgroundColor;
             ForeColor = Color.White;
             Padding = new Padding(12);
-            MinimumSize = new Size(180, 100);
-            ClientSize = new Size(220, 120);
+            MinimumSize = new Size(150, 60);
+            ClientSize = new Size(220, 110);
             ResizeRedraw = true;
             SetBackgroundOpacity(DefaultBackgroundOpacity);
 


### PR DESCRIPTION
## Summary
- reduce the overlay section form's minimum height to allow smaller overlays
- slightly lower the default client height to match the reduced minimum size

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8870e0920832998a458182011b427