### PR TITLE
Fix auto suicide overlay cancel and delay actions

### DIFF
--- a/UI/MainForm.OSC.cs
+++ b/UI/MainForm.OSC.cs
@@ -214,7 +214,7 @@ namespace ToNRoundCounter.UI
                 if (abortFlag)
                 {
                     LogUi("Abort auto suicide requested via OSC.");
-                    CancelAutoSuicide();
+                    CancelAutoSuicide(manualOverride: true);
                 }
             }
             else if (message.Address == "/avatar/parameters/delayAutoSuside")
@@ -233,11 +233,10 @@ namespace ToNRoundCounter.UI
                 }
                 if (delayFlag && autoSuicideService.HasScheduled)
                 {
-                    TimeSpan remaining = TimeSpan.FromSeconds(40) - (DateTime.UtcNow - autoSuicideService.RoundStartTime);
-                    if (remaining > TimeSpan.Zero)
+                    var remaining = DelayAutoSuicide(manualOverride: true);
+                    if (remaining.HasValue)
                     {
-                        LogUi($"Delaying auto suicide by {remaining}.", LogEventLevel.Debug);
-                        ScheduleAutoSuicide(remaining, false);
+                        LogUi($"Delaying auto suicide by {remaining.Value}.", LogEventLevel.Debug);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- remember when the overlay or OSC requests an auto-suicide cancel so automatic scheduling is suppressed for the rest of the round
- keep the manually requested delay window so automatic reschedules cannot shorten it and wire the overlay/OSC buttons to use it

## Testing
- not run (environment lacks dotnet)

------
https://chatgpt.com/codex/tasks/task_e_68d8921d6e64832984bc7ffb3bff62cd