### PR TITLE
Improve round log handling and runtime performance

### DIFF
--- a/Application/IEventLogger.cs
+++ b/Application/IEventLogger.cs
@@ -1,9 +1,15 @@
+using System;
+using Serilog.Events;
+
 namespace ToNRoundCounter.Application
 {
-    using Serilog.Events;
 
     public interface IEventLogger
     {
         void LogEvent(string eventType, string message, LogEventLevel level = LogEventLevel.Information);
+
+        void LogEvent(string eventType, Func<string> messageFactory, LogEventLevel level = LogEventLevel.Information);
+
+        bool IsEnabled(LogEventLevel level);
     }
 }

--- a/Application/IMainView.cs
+++ b/Application/IMainView.cs
@@ -5,6 +5,7 @@ namespace ToNRoundCounter.Application
     public interface IMainView
     {
         void UpdateRoundLog(IEnumerable<string> logEntries);
+        void AppendRoundLogEntry(string logEntry);
     }
 }
 

--- a/Infrastructure/EventBus.cs
+++ b/Infrastructure/EventBus.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using Serilog.Events;
 using ToNRoundCounter.Application;
 
 namespace ToNRoundCounter.Infrastructure
@@ -10,7 +12,7 @@ namespace ToNRoundCounter.Infrastructure
     /// </summary>
     public class EventBus : IEventBus
     {
-        private readonly ConcurrentDictionary<Type, ConcurrentDictionary<Delegate, byte>> _handlers = new();
+        private readonly ConcurrentDictionary<Type, ImmutableArray<Delegate>> _handlers = new();
         private readonly IEventLogger? _logger;
 
         public EventBus(IEventLogger? logger = null)
@@ -20,44 +22,81 @@ namespace ToNRoundCounter.Infrastructure
 
         public void Subscribe<T>(Action<T> handler)
         {
-            var dict = _handlers.GetOrAdd(typeof(T), _ => new ConcurrentDictionary<Delegate, byte>());
-            dict.TryAdd(handler, 0);
-            _logger?.LogEvent("EventBus", $"Subscribed handler '{handler.Method.DeclaringType?.FullName}.{handler.Method.Name}' for message type {typeof(T).FullName}. Total handlers: {dict.Count}");
+            var messageType = typeof(T);
+            while (true)
+            {
+                if (_handlers.TryGetValue(messageType, out var existing))
+                {
+                    var updated = existing.Add(handler);
+                    if (_handlers.TryUpdate(messageType, updated, existing))
+                    {
+                        _logger?.LogEvent("EventBus", () => $"Subscribed handler '{handler.Method.DeclaringType?.FullName}.{handler.Method.Name}' for message type {messageType.FullName}. Total handlers: {updated.Length}");
+                        return;
+                    }
+                }
+                else
+                {
+                    var initial = ImmutableArray.Create<Delegate>(handler);
+                    if (_handlers.TryAdd(messageType, initial))
+                    {
+                        _logger?.LogEvent("EventBus", () => $"Subscribed handler '{handler.Method.DeclaringType?.FullName}.{handler.Method.Name}' for message type {messageType.FullName}. Total handlers: {initial.Length}");
+                        return;
+                    }
+                }
+            }
         }
 
         public void Unsubscribe<T>(Action<T> handler)
         {
-            if (_handlers.TryGetValue(typeof(T), out var dict))
+            var messageType = typeof(T);
+            while (_handlers.TryGetValue(messageType, out var existing))
             {
-                dict.TryRemove(handler, out _);
-                if (dict.IsEmpty)
+                var updated = existing.Remove(handler);
+                if (updated.Length == existing.Length)
                 {
-                    _handlers.TryRemove(typeof(T), out _);
+                    _logger?.LogEvent("EventBus", () => $"Attempted to unsubscribe handler '{handler.Method.DeclaringType?.FullName}.{handler.Method.Name}' for unregistered message type {messageType.FullName}.");
+                    return;
                 }
-                _logger?.LogEvent("EventBus", $"Unsubscribed handler '{handler.Method.DeclaringType?.FullName}.{handler.Method.Name}' for message type {typeof(T).FullName}. Remaining handlers: {dict.Count}");
+
+                if (_handlers.TryUpdate(messageType, updated, existing))
+                {
+                    if (updated.IsEmpty)
+                    {
+                        _handlers.TryRemove(messageType, out _);
+                    }
+
+                    _logger?.LogEvent("EventBus", () => $"Unsubscribed handler '{handler.Method.DeclaringType?.FullName}.{handler.Method.Name}' for message type {messageType.FullName}. Remaining handlers: {updated.Length}");
+                    return;
+                }
             }
-            else
-            {
-                _logger?.LogEvent("EventBus", $"Attempted to unsubscribe handler '{handler.Method.DeclaringType?.FullName}.{handler.Method.Name}' for unregistered message type {typeof(T).FullName}.");
-            }
+
+            _logger?.LogEvent("EventBus", () => $"Attempted to unsubscribe handler '{handler.Method.DeclaringType?.FullName}.{handler.Method.Name}' for unregistered message type {messageType.FullName}.");
         }
 
         public void Publish<T>(T message)
         {
-            if (_handlers.TryGetValue(typeof(T), out var dict))
+            var messageType = typeof(T);
+            if (_handlers.TryGetValue(messageType, out var handlers) && !handlers.IsDefaultOrEmpty)
             {
-                _logger?.LogEvent("EventBus", $"Publishing message of type {typeof(T).FullName} to {dict.Count} handler(s).");
-                foreach (var d in dict.Keys)
+                _logger?.LogEvent("EventBus", () => $"Publishing message of type {messageType.FullName} to {handlers.Length} handler(s).");
+                foreach (var entry in handlers)
                 {
-                    if (d is Action<T> action)
+                    if (entry is Action<T> action)
                     {
-                        action(message);
+                        try
+                        {
+                            action(message);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger?.LogEvent("EventBus", () => $"Handler '{action.Method.DeclaringType?.FullName}.{action.Method.Name}' threw: {ex}", LogEventLevel.Error);
+                        }
                     }
                 }
             }
             else
             {
-                _logger?.LogEvent("EventBus", $"Publishing message of type {typeof(T).FullName} with no registered handlers.");
+                _logger?.LogEvent("EventBus", () => $"Publishing message of type {messageType.FullName} with no registered handlers.");
             }
         }
     }

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -117,6 +117,7 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.5" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add lazy-evaluated logging support and update state-driven presenters to emit incremental round log updates
- optimize state and UI round log flows to avoid full history rebuilds and introduce a dedicated append hook
- tighten WebSocket buffering/channeling and rework the event bus to use immutable handler snapshots while bounding backpressure
- add System.Collections.Immutable dependency required by the new event bus snapshot implementation

## Testing
- `dotnet build ToNRoundCounter.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e34972e2f08329ab8043253602ad3f