### PR TITLE
Include MainForm overlay and stats partials in project file

### DIFF
--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -128,6 +128,14 @@
       <DependentUpon>MainForm.cs</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="UI\MainForm.Overlay.cs">
+      <DependentUpon>MainForm.cs</DependentUpon>
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\MainForm.Stats.cs">
+      <DependentUpon>MainForm.cs</DependentUpon>
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="UI\MainForm.OSC.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
       <SubType>Form</SubType>


### PR DESCRIPTION
## Summary
- include the MainForm overlay and statistics partial source files in the project so their implementations compile with the main form

## Testing
- not run (Windows-only .NET Framework 4.8 project)


------
https://chatgpt.com/codex/tasks/task_e_68de55aab4908329be4f88e4415c2754