### PR TITLE
Fix build errors by configuring dependencies and language version

### DIFF
--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -109,6 +109,7 @@
     <PackageReference Include="Serilog" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="System.Memory" Version="4.5.5" />

--- a/Updater/Updater.csproj
+++ b/Updater/Updater.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.IO.Compression" />


### PR DESCRIPTION
## Summary
- add a System.Text.Json package reference to the main application so SafeModeManager can compile
- configure the updater project to use the latest C# language version, allowing existing using declarations to build

## Testing
- not run (dotnet CLI is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e34477c6808329ac0d59aaa1271ed4