### PR TITLE
Ensure round log captures latest map name

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1999,6 +1999,17 @@ namespace ToNRoundCounter.UI
             if (stateService.CurrentRound != null)
             {
                 string roundType = stateService.CurrentRound.RoundType ?? string.Empty;
+
+                if (string.IsNullOrWhiteSpace(stateService.CurrentRound.MapName))
+                {
+                    string latestMapName = string.Empty;
+                    _dispatcher.Invoke(() => latestMapName = InfoPanel.MapValue.Text);
+                    if (!string.IsNullOrWhiteSpace(latestMapName))
+                    {
+                        stateService.CurrentRound.MapName = latestMapName;
+                    }
+                }
+
                 stateService.SetRoundMapName(roundType, stateService.CurrentRound.MapName ?? "");
                 if (!string.IsNullOrEmpty(stateService.CurrentRound.TerrorKey))
                 {


### PR DESCRIPTION
## Summary
- capture the latest map name from the info panel when finalizing a round
- ensure the round log uses the captured map name so MAP entries are populated

## Testing
- dotnet build *(fails: dotnet not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d89e09be588329ba6413273245b16a