### PR TITLE
Fill round log map using previous round snapshot

### DIFF
--- a/Application/MainPresenter.cs
+++ b/Application/MainPresenter.cs
@@ -47,6 +47,15 @@ namespace ToNRoundCounter.Application
                 mapName = _stateService.GetRoundMapName(round.RoundType!);
             }
 
+            if (string.IsNullOrWhiteSpace(mapName))
+            {
+                var previousRound = _stateService.PreviousRound;
+                if (previousRound != null && !string.IsNullOrWhiteSpace(previousRound.MapName))
+                {
+                    mapName = previousRound.MapName;
+                }
+            }
+
             if (!string.IsNullOrWhiteSpace(mapName) && mapName != round.MapName)
             {
                 round.MapName = mapName;

--- a/Domain/Round.cs
+++ b/Domain/Round.cs
@@ -26,6 +26,31 @@ namespace ToNRoundCounter.Domain
         public int PageCount { get; set; }
         public int InstancePlayersCount { get; internal set; }
         public int? RoundColor { get; set; }
+
+        /// <summary>
+        /// Creates a deep copy of the round so that snapshots can be stored safely.
+        /// </summary>
+        public Round Clone()
+        {
+            var clone = new Round(Id)
+            {
+                RoundType = RoundType,
+                IsDeath = IsDeath,
+                TerrorKey = TerrorKey,
+                MapName = MapName,
+                Damage = Damage,
+                PageCount = PageCount,
+                InstancePlayersCount = InstancePlayersCount,
+                RoundColor = RoundColor
+            };
+
+            if (ItemNames != null && ItemNames.Count > 0)
+            {
+                clone.ItemNames.AddRange(ItemNames);
+            }
+
+            return clone;
+        }
     }
 }
 

--- a/ToNRoundCounter.Tests/StateServiceTests.cs
+++ b/ToNRoundCounter.Tests/StateServiceTests.cs
@@ -1,4 +1,5 @@
 using ToNRoundCounter.Application;
+using ToNRoundCounter.Domain;
 using Xunit;
 
 namespace ToNRoundCounter.Tests
@@ -36,6 +37,51 @@ namespace ToNRoundCounter.Tests
             Assert.Equal(5, stats["Survivals"]);
             service.Reset();
             Assert.Empty(service.GetStats());
+        }
+
+        [Fact]
+        public void UpdateCurrentRound_StoresPreviousRoundSnapshot()
+        {
+            var service = new StateService();
+            var round = new Round
+            {
+                RoundType = "Alpha",
+                MapName = "Sanctuary",
+                TerrorKey = "Phantom",
+                Damage = 27,
+                PageCount = 3,
+                IsDeath = true,
+                RoundColor = 0x112233
+            };
+            round.ItemNames.Add("Lantern");
+
+            service.UpdateCurrentRound(round);
+            service.UpdateCurrentRound(null);
+
+            // Mutate the original to ensure a deep copy was stored.
+            round.MapName = "Changed";
+            round.ItemNames.Add("Sword");
+            round.Damage = 99;
+
+            var previous = service.PreviousRound;
+
+            Assert.NotNull(previous);
+            Assert.NotSame(round, previous);
+            Assert.Equal("Alpha", previous!.RoundType);
+            Assert.Equal("Sanctuary", previous.MapName);
+            Assert.Equal("Phantom", previous.TerrorKey);
+            Assert.Equal(27, previous.Damage);
+            Assert.Equal(3, previous.PageCount);
+            Assert.True(previous.IsDeath);
+            Assert.Equal(0x112233, previous.RoundColor);
+            Assert.Single(previous.ItemNames);
+            Assert.Equal("Lantern", previous.ItemNames[0]);
+
+            var snapshotBeforeNewRound = service.PreviousRound;
+            service.UpdateCurrentRound(new Round { RoundType = "Beta" });
+
+            Assert.Same(snapshotBeforeNewRound, service.PreviousRound);
+            Assert.Equal("Alpha", service.PreviousRound!.RoundType);
         }
     }
 }


### PR DESCRIPTION
## Summary
- finalize rounds using the archived snapshot so round logs operate on the stored data
- fall back to the previous round snapshot when a map name is missing while composing the log entry

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a64b20688329b7c050100a490d24