### PR TITLE
Ensure round map names persist

### DIFF
--- a/Application/MainPresenter.cs
+++ b/Application/MainPresenter.cs
@@ -37,13 +37,14 @@ namespace ToNRoundCounter.Application
         public void AppendRoundLog(Round round, string status)
         {
             string? mapName = round.MapName;
+            if (string.IsNullOrWhiteSpace(mapName) && !string.IsNullOrWhiteSpace(round.RoundType) && !string.IsNullOrWhiteSpace(round.TerrorKey))
+            {
+                mapName = _stateService.GetTerrorMapName(round.RoundType!, round.TerrorKey!);
+            }
+
             if (string.IsNullOrWhiteSpace(mapName) && !string.IsNullOrWhiteSpace(round.RoundType))
             {
-                var mapNames = _stateService.GetRoundMapNames();
-                if (mapNames.TryGetValue(round.RoundType!, out var storedMap) && !string.IsNullOrWhiteSpace(storedMap))
-                {
-                    mapName = storedMap;
-                }
+                mapName = _stateService.GetRoundMapName(round.RoundType!);
             }
 
             if (!string.IsNullOrWhiteSpace(mapName) && mapName != round.MapName)
@@ -52,8 +53,9 @@ namespace ToNRoundCounter.Application
             }
 
             string items = round.ItemNames.Count > 0 ? string.Join("、", round.ItemNames) : "アイテム未使用";
+            string displayMapName = mapName ?? string.Empty;
             string logEntry = string.Format("ラウンドタイプ: {0}, テラー: {1}, MAP: {2}, アイテム: {3}, ダメージ: {4}, 生死: {5}",
-                round.RoundType, round.TerrorKey, mapName, items, round.Damage, status);
+                round.RoundType, round.TerrorKey, displayMapName, items, round.Damage, status);
             _stateService.AddRoundLog(round, logEntry);
             _view?.UpdateRoundLog(_stateService.GetRoundLogHistory().Select(e => e.Item2));
             _logger.LogEvent("MainPresenter", $"Round log appended: {round.RoundType} ({status}).");


### PR DESCRIPTION
## Summary
- persist map names to the state service when LOCATION events update the current round
- expose a dedicated state service lookup for round map names used by the presenter
- avoid masking missing map data with the "不明" fallback in round log formatting

## Testing
- Not run (dotnet CLI is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d89ecec3e083299386b40d8bc48cfa