### PR TITLE
Show round type names in round history overlay

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -126,6 +126,7 @@ namespace ToNRoundCounter.UI
         private int terrorCountdownLastDisplayedSeconds = -1;
         private readonly Dictionary<OverlaySection, OverlaySectionForm> overlayForms = new();
         private readonly List<(string Label, string Status)> overlayRoundHistory = new();
+        private string lastRoundTypeForHistory = string.Empty;
         private System.Windows.Forms.Timer? overlayVisibilityTimer;
         private OverlayShortcutForm? shortcutOverlayForm;
         private bool overlayTemporarilyHidden;
@@ -2094,6 +2095,7 @@ namespace ToNRoundCounter.UI
 
                 stateService.UpdateCurrentRound(null);
                 var roundForHistory = stateService.PreviousRound ?? round;
+                lastRoundTypeForHistory = roundForHistory?.RoundType ?? string.Empty;
 
                 _dispatcher.Invoke(() =>
                 {
@@ -2302,6 +2304,7 @@ namespace ToNRoundCounter.UI
                 {
                     overlayRoundHistory.Clear();
                 }
+                lastRoundTypeForHistory = string.Empty;
                 RefreshRoundHistoryOverlay();
                 return;
             }
@@ -2331,7 +2334,9 @@ namespace ToNRoundCounter.UI
 
         private void RecordRoundHistory(string? statusOverride)
         {
-            string label = InfoPanel?.NextRoundType?.Text ?? string.Empty;
+            string label = !string.IsNullOrWhiteSpace(lastRoundTypeForHistory)
+                ? lastRoundTypeForHistory
+                : InfoPanel?.NextRoundType?.Text ?? string.Empty;
             if (string.IsNullOrWhiteSpace(label) && string.IsNullOrWhiteSpace(statusOverride))
             {
                 return;


### PR DESCRIPTION
## Summary
- keep track of the most recent round type when recording overlay history
- populate the round history overlay header with the actual round type name and reset it when predictions are unavailable

## Testing
- not run (dotnet CLI is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8c1bd600083299db3606891980b75