### PR TITLE
Optimize SQLite persistence and WebSocket buffering

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -50,7 +50,7 @@ namespace ToNRoundCounter
             var statisticsPath = Path.Combine(dataDirectory, "statistics", $"{timestamp}.sqlite");
             var settingsPath = Path.Combine(dataDirectory, "settings", $"{timestamp}.sqlite");
 
-            var roundDataRepository = new SqliteRoundDataRepository(roundDataPath);
+            using var roundDataRepository = new SqliteRoundDataRepository(roundDataPath);
             var eventLogRepository = new SqliteEventLogRepository(statisticsPath);
             var settingsRepository = new SqliteSettingsRepository(settingsPath);
 


### PR DESCRIPTION
## Summary
- reuse a long-lived SQLite connection with transactional batching for round data persistence and enable WAL mode
- add disposal safeguards for the shared repository and ensure the instance is disposed during application shutdown
- minimize allocations in the WebSocket receive loop by reusing pooled buffers for message assembly

## Testing
- not run (dotnet CLI is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e3473cdef8832999d098a5775e90e9