### PR TITLE
Fix .NET Framework compatibility warnings

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -163,7 +163,7 @@ namespace ToNRoundCounter
                     return new AppSettingsData();
                 }
 
-                var json = await File.ReadAllTextAsync("appsettings.json").ConfigureAwait(false);
+                var json = await Task.Run(() => File.ReadAllText("appsettings.json")).ConfigureAwait(false);
                 return JsonConvert.DeserializeObject<AppSettingsData>(json) ?? new AppSettingsData();
             }
             catch

--- a/UI/DirectX/DirectXSegmentRenderer.cs
+++ b/UI/DirectX/DirectXSegmentRenderer.cs
@@ -173,7 +173,7 @@ namespace ToNRoundCounter.UI.DirectX
                 return glyphs;
             }
 
-            foreach (char c in text)
+            foreach (char c in text!)
             {
                 if (c == '.')
                 {

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -25,6 +25,8 @@ using MediaPlayer = System.Windows.Media.MediaPlayer;
 using WinFormsApp = System.Windows.Forms.Application;
 using ToNRoundCounter.Infrastructure.Interop;
 
+#nullable enable
+
 namespace ToNRoundCounter.UI
 {
     public partial class MainForm : Form, IMainView


### PR DESCRIPTION
## Summary
- replace the use of File.ReadAllTextAsync with a Task.Run wrapper to keep the bootstrap loader compatible with .NET Framework 4.8
- enable nullable reference types in MainForm to silence repeated annotation warnings
- annotate segment renderer glyph creation to avoid nullable dereference analysis warnings

## Testing
- `dotnet build ToNRoundCounter.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de56c141708329a83b7c2426db99c7