### PR TITLE
Enable scrolling on settings panel

### DIFF
--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -122,6 +122,8 @@ namespace ToNRoundCounter.UI
             int columnWidth = 540;
             int totalWidth = columnWidth * 3 + margin * 4;
             this.Size = new Size(totalWidth, 1100);
+            this.AutoScroll = true;
+            this.AutoScrollMinSize = new Size(totalWidth, 1100);
 
             int currentY = margin;
             int rightColumnY = margin;


### PR DESCRIPTION
## Summary
- enable automatic scrolling on the settings panel so overflowing content remains accessible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3313234d88329a9f3040e66505714