### PR TITLE
Ensure WebSocket LOCATION events persist map name state

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1646,17 +1646,34 @@ namespace ToNRoundCounter.UI
                     {
                         InfoPanel.MapValue.Text = updatedMapName;
                     });
+
                     var existingRound = stateService.CurrentRound;
+                    string? roundTypeForStorage = existingRound?.RoundType;
+                    string? terrorKeyForStorage = existingRound?.TerrorKey;
+
                     if (existingRound != null)
                     {
                         existingRound.MapName = updatedMapName;
-                        if (!string.IsNullOrWhiteSpace(updatedMapName) && !string.IsNullOrWhiteSpace(existingRound.RoundType))
+                    }
+
+                    if (string.IsNullOrWhiteSpace(roundTypeForStorage))
+                    {
+                        _dispatcher.Invoke(() =>
                         {
-                            stateService.SetRoundMapName(existingRound.RoundType!, updatedMapName);
-                            if (!string.IsNullOrWhiteSpace(existingRound.TerrorKey))
+                            var currentRoundType = InfoPanel.RoundTypeValue.Text;
+                            if (!string.IsNullOrWhiteSpace(currentRoundType))
                             {
-                                stateService.SetTerrorMapName(existingRound.RoundType!, existingRound.TerrorKey!, updatedMapName);
+                                roundTypeForStorage = currentRoundType;
                             }
+                        });
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(updatedMapName) && !string.IsNullOrWhiteSpace(roundTypeForStorage))
+                    {
+                        stateService.SetRoundMapName(roundTypeForStorage!, updatedMapName);
+                        if (!string.IsNullOrWhiteSpace(terrorKeyForStorage))
+                        {
+                            stateService.SetTerrorMapName(roundTypeForStorage!, terrorKeyForStorage!, updatedMapName);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- capture the current round type from UI when processing LOCATION events
- persist LOCATION map updates to the state service even if the round object is missing its type
- keep terror-specific map associations in sync with LOCATION updates

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a3497c788329883c9731dfe99693