### PR TITLE
Add support for additional UI languages

### DIFF
--- a/Application/IAppSettings.cs
+++ b/Application/IAppSettings.cs
@@ -50,6 +50,7 @@ namespace ToNRoundCounter.Application
         bool AutoSuicideEnabled { get; set; }
         string apikey { get; set; }
         string ThemeKey { get; set; }
+        string Language { get; set; }
         string LogFilePath { get; set; }
         string WebSocketIp { get; set; }
         bool AutoLaunchEnabled { get; set; }

--- a/Infrastructure/AppSettings.cs
+++ b/Infrastructure/AppSettings.cs
@@ -72,6 +72,7 @@ namespace ToNRoundCounter.Infrastructure
         public bool AutoSuicideEnabled { get; set; }
         public string apikey { get; set; } = string.Empty;
         public string ThemeKey { get; set; } = Theme.DefaultThemeKey;
+        public string Language { get; set; } = LanguageManager.DefaultCulture;
         public string LogFilePath { get; set; } = "logs/log-.txt";
         public string WebSocketIp { get; set; } = "127.0.0.1";
         public bool AutoLaunchEnabled { get; set; }
@@ -160,6 +161,8 @@ namespace ToNRoundCounter.Infrastructure
                 }
 
                 ThemeKey = NormalizeThemeKey(ThemeKey);
+                Language = LanguageManager.NormalizeCulture(Language);
+                LanguageManager.SetLanguage(Language);
                 _logger.LogEvent("AppSettings", $"Theme normalized to '{ThemeKey}'.");
                 _bus.Publish(new SettingsValidating(this, validationErrors));
                 var errors = Validate();
@@ -466,6 +469,7 @@ namespace ToNRoundCounter.Infrastructure
                 AutoSuicideUseDetail = AutoSuicideUseDetail,
                 apikey = apikey,
                 ThemeKey = NormalizeThemeKey(ThemeKey),
+                Language = LanguageManager.NormalizeCulture(Language),
                 LogFilePath = LogFilePath,
                 WebSocketIp = WebSocketIp,
                 AutoLaunchEnabled = AutoLaunchEnabled,
@@ -551,6 +555,7 @@ namespace ToNRoundCounter.Infrastructure
         public bool AutoSuicideUseDetail { get; set; }
         public string apikey { get; set; } = string.Empty;
         public string ThemeKey { get; set; } = Theme.DefaultThemeKey;
+        public string Language { get; set; } = LanguageManager.DefaultCulture;
         public string LogFilePath { get; set; } = string.Empty;
         public string WebSocketIp { get; set; } = string.Empty;
         public bool AutoLaunchEnabled { get; set; }

--- a/Infrastructure/LanguageManager.cs
+++ b/Infrastructure/LanguageManager.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Resources;
 using System.Threading;
 
@@ -9,17 +12,155 @@ namespace ToNRoundCounter.Infrastructure
         private static readonly ResourceManager _resourceManager =
             new ResourceManager("ToNRoundCounter.Infrastructure.Resources.Strings", typeof(LanguageManager).Assembly);
 
-        private static CultureInfo _culture = CultureInfo.CurrentUICulture;
+        private static readonly (string Code, string[] Aliases)[] _supportedCultures = new[]
+        {
+            ("ja", new[] { "ja", "ja-JP", "Japanese", "日本語" }),
+            ("en", new[] { "en", "English", "英語" }),
+            ("en-US", new[] { "en-US", "English (United States)", "English (US)", "英語, アメリカ", "英語 (アメリカ)" }),
+            ("en-GB", new[] { "en-GB", "English (United Kingdom)", "English (UK)", "英語, イギリス", "英語 (イギリス)" }),
+            ("ko", new[] { "ko", "ko-KR", "Korean", "한국어", "韓国語" }),
+            ("zh-Hans", new[] { "zh", "zh-CN", "zh-SG", "zh-Hans", "Chinese (Simplified)", "中文(简体)", "中国語(簡体字)" }),
+            ("da", new[] { "da", "da-DK", "Danish", "デンマーク語", "덴마크어", "丹麦语" }),
+            ("de", new[] { "de", "de-DE", "German", "ドイツ語", "독일어", "德语" }),
+            ("es", new[] { "es", "es-ES", "Spanish", "スペイン語", "스페인어", "西班牙语" }),
+            ("es-419", new[] { "es-419", "es-MX", "es-AR", "es-CO", "es-CL", "es-PE", "es-LA", "Spanish (Latin America)", "スペイン語 (ラテンアメリカ)", "스페인어 (라틴 아메리카)", "西班牙语（拉丁美洲）" }),
+            ("fr", new[] { "fr", "fr-FR", "French", "フランス語", "프랑스어", "法语" }),
+            ("hr", new[] { "hr", "hr-HR", "Croatian", "クロアチア語", "크로아티ア어", "克罗地亚语" }),
+            ("it", new[] { "it", "it-IT", "Italian", "イタリア語", "이탈리아어", "意大利语" }),
+            ("lt", new[] { "lt", "lt-LT", "Lithuanian", "リトアニア語", "리투아니아어", "立陶宛语" }),
+            ("hu", new[] { "hu", "hu-HU", "Hungarian", "ハンガリー語", "헝가리어", "匈牙利语" }),
+            ("nl", new[] { "nl", "nl-NL", "Dutch", "オランダ語", "네덜란드어", "荷兰语" }),
+            ("nb", new[] { "nb", "nb-NO", "no", "no-NO", "Norwegian", "ノルウェー語", "노르웨이어", "挪威语" }),
+            ("pl", new[] { "pl", "pl-PL", "Polish", "ポーランド語", "폴란드어", "波兰语" }),
+            ("pt-BR", new[] { "pt-BR", "pt", "pt-PT", "Portuguese (Brazil)", "ポルトガル語, ブラジル", "ポルトガル語 (ブラジル)", "포르투갈어 (브라질)", "葡萄牙语（巴西）" }),
+            ("ro", new[] { "ro", "ro-RO", "Romanian", "ルーマニア語", "루마니아어", "罗马尼亚语" }),
+            ("fi", new[] { "fi", "fi-FI", "Finnish", "フィンランド語", "핀란드어", "芬兰语" }),
+            ("sv", new[] { "sv", "sv-SE", "Swedish", "スウェーデン語", "스웨덴어", "瑞典语" }),
+            ("vi", new[] { "vi", "vi-VN", "Vietnamese", "ベトナム語", "베트남어", "越南语" }),
+            ("tr", new[] { "tr", "tr-TR", "Turkish", "トルコ語", "터키어", "土耳其语" }),
+            ("th", new[] { "th", "th-TH", "Thai", "タイ語", "태국어", "泰语" }),
+            ("el", new[] { "el", "el-GR", "Greek", "ギリシャ語", "그리스어", "希腊语" }),
+            ("bg", new[] { "bg", "bg-BG", "Bulgarian", "ブルガリア語", "불가리아어", "保加利亚语" }),
+            ("ru", new[] { "ru", "ru-RU", "Russian", "ロシア語", "러시아어", "俄语" }),
+            ("uk", new[] { "uk", "uk-UA", "Ukrainian", "ウクライナ語", "우크라이나어", "乌克兰语" }),
+        };
+
+        private static readonly string[] _supportedCultureCodes = _supportedCultures.Select(c => c.Code).ToArray();
+
+        private static readonly Dictionary<string, string> _cultureAliases = CreateAliasDictionary();
+
+        private static Dictionary<string, string> CreateAliasDictionary()
+        {
+            var aliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (code, values) in _supportedCultures)
+            {
+                if (!string.IsNullOrWhiteSpace(code))
+                {
+                    aliases[code] = code;
+                }
+
+                if (values == null)
+                {
+                    continue;
+                }
+
+                foreach (var alias in values)
+                {
+                    if (string.IsNullOrWhiteSpace(alias))
+                    {
+                        continue;
+                    }
+
+                    aliases[alias] = code;
+                }
+            }
+
+            return aliases;
+        }
+
+        private static readonly string _defaultCulture = DetermineDefaultCulture();
+
+        private static CultureInfo _culture = CultureInfo.GetCultureInfo(_defaultCulture);
+
+        public static IReadOnlyList<string> SupportedCultureCodes { get; } = Array.AsReadOnly(_supportedCultureCodes);
+
+        public static string DefaultCulture => _defaultCulture;
 
         public static void SetLanguage(string cultureCode)
         {
-            Interlocked.Exchange(ref _culture, new CultureInfo(cultureCode));
+            var normalized = NormalizeCulture(cultureCode);
+            var culture = CultureInfo.GetCultureInfo(normalized);
+            Interlocked.Exchange(ref _culture, culture);
         }
 
         public static string Translate(string key)
         {
             var culture = Volatile.Read(ref _culture);
             return _resourceManager.GetString(key, culture) ?? key;
+        }
+
+        public static string NormalizeCulture(string? cultureCode)
+        {
+            return NormalizeCultureInternal(cultureCode) ?? _defaultCulture;
+        }
+
+        private static string DetermineDefaultCulture()
+        {
+            return NormalizeCultureInternal(CultureInfo.CurrentUICulture.Name) ?? "ja";
+        }
+
+        private static string? NormalizeCultureInternal(string? cultureCode)
+        {
+            if (string.IsNullOrWhiteSpace(cultureCode))
+            {
+                return null;
+            }
+
+            if (_cultureAliases.TryGetValue(cultureCode, out var alias))
+            {
+                return alias;
+            }
+
+            try
+            {
+                var culture = CultureInfo.GetCultureInfo(cultureCode);
+
+                if (_cultureAliases.TryGetValue(culture.Name, out var fromName))
+                {
+                    return fromName;
+                }
+
+                if (_cultureAliases.TryGetValue(culture.TwoLetterISOLanguageName, out var fromTwoLetter))
+                {
+                    return fromTwoLetter;
+                }
+
+                var exactMatch = _supportedCultureCodes.FirstOrDefault(code =>
+                    string.Equals(code, culture.Name, StringComparison.OrdinalIgnoreCase));
+                if (!string.IsNullOrEmpty(exactMatch))
+                {
+                    return exactMatch;
+                }
+
+                var neutralMatch = _supportedCultureCodes.FirstOrDefault(code =>
+                    string.Equals(code, culture.TwoLetterISOLanguageName, StringComparison.OrdinalIgnoreCase));
+                if (!string.IsNullOrEmpty(neutralMatch))
+                {
+                    return neutralMatch;
+                }
+
+                if (string.Equals(culture.TwoLetterISOLanguageName, "zh", StringComparison.OrdinalIgnoreCase))
+                {
+                    return "zh-Hans";
+                }
+            }
+            catch (CultureNotFoundException)
+            {
+                // Ignore and fall back to default.
+            }
+
+            return null;
         }
     }
 }

--- a/Infrastructure/Resources/Strings.bg.resx
+++ b/Infrastructure/Resources/Strings.bg.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API ключ:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Ключовете на API трябва да са дълги най -малко 32 знака.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Свързани</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Изключен</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Настройки за уведомяване за раздора</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Щети:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Елемент:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>Карта:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Кръгъл тип:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Терор:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Китайски (опростен)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Английски</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Японски</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Корейски</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>Добре</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC порт:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Настройки на OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Грешка в анализа</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Настройки на Tonroundcounter-Cloud</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud е облачна услуга, която може автоматично да синхронизира кодове за запазване на множество устройства.
+Необходим е ключ за API.
+Моля, вземете ключ за API от уебсайта.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Отворете Tonroundcounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL адрес на Webhook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Приоритизирайте звуците на артикула</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Музикална хитрост на артикула</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Показване на необвързани подробности за терора</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Импортиране</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Windows</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Експорт</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Грешка</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Настройки на наслагване</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Отказ</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Покажете преки пътища</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Покажете щети</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Терор</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Заключване на името на терора: Цвят:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Покажи ужас</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Име на терора</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Покажете подробности за терора</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Тема</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Показване на информация за отстраняване на грешки</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Файл</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Настройки на филтъра</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Предварително зададен:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Предварително зададено.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Предварително зададено.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Предварително зададен.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Настройки на кръг/терор BGM</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Играйте BGM по кръг/терор</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Приоритизирайте кръглата BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Кръгъл тип</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Дисплей на статистиката с кръгъл тип:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Показване на историята на кръглата типа</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Кръгъл дневник</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Показване на кръгъл дневник</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Фон за кръгло дневник:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Кръгло име</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Показване на състоянието на кръг</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Конфигурирайте URL адреса на WebHook, за да изпращате кръгли резултати на Discord. Оставете празно, за да деактивирате.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Показване на кръгли статистики</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Играйте и двете</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Запазете</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Аудио за възпроизвеждане</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Изяви</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Извадете</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Разгледайте ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>ПИК отгоре</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Unpin</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Стартирайте външни приложения автоматично</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Изпълним</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Име на целевия елемент</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Брой на историята:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Аргументи</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Информация</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Фон на информационния панел:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Покажи часовник</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Размито съвпадение</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Максимална скорост</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Мин скорост</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Активиран</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Синтаксична грешка</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Покажете предсказанието на следващия кръг</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Смъртни случаи</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Покажи таймер за обитаване на обитаване</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Пускайте музика за конкретни елементи</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-Suicide няма да работи с текущите настройки.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Оцелели</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Процент на оцеляване</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Приоритет, когато се появят конфликти:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Изход</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Показват статистика</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Статистика</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Фон на панела на статистиката:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Цветове на фона</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Автоматичният самоубийство е деактивиран.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Активирайте автоматично самоубийство</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Режим на автоматично самоубийство</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Автоматични целеви кръгове:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Автоматични настройки</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Изберете цвят</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Настройки на дисплея</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Покажете ъгъл</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Линиите не могат да бъдат анализирани:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Език</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Настройки</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Настройки ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Конфигурация</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Преглед на конфигурацията</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Промяна на настройките</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Използвайте разширени настройки</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Разширени настройки документи</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Зареждане</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Предупреждение</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Добавяне</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Допълнителни настройки</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Непрозрачност</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Показват скорост</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Датски</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Немски</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Английски (Обединеното кралство)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Английски (САЩ)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Испански</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Испанска (Латинска Америка)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Френски</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Хърватски</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Италиански</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Литовски</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Унгарски</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Холандски</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Норвежки</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Лак</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Португалски (Бразилия)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Румънски</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Финландски</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Шведски</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Виетнамски</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Турски</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Тайландски</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Гръцки</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Български</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Руски</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Украински</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.da.resx
+++ b/Infrastructure/Resources/Strings.da.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API -nøgle:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API -nøgler skal være mindst 32 tegn lange.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Tilsluttet</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Frakoblet</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Indstillinger af uoverensstemmelser</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Skade:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Punkt:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>Kort:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Rund type:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Kinesisk (forenklet)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Engelsk</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Japansk</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Koreansk</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC Port:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC -indstillinger</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Parse fejl</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>TonRoundCounter-Cloud-indstillinger</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonRoundCounter-Cloud er en cloud-service, der automatisk kan synkronisere gemme koder på tværs af flere enheder.
+En API -nøgle er påkrævet.
+Få en API -nøgle fra webstedet.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Åbn TonRoundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>TonRoundCounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>WebHook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Prioriter varelyde</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Varemusik Gimmick</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Vis ubundne terrordetaljer</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Importere</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Windows</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Eksportere</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Fejl</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Overlay -indstillinger</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Ophæve</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Vis genveje</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Vis skade</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terror</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Lås terrornavn Farve:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Vis terror</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Terrornavn</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Vis terrordetaljer</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Tema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Vis debuginfo</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Fil</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Filterindstillinger</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Forudindstillet:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Forudindstillet importeret.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Forudindstillet eksporteret.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Forudindstillet gemt.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Rund/terror BGM -indstillinger</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Spil BGM efter rund/terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Prioriter Round BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Rund type</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Statistik af rund type: Display:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Vis historie om rund type</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Rund log</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Vis rund log</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Rund logbaggrund:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Rundt navn</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Vis rund status</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Konfigurer webhook -URL'en til at sende runde resultater til Discord. Lad være tomt for at deaktivere.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Vis rundstatistikker</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Spil begge</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Spare</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Lyd til at afspille</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Optrædener</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Fjerne</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Gennemse ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin på toppen</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Unpin</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Start eksterne apps automatisk</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Eksekverbar</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Målartikelnavn</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Historieoptælling:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumenter</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Information</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Info -panelbaggrund:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Vis ur</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Fuzzy matching</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Maksimal hastighed</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Min hastighed</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Aktiveret</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Syntaksfejl</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Vis forudsigelse af næste runde</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Dødsfald : døde</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Vis opholdstimer</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Spil musik til specifikke genstande</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-selvmord kører ikke med de aktuelle indstillinger.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Overlevelse</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Overlevelsesrate</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioritet Når konflikter opstår:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Udgang</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Vis statistikker</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistik</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Statistikpanelbaggrund:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Baggrundsfarver</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-selvmord er deaktiveret.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Aktivér auto-selvmord</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Auto-selvmordstilstand</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Auto-selvmordsmålrunder:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Auto-lanceringsindstillinger</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Vælg farve</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Vis indstillinger</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Vis vinkel</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Linjer kunne ikke parses:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Sprog</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Indstillinger</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Indstillinger ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Konfiguration</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Gennemgå konfiguration</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Skift indstillinger</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Brug avancerede indstillinger</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Avancerede indstillinger Dokumenter</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Belastning</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Advarsel</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Tilføje</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Yderligere indstillinger</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacitet</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Vis hastighed</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Dansk</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Tysk</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Engelsk (Storbritannien)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Engelsk (USA)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Spansk</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Spansk (Latinamerika)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Fransk</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Kroatisk</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Italiensk</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Litauisk</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Ungarsk</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Hollandsk</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Norsk</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Polere</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugisisk (Brasilien)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Rumænsk</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Finsk</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Svensk</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Vietnamesisk</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Tyrkisk</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thai</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Græsk</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bulgarsk</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Russisk</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Ukrainsk</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.de.resx
+++ b/Infrastructure/Resources/Strings.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API -Schlüssel:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API -Schlüssel müssen mindestens 32 Zeichen lang sein.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Verbunden</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Getrennt</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Einstellungen zur Benachrichtigung der Zwietracht</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Schaden:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Artikel:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>KARTE:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Runder Typ:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Chinesisch (vereinfacht)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Englisch</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>japanisch</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Koreanisch</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC -Anschluss:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC -Einstellungen</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Fehler analysieren</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Tonroundcounter-Cloud-Einstellungen</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud ist ein Cloud-Dienst, mit dem automatisch Speichercodes auf mehreren Geräten synchronisiert werden können.
+Ein API -Schlüssel ist erforderlich.
+Bitte erhalten Sie einen API -Schlüssel von der Website.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Öffnen Sie die Tonroundcounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
-    <value>WebSocket IP:</value>
+    <value>Websocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Priorisieren Sie die Geräusche der Artikel</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Item Music Gimmick</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Zeigen Sie ungebundene Terrordetails</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Import</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Fenster</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Export</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Fehler</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Überlagerungseinstellungen</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Stornieren</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Zeigen Sie Verknüpfungen</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Schaden zeigen</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terror</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Lock Terror Name Farbe:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Terror zeigen</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Terrorname</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Terrordetails zeigen</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Thema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Debug -Info Show</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Datei</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Filtereinstellungen</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Voreinstellung:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Voreingestellter importiert.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Voreingestellt exportiert.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Voreingestellter gerettet.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Runde/Terror -BGM -Einstellungen</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Spielen Sie BGM für Runde/Terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Priorisieren Sie runde BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Runder Typ</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Statistiken zum runden Typ angezeigt:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Runde Typ History zeigen</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Runde Protokoll</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Runden Protokoll anzeigen</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Hintergrund des runden Protokolls:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Runder Name</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Rundstatus anzeigen</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Konfigurieren Sie die Webhook -URL, um runde Ergebnisse an Discord zu senden. Lassen Sie leer, um zu deaktivieren.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Runde Statistiken zeigen</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Spiel beides</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Speichern</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio zu spielen</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Erscheinungen</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Entfernen</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Durchsuchen ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin darauf</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Unpin</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Starten Sie externe Apps automatisch</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Ausführbar</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Zielelementname</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>GESCHICHTE Zählung:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumente</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Information</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Info -Panel -Hintergrund:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Uhr zeigen</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Fuzzy Matching</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Maximale Geschwindigkeit</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Minengeschwindigkeit</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Ermöglicht</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Syntaxfehler</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Vorhersage der nächsten Runde zeigen</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Todesfälle</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Show Dwell Timer</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Spielen Sie Musik für bestimmte Gegenstände</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Der Auto-Selbstmord wird nicht mit den aktuellen Einstellungen ausgeführt.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Überleben</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Überlebensrate</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Priorität, wenn Konflikte auftreten:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Ausfahrt</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Statistiken zeigen</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistiken</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Statistikpanel Hintergrund:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Hintergrundfarben</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-Suizid ist deaktiviert.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Aktivieren Sie Auto-Suizid</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Auto-Suizid-Modus</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Auto-Suizid-Zielrunden:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Auto-Launch-Einstellungen</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Wählen Sie Farbe</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Einstellungen anzeigen</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Winkel zeigen</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Linien konnten nicht analysiert werden:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Sprache</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Einstellungen</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Einstellungen...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Konfiguration</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Überprüfung der Konfiguration</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Einstellungen ändern</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Verwenden Sie erweiterte Einstellungen</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Erweiterte Einstellungen docs</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Laden</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Warnung</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Hinzufügen</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Zusätzliche Einstellungen</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opazität</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Geschwindigkeit zeigen</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>dänisch</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Deutsch</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Englisch (Vereinigtes Königreich)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Englisch (Vereinigte Staaten)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Spanisch</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Spanisch (Lateinamerika)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Französisch</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>kroatisch</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Italienisch</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>litauisch</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>ungarisch</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Niederländisch</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>norwegisch</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Polieren</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugiesisch (Brasilien)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>rumänisch</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>finnisch</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Schwedisch</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Vietnamesisch</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Türkisch</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thai</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>griechisch</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>bulgarisch</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Russisch</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ukrainisch</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.el.resx
+++ b/Infrastructure/Resources/Strings.el.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,72 +13,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>Key API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Τα πλήκτρα API πρέπει να έχουν τουλάχιστον 32 χαρακτήρες.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Συνδεδεμένος</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Ασύνδετος</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Ρυθμίσεις ειδοποίησης διαφωνίας</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Βλάβη:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Είδος:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>ΧΑΡΤΗΣ:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Τύπος στρογγυλού:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Τρόμος:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Κινέζοι (απλοποιημένοι)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>αγγλικός</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Ιαπωνικά</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>κορεάτης</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>ΕΝΤΑΞΕΙ</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Θύρα OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Ρυθμίσεις OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Σφάλμα αναλύσεων</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Ρυθμίσεις TonroundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>Το TonroundCounter-Cloud είναι μια υπηρεσία cloud που μπορεί να συγχρονίσει αυτόματα τους κωδικούς αποθήκευσης σε πολλές συσκευές.
+Απαιτείται ένα κλειδί API.
+Λάβετε ένα κλειδί API από τον ιστότοπο.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Ανοιχτό tonroundcounter-cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Τόνο</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
@@ -87,360 +87,360 @@ APIキーはwebサイトから取得してください。</value>
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Προτεραιότητα στους ήχους του αντικειμένου</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Στοιχείο μουσικής τέχνασμα</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Εμφάνιση αδέσμευτων λεπτομερειών τρομοκρατίας</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Εισαγωγή</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Παράθυρα</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Εξαγωγή</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Σφάλμα</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Ρυθμίσεις επικάλυψης</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Ματαίωση</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Εμφάνιση συντομεύσεων</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Δείξτε ζημιά</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Τρόμος</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Κλειδώνετε το χρώμα της τρομοκρατίας:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Δείχνουν τρόμο</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Όνομα τρόμου</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Εμφάνιση λεπτομερειών τρομοκρατίας</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Θέμα</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Εμφάνιση πληροφοριών εντοπισμού σφαλμάτων</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Αρχείο</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Ρυθμίσεις φίλτρου</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Προκαθορισμένη:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Προκαθορισμένη εισαγόμενη.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Προεπιλογή που εξάγεται.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Προεπιλογή αποθηκεύτηκε.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Ρυθμίσεις στρογγυλής/τρομοκρατίας BGM</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Παίξτε BGM με στρογγυλό/τρομοκρατία</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Δώστε προτεραιότητα στο στρογγυλό BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Στρογγυλός τύπος</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Στατιστικά στοιχεία τύπου Στατιστικά:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Εμφάνιση ιστορικού τύπου στρογγυλού</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Στρογγυλό αρχείο καταγραφής</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Εμφάνιση στρογγυλού αρχείου καταγραφής</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Στρογγυρό φόντο καταγραφής:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Ονόματα</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Εμφάνιση στρογγυλής κατάστασης</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Ρυθμίστε τη διεύθυνση URL WebHook για να στείλετε αποτελέσματα στρογγυλοποίησης στη διαφωνία. Αφήστε κενό για να απενεργοποιήσετε.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Εμφάνιση στρογγυλών στατιστικών</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Παίζω και τα δύο</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Εκτός</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Ήχος για αναπαραγωγή</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Εμφανίσεις</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Αφαιρώ</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Ξεφυλλίζω...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Καρφίτσα στην κορυφή</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Ξεκαρφιτσώνω</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Εκκίνηση εξωτερικών εφαρμογών αυτόματα</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Εκτελέσιμος</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Όνομα στοιχείου στόχου</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Αριθμός ιστορικών:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Επιχειρήματα</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Πληροφορίες</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>ΠΛΗΡΟΦΟΡΙΕΣ ΠΛΗΡΟΦΟΡΙΕΣ:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Εμφάνιση ρολογιού</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Ασαφής αντιστοίχιση</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Μέγιστη ταχύτητα</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Ελάχιστη ταχύτητα</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Ενεργοποιημένος</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Σφάλμα σύνταξης</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Εμφάνιση επόμενου γύρου πρόβλεψη</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Θάνατοι</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Εμφάνιση χρονοδιακόπτη</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Παίξτε μουσική για συγκεκριμένα αντικείμενα</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Η αυτόματη αυτοκτονία δεν θα εκτελεστεί με τις τρέχουσες ρυθμίσεις.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Επιζώντες</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Ποσοστό επιβίωσης</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Προτεραιότητα όταν συμβαίνουν συγκρούσεις:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Εξοδος</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Εμφάνιση στατιστικών στοιχείων</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Στατιστική</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Φόντο του πίνακα στατιστικών στοιχείων:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Χρώματα φόντου</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Η αυτόματη αυτοκτονία είναι απενεργοποιημένη.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Ενεργοποίηση αυτόματης αυτοκτονίας</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Λειτουργία αυτόματης αυτοκτονίας</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Γύροι στόχου αυτόματης αυτοκτονίας:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Ρυθμίσεις αυτόματης εκκίνησης</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Επιλέξτε χρώμα</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Ρυθμίσεις εμφάνισης</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Γωνιά εμφάνισης</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Οι γραμμές δεν μπορούσαν να αναλυθούν:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Γλώσσα</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Ρυθμίσεις</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Ρυθμίσεις ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Διαμόρφωση</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Αναθεωρήστε τη διαμόρφωση</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Αλλαγή ρυθμίσεων</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Χρησιμοποιήστε προηγμένες ρυθμίσεις</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Προχωρημένες ρυθμίσεις Ρυθμίσεις</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Φορτίο</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Προειδοποίηση</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Προσθέτω</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Πρόσθετες ρυθμίσεις</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Αδιαφάνεια</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Εμφάνιση ταχύτητας</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>δανικός</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Γερμανός</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Αγγλικά (Ηνωμένο Βασίλειο)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Αγγλικά (Ηνωμένες Πολιτείες)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>ισπανικά</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Ισπανικά (Λατινική Αμερική)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Γάλλος</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Κροατία</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>ιταλικά</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Λιθουανικός</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>ουγγρικός</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Ολλανδός</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Νορβηγός</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Στίλβωση</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Πορτογαλικά (Βραζιλία)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>ρουμανικός</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>φινλανδικός</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>σουηδικά</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Βιετναμέζος</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>τούρκικος</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Ταϊλάνδης</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>ελληνικά</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Βούλγαρος</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>ρωσικός</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Ουκρανός</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.en-GB.resx
+++ b/Infrastructure/Resources/Strings.en-GB.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,69 +13,69 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API Key:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API keys must be at least 32 characters long.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Connected</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Disconnected</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Discord Notification Settings</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Damage:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Item:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
     <value>MAP:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Round Type:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Chinese (Simplified)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>English</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Japanese</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Korean</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC Port:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC Settings</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Parse Error</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>ToNRoundCounter-Cloud Settings</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>ToNRoundCounter-Cloud is a cloud service that can automatically sync save codes across multiple devices.
+An API key is required.
+Please obtain an API key from the website.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Open ToNRoundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
     <value>ToNRoundCounter</value>
@@ -87,360 +87,360 @@ APIキーはwebサイトから取得してください。</value>
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Prioritize item sounds</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Item Music Gimmick</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Show Unbound terror details</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Import</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Windows</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Export</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Error</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Overlay Settings</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Cancel</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Show shortcuts</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Show damage</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terror</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Lock terror name color:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Show terror</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Terror Name</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Show terror details</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Theme</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Show debug info</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>File</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Filter Settings</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Preset:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Preset imported.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Preset exported.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Preset saved.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Round/Terror BGM Settings</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Play BGM by round/terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Prioritize round BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Round Type</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Round type stats display:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Show round type history</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Round Log</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Show round log</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Round log background:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Round Name</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Show round status</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Configure the Webhook URL to send round results to Discord. Leave blank to disable.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Show round stats</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Play both</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Save</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio to play</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Appearances</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Remove</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Browse...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin on top</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Unpin</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Launch external apps automatically</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Executable</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Target item name</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>History count:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Arguments</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Information</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Info panel background:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Show clock</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Fuzzy matching</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Max speed</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Min speed</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Enabled</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Syntax error</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Show next round prediction</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Deaths</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Show dwell timer</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Play music for specific items</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-suicide will not run with the current settings.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Survivals</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Survival rate</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Priority when conflicts occur:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Exit</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Show statistics</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistics</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Stats panel background:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Background colors</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-suicide is disabled.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Enable auto-suicide</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Auto-suicide mode</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Auto-suicide target rounds:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Auto-launch settings</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Choose color</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Display settings</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Show angle</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Lines could not be parsed:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Language</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Settings</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Settings...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Configuration</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Review configuration</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Change settings</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Use advanced settings</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Advanced settings docs</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Load</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Warning</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Add</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Additional settings</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacity</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Show speed</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Danish</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>German</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>English (United Kingdom)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>English (United States)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Spanish</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Spanish (Latin America)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>French</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Croatian</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Italian</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Lithuanian</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Hungarian</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Dutch</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Norwegian</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Polish</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portuguese (Brazil)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Romanian</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Finnish</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Swedish</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Vietnamese</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Turkish</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thai</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Greek</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bulgarian</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Russian</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Ukrainian</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.en-US.resx
+++ b/Infrastructure/Resources/Strings.en-US.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,69 +13,69 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API Key:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API keys must be at least 32 characters long.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Connected</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Disconnected</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Discord Notification Settings</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Damage:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Item:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
     <value>MAP:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Round Type:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Chinese (Simplified)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>English</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Japanese</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Korean</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC Port:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC Settings</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Parse Error</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>ToNRoundCounter-Cloud Settings</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>ToNRoundCounter-Cloud is a cloud service that can automatically sync save codes across multiple devices.
+An API key is required.
+Please obtain an API key from the website.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Open ToNRoundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
     <value>ToNRoundCounter</value>
@@ -87,360 +87,360 @@ APIキーはwebサイトから取得してください。</value>
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Prioritize item sounds</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Item Music Gimmick</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Show Unbound terror details</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Import</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Windows</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Export</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Error</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Overlay Settings</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Cancel</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Show shortcuts</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Show damage</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terror</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Lock terror name color:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Show terror</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Terror Name</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Show terror details</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Theme</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Show debug info</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>File</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Filter Settings</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Preset:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Preset imported.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Preset exported.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Preset saved.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Round/Terror BGM Settings</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Play BGM by round/terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Prioritize round BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Round Type</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Round type stats display:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Show round type history</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Round Log</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Show round log</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Round log background:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Round Name</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Show round status</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Configure the Webhook URL to send round results to Discord. Leave blank to disable.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Show round stats</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Play both</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Save</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio to play</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Appearances</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Remove</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Browse...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin on top</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Unpin</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Launch external apps automatically</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Executable</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Target item name</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>History count:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Arguments</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Information</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Info panel background:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Show clock</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Fuzzy matching</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Max speed</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Min speed</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Enabled</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Syntax error</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Show next round prediction</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Deaths</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Show dwell timer</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Play music for specific items</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-suicide will not run with the current settings.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Survivals</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Survival rate</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Priority when conflicts occur:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Exit</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Show statistics</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistics</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Stats panel background:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Background colors</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-suicide is disabled.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Enable auto-suicide</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Auto-suicide mode</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Auto-suicide target rounds:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Auto-launch settings</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Choose color</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Display settings</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Show angle</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Lines could not be parsed:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Language</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Settings</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Settings...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Configuration</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Review configuration</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Change settings</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Use advanced settings</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Advanced settings docs</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Load</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Warning</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Add</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Additional settings</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacity</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Show speed</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Danish</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>German</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>English (United Kingdom)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>English (United States)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Spanish</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Spanish (Latin America)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>French</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Croatian</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Italian</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Lithuanian</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Hungarian</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Dutch</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Norwegian</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Polish</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portuguese (Brazil)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Romanian</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Finnish</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Swedish</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Vietnamese</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Turkish</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thai</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Greek</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bulgarian</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Russian</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Ukrainian</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.es-419.resx
+++ b/Infrastructure/Resources/Strings.es-419.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>Clave API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Las teclas API deben tener al menos 32 caracteres.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Conectado</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Desconectado</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Configuración de notificación de discordia</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Daño:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Artículo:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>MAPA:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Tipo redondo:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Chino (simplificado)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Inglés</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>japonés</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>coreano</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>DE ACUERDO</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Puerto OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Configuración de OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Error</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Configuración de nube de tonroundcounter</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter Cloud es un servicio en la nube que puede sincronizar automáticamente los códigos de guardar en múltiples dispositivos.
+Se requiere una clave API.
+Obtenga una clave API del sitio web.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Nube abierta de tonroundcounter</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
-    <value>WebSocket IP:</value>
+    <value>IP WebSocket:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL de webhook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Priorizar sonidos del elemento</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Elemento de música</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Mostrar detalles del terror no ungo</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Importar</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Windows</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Exportar</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Error</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Configuración de superposición</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Cancelar</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Mostrar atajos</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Mostrar daños</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terror</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Bloquear el color del nombre del terror:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Terror de exhibición</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Nombre del terror</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Mostrar detalles del terror</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Tema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Mostrar información de depuración</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Archivo</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Configuración de filtro</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Programar:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Preestablecido importado.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Preset exportado.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Preestablecido guardado.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Configuración de BGM redondas/terroristas</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Juega BGM por Round/Terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Priorizar la redonda BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Tipo redondo</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Pantalla de estadísticas de tipo redondo:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Mostrar historia de tipo redondo</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Ronda de rondas</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Mostrar registro redondo</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Fondo de registro redondo:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Nombre redondo</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Mostrar estado redondo</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Configure la URL de Webhook para enviar resultados redondos a Discord. Deja en blanco para deshabilitar.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Mostrar estadísticas redondas</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Jugar</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Ahorrar</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio para reproducir</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Apariciones</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Eliminar</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Navegar...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin en la parte superior</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Desprender</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Iniciar aplicaciones externas automáticamente</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Ejecutable</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Nombre del elemento objetivo</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>History Count:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumentos</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Información</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Antecedentes del panel de información:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Vigilia</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Combate difuso</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Velocidad máxima</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Velocidad mínima</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Activado</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Error de sintaxis</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Mostrar la próxima predicción de la ronda</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Fallecidos</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Temporizador de exposición de mando</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Reproducir música para artículos específicos</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>El auto-suicidio no se ejecutará con la configuración actual.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Sobrevivientes</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Tasa de supervivencia</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioridad cuando ocurren conflictos:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Salida</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Mostrar estadísticas</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Estadística</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Antecedentes del panel de estadísticas:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Colores de fondo</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>El auto-suicidio está deshabilitado.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Habilitar auto-suicidio</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Modo de autosuicidio</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Rondas de objetivos automáticos de autos:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Configuración automática</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Elige el color</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Mostrar configuración</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Mostrar ángulo</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Las líneas no se pueden analizar:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Idioma</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Ajustes</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Ajustes...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Configuración</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Revisar la configuración</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Cambiar la configuración</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Utilice la configuración avanzada</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Configuración avanzada documentos</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Carga</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Advertencia</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Agregar</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Configuración adicional</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacidad</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Vía de exhibición</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>danés</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Alemán</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Inglés (Reino Unido)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Inglés (Estados Unidos)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Español</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Español (América Latina)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Francés</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>croata</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>italiano</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>lituano</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>húngaro</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Holandés</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>noruego</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Polaco</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugués (Brasil)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>rumano</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>finlandés</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>sueco</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>vietnamita</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>turco</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>tailandés</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Griego</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>búlgaro</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>ruso</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ucranio</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.es.resx
+++ b/Infrastructure/Resources/Strings.es.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>Clave API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Las teclas API deben tener al menos 32 caracteres.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Conectado</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Desconectado</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Configuración de notificación de discordia</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Daño:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Artículo:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>MAPA:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Tipo redondo:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Chino (simplificado)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Inglés</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>japonés</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>coreano</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>DE ACUERDO</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Puerto OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Configuración de OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Error</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Configuración de nube de tonroundcounter</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter Cloud es un servicio en la nube que puede sincronizar automáticamente los códigos de guardar en múltiples dispositivos.
+Se requiere una clave API.
+Obtenga una clave API del sitio web.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Nube abierta de tonroundcounter</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
-    <value>WebSocket IP:</value>
+    <value>IP WebSocket:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL de webhook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Priorizar sonidos del elemento</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Elemento de música</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Mostrar detalles del terror no ungo</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Importar</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Windows</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Exportar</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Error</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Configuración de superposición</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Cancelar</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Mostrar atajos</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Mostrar daños</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terror</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Bloquear el color del nombre del terror:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Terror de exhibición</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Nombre del terror</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Mostrar detalles del terror</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Tema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Mostrar información de depuración</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Archivo</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Configuración de filtro</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Programar:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Preestablecido importado.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Preset exportado.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Preestablecido guardado.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Configuración de BGM redondas/terroristas</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Juega BGM por Round/Terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Priorizar la redonda BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Tipo redondo</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Pantalla de estadísticas de tipo redondo:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Mostrar historia de tipo redondo</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Ronda de rondas</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Mostrar registro redondo</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Fondo de registro redondo:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Nombre redondo</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Mostrar estado redondo</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Configure la URL de Webhook para enviar resultados redondos a Discord. Deja en blanco para deshabilitar.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Mostrar estadísticas redondas</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Jugar</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Ahorrar</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio para reproducir</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Apariciones</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Eliminar</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Navegar...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin en la parte superior</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Desprender</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Iniciar aplicaciones externas automáticamente</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Ejecutable</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Nombre del elemento objetivo</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>History Count:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumentos</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Información</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Antecedentes del panel de información:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Vigilia</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Combate difuso</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Velocidad máxima</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Velocidad mínima</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Activado</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Error de sintaxis</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Mostrar la próxima predicción de la ronda</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Fallecidos</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Temporizador de exposición de mando</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Reproducir música para artículos específicos</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>El auto-suicidio no se ejecutará con la configuración actual.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Sobrevivientes</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Tasa de supervivencia</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioridad cuando ocurren conflictos:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Salida</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Mostrar estadísticas</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Estadística</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Antecedentes del panel de estadísticas:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Colores de fondo</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>El auto-suicidio está deshabilitado.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Habilitar auto-suicidio</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Modo de autosuicidio</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Rondas de objetivos automáticos de autos:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Configuración automática</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Elige el color</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Mostrar configuración</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Mostrar ángulo</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Las líneas no se pueden analizar:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Idioma</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Ajustes</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Ajustes...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Configuración</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Revisar la configuración</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Cambiar la configuración</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Utilice la configuración avanzada</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Configuración avanzada documentos</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Carga</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Advertencia</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Agregar</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Configuración adicional</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacidad</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Vía de exhibición</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>danés</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Alemán</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Inglés (Reino Unido)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Inglés (Estados Unidos)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Español</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Español (América Latina)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Francés</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>croata</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>italiano</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>lituano</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>húngaro</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Holandés</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>noruego</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Polaco</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugués (Brasil)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>rumano</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>finlandés</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>sueco</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>vietnamita</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>turco</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>tailandés</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Griego</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>búlgaro</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>ruso</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ucranio</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.fi.resx
+++ b/Infrastructure/Resources/Strings.fi.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,72 +13,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API -avain:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API -avaimien on oltava vähintään 32 merkkiä pitkä.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Kytketty</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Irrotettu</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Discord -ilmoitusasetukset</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Vahingoittaa:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Tuote:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>KARTTA:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Pyöreä tyyppi:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Kiinalainen (yksinkertaistettu)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>englanti</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Japanilainen</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Korealainen</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>Hyvä</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC -portti:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC -asetukset</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Jäsennysvirhe</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>TonroundCounter-Cloud-asetukset</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud on pilvipalvelu, joka voi synkronoida automaattisesti koodit useiden laitteiden välillä.
+API -avain vaaditaan.
+Hanki API -avain verkkosivustolta.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Avoin tonroundcounter-cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
@@ -87,360 +87,360 @@ APIキーはwebサイトから取得してください。</value>
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Priorisoi kohteen äänet</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Tuotemusiikkia</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Näytä sitoutumattomat terrorin yksityiskohdat</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Tuoda</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Ikkunat</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Viedä</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Virhe</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Päällyste asetukset</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Peruuttaa</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Näytä pikakuvakkeet</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Osoittaa vaurioita</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Kauhu</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Lukitse terrorin nimi väri:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Osoittaa terroria</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Terrorinimi</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Näytä terrorin yksityiskohdat</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Teema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Näytä virheenkorjaustiedot</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Tiedosto</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Suodatinasetukset</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Esiasetus:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Esiasetettu tuotu.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Esiasetettu.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Esiasetettu tallennettu.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Pyöreä/terrori BGM -asetukset</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Pelaa BGM: tä kierroksella/terrorilla</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Priorisoi pyöreä BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Pyöreä tyyppi</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Pyöreän tyyppiset tilastot Näytä:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Näytä pyöreän tyyppinen historia</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Pyöreä tukki</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Näytä pyöreä loki</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Pyöreän lokin tausta:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Pyöreä nimi</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Näytä pyöreä tila</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Määritä Webhook -URL -osoite lähettääksesi kierrokset tulokset Discordiin. Jätä tyhjää poistaaksesi käytöstä.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Näytä pyöreät tilastot</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Pelata molemmat</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Tallentaa</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Ääni toistaa</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Esiintymiset</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Poistaa</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Selaa ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pintää</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Purkaa</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Käynnistä ulkoiset sovellukset automaattisesti</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Suoritettava</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Kohdetuotteen nimi</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Historia ei</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Väitteet</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Tiedot</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Info -paneelin tausta:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Näyttökello</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Sumea sovitus</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Enimmäisnopeus</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Mininopeus</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Poistettu</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Syntaksivirhe</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Näytä seuraavan kierroksen ennuste</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Kuolemat</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Show Durk Timer</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Toista musiikkia tietyille tuotteille</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-itsemurha ei toimi nykyisten asetusten kanssa.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Selviytyjät</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Eloonjäämisaste</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Etusija, kun konflikteja esiintyy:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Poistuminen</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Näytä tilastot</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Tilastot</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Tilastojen paneelin tausta:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Taustavärit</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-itsemurha on poistettu käytöstä.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Ota auto-itsemurha</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Auto-itsemurha-tila</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Auto-itsemurha-kohdekierrokset:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Automaattisen aseman asetukset</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Valitse väri</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Näyttöasetukset</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Näyttelykulma</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Linjoja ei voitu jäsentää:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Kieli</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Asetukset</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Asetukset ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Kokoonpano</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Tarkista kokoonpano</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Vaihda asetukset</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Käytä lisäasetuksia</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Lisäasetukset Docs</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Ladata</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Varoitus</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Lisätä</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Lisäasetukset</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opasiteetti</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Näytönopeus</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Tanskalainen</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Saksalainen</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Englanti (Yhdistynyt kuningaskunta)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Englanti (Yhdysvallat)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Espanjalainen</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Espanja (Latinalainen Amerikka)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Ranskalainen</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Kroatialainen</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Italialainen</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Liettualainen</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Unkarilainen</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Hollantilainen</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Norja</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Kiillottaa</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugalilainen (Brasilia)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Romanialainen</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Suomalainen</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Ruotsalainen</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>vietnam</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Turkkilainen</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thaimaalainen</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Kreikka</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bulgarialainen</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Venäläinen</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Ukrainalainen</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.fr.resx
+++ b/Infrastructure/Resources/Strings.fr.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>Clé API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Les clés de l'API doivent compter au moins 32 caractères.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Connecté</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Déconnecté</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Paramètres de notification de discorde</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Dommage:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Article:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>CARTE:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Type rond:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terreur:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Chinois (simplifié)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Anglais</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>japonais</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>coréen</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>D'ACCORD</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Port OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Paramètres OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Erreur d'analyse</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Paramètres TonroundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud est un service cloud qui peut synchroniser automatiquement les codes de sauvegarde sur plusieurs périphériques.
+Une clé API est requise.
+Veuillez obtenir une clé API sur le site Web.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Open Tonroundcounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL Webhook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Prioriser les sons des éléments</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Gimmick de musique d'article</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Montrer les détails de la terreur non liés</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Importer</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Fenêtre</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Exporter</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Erreur</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Paramètres de superposition</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Annuler</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Montrer les raccourcis</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Faire preuve de dégâts</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terreur</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Verrouiller le nom de la terreur Couleur:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Montrer la terreur</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Nom de terreur</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Montrer les détails de la terreur</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Thème</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Afficher les informations de débogage</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Déposer</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Paramètres de filtre</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Préréglage:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Prédéfini importé.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Prédéfini exporté.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Préréglé sauvé.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Paramètres BGM ronds / terroristes</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Jouez à BGM par rond / terreur</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Prioriser le rond BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Type rond</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Affichage des statistiques de type rond:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Montrer l'histoire du type rond</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Bûche ronde</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Afficher le journal rond</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Arrière-plan rond:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Nom ronde</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Afficher le statut rond</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Configurez l'URL WebHook pour envoyer des résultats ronds à Discord. Laissez vide pour désactiver.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Montrer les statistiques rondes</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Jouer les deux</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Sauvegarder</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio pour jouer</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Apparitions</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Retirer</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Parcourir...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Épingler sur le dessus</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Détacher</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Lancez automatiquement les applications externes</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Exécutable</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Nom de l'élément cible</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Nombre d'histoire:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Arguments</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Information</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Contexte du panneau d'information:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Horloge de spectacle</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Correspondance floue</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Vitesse maximale</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Vitesse min</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Activé</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Erreur de syntaxe</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Afficher la prédiction du tour suivant</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Décès</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Show habitant la minuterie</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Jouer de la musique pour des articles spécifiques</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-Suicide ne fonctionnera pas avec les paramètres actuels.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Survivants</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Taux de survie</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Priorité lorsque les conflits se produisent:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Sortie</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Montrer des statistiques</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistiques</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Contexte du panneau des statistiques:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Couleurs de fond</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>L'auto-suicide est handicapé.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Activer l'auto-suicide</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Mode automatique-suicide</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Rounds cibles de suicide automatique:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Paramètres de lancement automatique</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Choisissez la couleur</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Paramètres d'affichage</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Angle de montre</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Les lignes ne pouvaient pas être analysées:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Langue</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Paramètres</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Paramètres...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Configuration</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Examiner la configuration</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Modifier les paramètres</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Utiliser des paramètres avancés</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Docs de paramètres avancés</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Charger</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Avertissement</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Ajouter</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Paramètres supplémentaires</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacité</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Vitesse de montre</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>danois</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Allemand</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Anglais (Royaume-Uni)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Anglais (États-Unis)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Espagnol</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Espagnol (Amérique latine)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Français</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>croate</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>italien</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>lituanien</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>hongrois</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Néerlandais</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>norvégien</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>polonais</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugais (Brésil)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>roumain</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>finlandais</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>suédois</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>vietnamien</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>turc</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>thaïlandais</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>grec</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>bulgare</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>russe</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ukrainien</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.hr.resx
+++ b/Infrastructure/Resources/Strings.hr.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,72 +13,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API ključ:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API tipke moraju biti dugačke najmanje 32 znaka.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Povezan</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Nepovezan</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Postavke obavijesti o neskladu</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Oštećenje:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Artikal:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>KARTA:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Vrsta kruga:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Teror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Kinezi (pojednostavljeni)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>engleski</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>japanski</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>korejski</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>U REDU</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC luka:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC postavke</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Pogreška raščlanjivanja</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Postavke tonroundcounter-cloud</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud je usluga u oblaku koja može automatski sinkronizirati kodove na više uređaja.
+Potreban je API ključ.
+Na web stranici dobijte API ključ.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Otvoreni tonroundcounter-cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
@@ -87,360 +87,360 @@ APIキーはwebサイトから取得してください。</value>
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Prioritete zvukove predmeta</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Predmet glazbenog trik</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Pokažite nevezane detalje terora</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Uvoz</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Prozori</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Izvoz</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Pogreška</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Postavke prekrivanja</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Otkazati</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Prikaži prečace</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Pokazati štetu</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Teror</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Zaključajte boju imena terora:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Pokazati teror</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Ime terora</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Prikaži detalje o teroru</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Tema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Prikaži informacije o uklanjanju pogrešaka</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Datoteka</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Postavke filtra</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Unaprijed postavljeno:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Unaprijed postavljeno uvezeno.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Pretpostavljen izvezen.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Unaprijed spreman.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Postavke okrugle/terorizam BGM</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Igrajte BGM po okruglom/teroru</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Prioritet Okrugli BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Tipa</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Zaslon statistike s okruglim vrstama:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Prikaži povijest okruglog tipa</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Okrugli zapisnik</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Prikaži okrugli dnevnik</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Pozadina okruglog dnevnika:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Okruglo ime</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Prikaži status kruga</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Konfigurirajte URL WebHook da pošalje okrugle rezultate u nesklad. Ostavite prazno da se onemogući.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Pokažite okrugle statistike</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Igrajte oboje</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Uštedjeti</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Zvuk za reprodukciju</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Nastupi</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Ukloniti</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Pregledajte ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin na vrhu</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Raskoš</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Automatski pokrenite vanjske aplikacije</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Izvršni</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Naziv ciljne stavke</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Broj povijesti:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumenti</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Informacija</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Pozadina info ploče:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Show clock</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Nejasno podudaranje</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Maksimalna brzina</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Min brzina</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Omogućeno</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Pogreška sintakse</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Prikaži predviđanje sljedećeg kruga</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Smrtni slučajevi</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Prikaži tajmer</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Reproducirajte glazbu za određene predmete</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-samoubojstvo neće se pokrenuti s trenutnim postavkama.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Preživjeli</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Stopa preživljavanja</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioritet kada se pojave sukobi:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Izlaz </value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Pokazati statistiku</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistika</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Pozadina ploče statistike:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Boje pozadine</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-samoubojstvo je onemogućeno.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Omogući auto-samoubojstvo</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Auto-samoucidinski način</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Auto-samo-samoubojstvo ciljanih krugova:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Postavke automatskog lansiranja</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Odaberite boju</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Postavke prikaza</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Pokazati kut</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Linije se nisu mogle raščlaniti:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Jezik</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Postavke</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Postavke ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Konfiguracija</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Pregledajte konfiguraciju</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Promijenite postavke</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Koristite napredne postavke</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Dokumenti naprednih postavki</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Opterećenje</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Upozorenje</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Dodati</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Dodatne postavke</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Neprozirnost</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Pokazati brzinu</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>danski</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>njemački</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Engleski (Ujedinjeno Kraljevstvo)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Engleski (Sjedinjene Države)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Španjolski</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Španjolska (Latinska Amerika)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>francuski</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>hrvatski</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>talijanski</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>litvanski</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Mađarski</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Nizozemski</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Norvežanin</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Polirati</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugal (Brazil)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Rumun</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Finski</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>švedski</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>vijetnamski</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>turski</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Tajlandski</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>grčki</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bugarski</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>ruski</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ukrajinski</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.hu.resx
+++ b/Infrastructure/Resources/Strings.hu.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API kulcs:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Az API -kulcsoknak legalább 32 karakternek kell lennie.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Összekapcsolt</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Szétkapcsolt</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>A diszkréció értesítési beállításai</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Kár:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Tétel:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>TÉRKÉP:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Kerek típus:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Kínai (egyszerűsített)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>angol</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>japán</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>koreai</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>RENDBEN</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC kikötő:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC -beállítások</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Elemzés hibája</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>TonroundCounter-Cloud beállítások</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>A TonRoundCounter-Cloud egy felhőalapú szolgáltatás, amely automatikusan szinkronizálhatja a kódok mentését több eszközön.
+API -kulcs szükséges.
+Kérjük, szerezzen egy API -kulcsot a weboldalról.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Nyissa meg a TonRoundCounter-Cloudot</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
-    <value>WebSocket IP:</value>
+    <value>Websocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Az elem hangjainak rangsorolása</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Cikk zenei trükk</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Mutasd meg a nem kötött terror részleteit</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Behozatal</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Ablakok</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Export</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Hiba</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Áplás beállítások</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Töröl</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Mutassa meg a parancsikonokat</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Sérüléseket mutat</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terror</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Lock terror név színe:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Terrort mutat</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Terrornév</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Mutasd meg a terrorista részleteit</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Téma</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Mutasd meg a hibakeresési információkat</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Irat</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Szűrőbeállítások</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Előre beállított:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Előre beállított behozatal.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Előre beállított exportált.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Előre beállított.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Kerek/terror BGM beállítások</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Játsszon a BGM -t kerek/terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>A BGM kerek prioritása</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Kerek típus</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Kerek típusú statisztika kijelző:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Mutasd meg a kerek típusú előzményeket</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Kerek napló</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Kerek napló megjelenítése</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Kerek napló háttér:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Kerek neve</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Mutasd meg a kerek állapotot</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Konfigurálja a WebHook URL -t, hogy kerek eredményeket küldjön a diszkréciónak. Hagyja üresen a letiltást.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Mutasd meg a kerek statisztikákat</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Játszani mindkettőt</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Megtakarítás</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio lejátszható</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Fellépés</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Eltávolítás</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Böngészj ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin a tetejére</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Kibont</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>A külső alkalmazások automatikus indítása</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Végrehajtható</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Cél elem neve</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>A történelem száma:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Érvek</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Információ</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Info panel háttér:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Az óra bemutatása</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Fuzzy illesztés</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Maximális sebesség</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Perc sebesség</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Engedélyezve</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Szintaxis hiba</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Mutasd meg a következő forduló előrejelzését</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Halálozások</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Show timer show timer</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Játsszon zenélni konkrét tárgyakhoz</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Az auto-öngyilkosság nem fog futni az aktuális beállításokkal.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Túlélés</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Túlélési arány</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioritás, amikor konfliktusok merülnek fel:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Kijárat</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Statisztikákat mutatni</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statisztika</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Statisztika panel háttér:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Háttérszínek</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Az auto-öngyilkosság le van tiltva.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Engedélyezze az auto-öngyilkosságot</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Auto-gyilkossági mód</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Auto-öngyilkossági célok:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Automatikus elindítás beállítások</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Válassza a Színt</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Megjelenítési beállítások</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Megmutatási szöget mutat</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>A vonalakat nem lehetett elemezni:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Nyelv</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Beállítások</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Beállítások ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Konfiguráció</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Felülvizsgálati konfiguráció</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>A beállítások módosítása</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Használja a Speciális beállításokat</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Speciális beállítások dokumentumai</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Terhelés</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Figyelmeztetés</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Hozzáad</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>További beállítások</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Átlátszatlanság</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Megmutatja a sebességet</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>dán</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>német</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Angol (Egyesült Királyság)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Angol (Egyesült Államok)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>spanyol</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Spanyol (Latin -Amerika)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>francia</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>horvát</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>olasz</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>litván</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>magyar</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>holland</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>norvég</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>lengyel</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugál (Brazília)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>román</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>finn</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>svéd</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>vietnami</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>török</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thaiföldi</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>görög</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>bolgár</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>orosz</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ukrán</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.it.resx
+++ b/Infrastructure/Resources/Strings.it.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>Chiave API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Le chiavi API devono essere lunghe almeno 32 caratteri.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Collegato</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Disconnesso</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Impostazioni di notifica discord</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Danno:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Articolo:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>MAPPA:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Tipo rotondo:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terrore:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Cinese (semplificato)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Inglese</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>giapponese</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>coreano</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Porta OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Impostazioni OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Errore di analisi</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Impostazioni TonroundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud è un servizio cloud che può sincronizzare automaticamente i codici di salvataggio su più dispositivi.
+È richiesta una chiave API.
+Si prega di ottenere una chiave API dal sito Web.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Open TonroundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>TonroundCounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL Webhook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Dai la priorità ai suoni degli articoli</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Gemme musicale oggetto</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Mostra i dettagli del terrore non legati</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Importare</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Finestre</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Esportare</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Errore</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Impostazioni di overlay</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Cancellare</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Mostra scorciatoie</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Mostrare danni</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terrore</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Blocca il colore del nome terroristico:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Mostra il terrore</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Nome terrore</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Mostra i dettagli del terrore</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Tema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Mostra informazioni sul debug</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>File</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Impostazioni del filtro</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Preimpostazione:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Preimpostata importata.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Preimpostata esportata.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Preimpostata salvata.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Impostazioni BGM rotonde/terroriche</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Gioca a BGM per round/terrore</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Dai la priorità al round bgm</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Tipo rotondo</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Display delle statistiche del tipo rotondo:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Mostra la cronologia del tipo rotondo</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Log rotondo</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Mostra registro rotondo</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Sfondo del registro rotondo:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Nome rotondo</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Mostra lo stato round</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Configurare l'URL Webhook per inviare risultati rotondi a Discord. Lasciare vuoto per disabilitare.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Mostra le statistiche rotonde</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Gioca entrambi</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Salva</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio da giocare</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Apparizioni</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Rimuovere</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Sfoglia ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin in cima</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Unpin</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Avvia automaticamente le app esterne</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Eseguibile</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Nome dell'articolo di destinazione</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Conteggio della storia:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argomenti</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Informazioni</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Sfondo del pannello di informazioni:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Mostra l'orologio</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Corrispondenza fuzzy</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Velocità massima</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Velocità min</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Abilitato</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Errore di sintassi</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Mostra la previsione del prossimo round</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Deceduti</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Mostra il timer di abitazione</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Riproduci musica per oggetti specifici</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>L'auto-suicidio non verrà eseguito con le impostazioni attuali.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Sopravvissuti</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Tasso di sopravvivenza</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Priorità quando si verificano conflitti:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Uscita</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Mostra statistiche</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistiche</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Sfondo del pannello delle statistiche:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Colori di sfondo</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>L'auto-suicidio è disabilitato.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Abilita l'auto-suicidio</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Modalità auto-suicidio</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Round bersaglio auto-suicidio:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Impostazioni di lancio automatico</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Scegli il colore</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Impostazioni di visualizzazione</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Mostra angolo</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Le linee non potrebbero essere analizzate:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Lingua</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Impostazioni</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Impostazioni...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Configurazione</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Revisione della configurazione</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Modificare le impostazioni</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Utilizzare le impostazioni avanzate</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Documenti di impostazioni avanzate</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Carico</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Avvertimento</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Aggiungere</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Impostazioni aggiuntive</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacità</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Mostra la velocità</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>danese</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>tedesco</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Inglese (Regno Unito)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Inglese (Stati Uniti)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>spagnolo</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Spagnolo (America Latina)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>francese</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>croato</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Italiano</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Lituano</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>ungherese</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Olandese</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>norvegese</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Polacco</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portoghese (Brasile)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>rumeno</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>finlandese</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>svedese</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>vietnamita</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>turco</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thai</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>greco</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>bulgaro</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>russo</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ucraino</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.ko.resx
+++ b/Infrastructure/Resources/Strings.ko.resx
@@ -13,69 +13,69 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API 키:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API 키는 32자 이상이어야 합니다.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>연결됨</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>연결 해제됨</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Discord 알림 설정</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>피해:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>아이템:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>맵:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>라운드 유형:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>테러:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>중국어(간체)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>영어</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>일본어</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>한국어</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>확인</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC 포트:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC 설정</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>파싱 오류</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>ToNRoundCounter-Cloud 설정</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>ToNRoundCounter-Cloud는 여러 기기 간에 세이브 코드를 자동으로 동기화할 수 있는 클라우드 서비스입니다.
+API 키가 필요합니다.
+웹사이트에서 API 키를 발급받아 주세요.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>ToNRoundCounter-Cloud 열기</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
     <value>ToNRoundCounter</value>
@@ -87,360 +87,360 @@ APIキーはwebサイトから取得してください。</value>
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>아이템 사운드 우선</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>아이템 음악 기믹</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>언바운드 테러 정보를 표시</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>가져오기</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>창</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>내보내기</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>오류</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>오버레이 설정</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>취소</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>단축키 표시</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>피해 표시</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>테러</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>테러 이름 색 고정:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>테러 표시</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>테러 이름</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>테러 상세 정보 표시</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>테마</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>디버그 정보 표시</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>파일</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>필터 설정</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>프리셋:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>프리셋을 가져왔습니다.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>프리셋을 내보냈습니다.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>프리셋을 저장했습니다.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>라운드/테러 BGM 설정</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>라운드/테러별로 BGM 재생</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>라운드 BGM 우선</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>라운드 유형</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>라운드 유형별 통계 표시 설정:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>라운드 유형 변화를 표시</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>라운드 로그</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>라운드 로그 표시</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>라운드 로그 배경색:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>라운드 이름</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>라운드 상태 표시</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>라운드 결과를 Discord로 전송할 Webhook URL을 설정합니다. 비워 두면 비활성화됩니다.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>라운드 통계 표시</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>둘 다 재생</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>저장</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>재생할 오디오</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>출현 횟수</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>삭제</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>찾아보기...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>고정하기</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>고정 해제</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>외부 앱 자동 실행</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>실행 파일</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>대상 아이템 이름</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>히스토리 표시 수:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>인수</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>정보</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>정보 표시 영역 배경색:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>시계 표시</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>퍼지 매칭</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>최대 속도</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>최소 속도</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>활성화</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>구문 오류</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>다음 라운드 예측 표시</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>사망 횟수</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>체류 타이머 표시</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>특정 아이템에서 음악 재생</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>현재 설정으로는 자동 자살이 실행되지 않습니다.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>생존 횟수</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>생존율</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>경합 시 우선 설정:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>종료</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>통계 정보 표시</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>통계 정보 영역</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>통계 표시 영역 배경색:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>배경색 설정</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>자동 자살이 비활성화되어 있습니다.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>자동 자살 활성화</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>자동 자살 모드</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>자동 자살 대상 라운드:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>자동 실행 설정</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>색 선택</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>표시 설정</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>각도 표시</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>해석할 수 없는 행이 있습니다:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>언어</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>설정</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>설정...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>설정 내용</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>설정 내용 확인</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>설정 변경</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>상세 설정 사용</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>상세 설정 문서</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>불러오기</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>경고</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>추가</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>추가 설정</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>투명도</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>속도 표시</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>덴마크어</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>독일어</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>영어 (영국)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>영어 (미국)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>스페인어</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>스페인어 (라틴 아메리카)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>프랑스어</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>크로아티아어</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>이탈리아어</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>리투아니아어</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>헝가리어</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>네덜란드어</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>노르웨이어</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>폴란드어</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>포르투갈어 (브라질)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>루마니아어</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>핀란드어</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>스웨덴어</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>베트남어</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>터키어</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>태국어</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>그리스어</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>불가리아어</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>러시아어</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>우크라이나어</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.lt.resx
+++ b/Infrastructure/Resources/Strings.lt.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API raktas:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API raktai turi būti bent 32 simboliai.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Prijungtas</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Atjungta</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Nesantaikos pranešimų nustatymai</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Žala:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Daiktas:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>Žemėlapis:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Apvalios tipas:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Teroras:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Kinai (supaprastinta)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Anglų kalba</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Japonų kalba</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Korėjietis</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>Gerai</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC prievadas:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC nustatymai</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Parse klaida</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>„TonroundCounter-Cloud“ nustatymai</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>„TonroundCounter-Cloud“ yra debesies paslauga, kuri gali automatiškai sinchronizuoti išsaugojimo kodus keliuose įrenginiuose.
+Reikalingas API raktas.
+Gaukite API raktą iš svetainės.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Atidarykite „TonroundCounter-Cloud“</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
-    <value>WebSocket IP:</value>
+    <value>„WebSocket“ IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>„WebHook“ URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Prioritetą teikite daiktų garsams</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Prekės muzikos gudrybė</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Parodykite be teroro detalių</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Importuoti</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>„Windows“</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Eksportas</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Klaida</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Perdangos nustatymai</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Atšaukti</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Rodyti nuorodas</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Parodykite žalą</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Teroras</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Užrakinkite teroro pavadinimo spalva:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Parodykite terorą</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Teroro vardas</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Parodykite teroro detales</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Tema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Rodyti derinimo informaciją</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Failas</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Filtro nustatymai</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Iš anksto nustatytas:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Iš anksto nustatytas importuota.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Iš anksto eksportuotas.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Iš anksto išsaugotas.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Apvalios/teroro BGM nustatymai</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Žaisk BGM per apvalų/terorą</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Prioritetas apvalus BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Apvalus tipas</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Apvalios tipo statistika:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Rodyti apvalios tipo istoriją</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Apvalus žurnalas</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Rodyti apvalų žurnalą</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Apvalaus žurnalo fonas:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Apvalus vardas</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Parodykite apvalią būseną</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Konfigūruokite „WebHook“ URL, kad galėtumėte išsiųsti ratus rezultatus į „Discord“. Palikite tuščią, kad išjungtumėte.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Rodyti apvalią statistiką</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Žaisk abu</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Išsaugoti</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Garsas žaisti</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Pasirodymai</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Pašalinti</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Naršykite ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Kaištis viršuje</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Unpin</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Automatiškai paleiskite išorines programas</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Vykdomas</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Tikslinio elemento pavadinimas</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Istorijos skaičius:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumentai</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Informacija</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Informacijos skydelio fonas:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Rodyti laikrodį</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Apytikslis atitikimas</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Maksimalus greitis</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Min greitis</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Įgalinta</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Sintaksės klaida</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Parodykite kitą turo prognozę</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Mirtys</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Parodykite „Dwell Timer“</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Groti muziką konkrečiems daiktams</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Automatinis savižudis neveiks su dabartiniais nustatymais.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Išgyvenimas</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Išgyvenimo procentas</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioritetas, kai kyla konfliktai:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Išvažiavimas</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Rodyti statistiką</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistika</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Statistikos skydelio fonas:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Fono spalvos</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Automatinis savižudybė yra išjungta.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Įgalinti automatinį savižudybę</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Automatinio savižudybės režimas</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Automatinio savižudybės taikinių raundai:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Automatinio paleidimo nustatymai</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Pasirinkite spalvą</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Ekrano nustatymai</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Rodyti kampą</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Linijos negalėjo būti analizuojamos:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Kalba</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Nustatymai</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Nustatymai ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Konfigūracija</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Peržiūrėkite konfigūraciją</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Keisti nustatymus</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Naudokite išplėstinius nustatymus</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Išplėstiniai nustatymų dokumentai</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Įkelti</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Įspėjimas</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Pridėti</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Papildomi nustatymai</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Neskaidrumas</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Rodyti greitį</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Danai</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Vokietis</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Anglų kalba (Jungtinė Karalystė)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Anglų kalba (JAV)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Ispanų kalba</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Ispanų kalba (Lotynų Amerika)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Prancūzų kalba</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Croatian</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Italų kalba</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Lietuvos</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Vengrų</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Olandai</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Norvegas</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Poliravimas</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugalai (Brazilija)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Rumunietis</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Suomija</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Švedijos</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Vietnamas</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Turkija</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Tailandas</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Graikų kalba</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bulgarijos kalba</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Rusas</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Ukrainos</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.nb.resx
+++ b/Infrastructure/Resources/Strings.nb.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,72 +13,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API -nøkkel:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API -nøkler må være minst 32 tegn.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Tilkoblet</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Koblet fra</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Discord -varslingsinnstillinger</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Skader:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Punkt:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>KART:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Rund type:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Skrekk:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Kinesisk (forenklet)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Engelsk</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Japansk</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Koreansk</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>Ok</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC -port:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC -innstillinger</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Analyser feil</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>TonRoundCounter-Cloud-innstillinger</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonRoundCounter-Cloud er en skytjeneste som automatisk kan synkronisere lagringskoder på flere enheter.
+Det kreves en API -nøkkel.
+Vennligst skaff deg en API -nøkkel fra nettstedet.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Åpen TonroundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
@@ -87,360 +87,360 @@ APIキーはwebサイトから取得してください。</value>
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Prioriter varelyder</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Varemusikk Gimmick</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Vis ubundne terroropplysninger</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Import</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Vinduer</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Eksport</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Feil</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Overleggsinnstillinger</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Kansellere</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Vis snarveier</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Vis skade</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Skrekk</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Lås terrornavn Farge:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Vis terror</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Terrornavn</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Vis terroropplysninger</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Tema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Vis feilsøkingsinfo</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Fil</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Filterinnstillinger</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Forhåndsinnstilt:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Forhåndsinnstilt importert.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Forhåndsinnstilt eksportert.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Forhåndsinnstilt lagret.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Runde/terror BGM -innstillinger</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Spill BGM av Round/Terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Prioriter Round BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Rund type</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Statistikk for runde type:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Vis historie om rund type</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Rund logg</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Vis rundlogg</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Rundloggbakgrunn:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Rundt navn</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Vis rund status</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Konfigurer netthook -URL for å sende runde resultater til Discord. La være tomt for å deaktivere.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Vis runde statistikk</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Spill begge deler</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Spare</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Lyd å spille</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Utseende</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Fjerne</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Bla gjennom ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin på toppen</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Upinn</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Start eksterne apper automatisk</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Kjørbar</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Mål varenavn</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Historielltelling:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumenter</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Informasjon</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Info -panelbakgrunn:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Vis klokke</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Fuzzy matching</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Maks hastighet</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Min hastighet</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Aktivert</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Syntaksfeil</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Vis neste runde spådom</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Dødsfall</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Vis DWELL TIMER</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Spill musikk for spesifikke ting</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-selvmord vil ikke kjøre med gjeldende innstillinger.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Overlevende</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Overlevelsesrate</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioritet når konflikter oppstår:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Gå</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Vis statistikk</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistikk</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Statistikk panelbakgrunn:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Bakgrunnsfarger</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-selvmord er deaktivert.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Aktiver auto-selvmord</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Auto-selvmordsmodus</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Auto-selvmordsmålrunder:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Innstillinger for automatisk lansering</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Velg farge</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Vis innstillinger</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Vis vinkel</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Linjer kunne ikke analyseres:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Språk</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Innstillinger</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Innstillinger ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Konfigurasjon</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Gjennomgå konfigurasjon</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Endre innstillinger</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Bruk avanserte innstillinger</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Avanserte innstillingsdokumenter</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Laste</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Advarsel</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Legge til</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Ytterligere innstillinger</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacitet</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Vis hastighet</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Dansk</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Tysk</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Engelsk (Storbritannia)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Engelsk (USA)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Spansk</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Spansk (Latin -Amerika)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Fransk</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Kroatisk</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Italiensk</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Litauisk</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Ungarsk</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Nederlandsk</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Norsk</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Pusse</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugisisk (Brasil)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Rumensk</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Finsk</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Svensk</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Vietnamesisk</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Tyrkisk</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thai</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Gresk</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bulgarsk</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Russisk</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Ukrainsk</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.nl.resx
+++ b/Infrastructure/Resources/Strings.nl.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API -sleutel:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API -toetsen moeten minimaal 32 tekens lang zijn.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Aangesloten</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Losgekoppeld</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Discord -meldingsinstellingen</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Schade:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Item:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>KAART:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Ronde type:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terreur:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Chinees (vereenvoudigd)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Engels</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Japanse</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Koreaans</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC -poort:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC -instellingen</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Parse -fout</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Tonroundcounter-cloud-instellingen</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud is een cloudservice die automatisch opslaan van codes op meerdere apparaten kan synchroniseren.
+Een API -sleutel is vereist.
+Krijg een API -sleutel van de website.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Open tonroundcounter-cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
-    <value>WebSocket IP:</value>
+    <value>Websocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Prioriteer itemgeluiden</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Item muziek gimmick</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Toon ongebonden terreurdetails</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Importeren</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Ramen</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Exporteren</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Fout</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Overlay -instellingen</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Annuleren</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Toon snelkoppelingen</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Toon schade</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terreur</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Lock Terror Name Color:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Toon terreur</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Terreurnaam</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Toon terreurdetails</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Thema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Toon debug -info</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Bestand</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Filterinstellingen</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Vooraf ingesteld:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Vooraf ingesteld geïmporteerd.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Vooraf ingesteld geëxporteerd.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Vooraf ingesteld opgeslagen.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Ronde/terreur BGM -instellingen</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Speel bgm door ronde/terreur</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Prioriteer round bgm</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Ronde type</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Ronde type statistieken weergeven:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Toon ronde type geschiedenis</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Ronde logboek</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Toon ronde logboek</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Ronde log -achtergrond:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Ronde naam</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Ronde status weergeven</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Configureer de WebHook -URL om ronde resultaten naar Discord te verzenden. Blijf leeg laten om uit te schakelen.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Toon ronde statistieken</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Speel beide</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Redden</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio om te spelen</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Verschijningen</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Verwijderen</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Blader ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin erop</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Losmaken</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Start externe apps automatisch</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Uitvoerbaar</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Doel -itemnaam</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Geschiedenis tellen:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumenten</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Informatie</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>INFO's Paneel Achtergrond:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Klok tonen</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Fuzzy matching</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Maximale snelheid</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Mijnsnelheid</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Ingeschakeld</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Syntaxisfout</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Toon de volgende ronde voorspelling</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Sterfgevallen</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Show Dwell Timer</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Speel muziek voor specifieke items</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-zelfmoord wordt niet uitgevoerd met de huidige instellingen.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Overlevingen</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Overlevingspercentage</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioriteit wanneer er conflicten optreden:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Uitgang</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Statistieken weergeven</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistieken</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Statistieken Paneel Achtergrond:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Achtergrondkleuren</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-zelfmoord is uitgeschakeld.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Schakel automatische zelficide in</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Auto-zelficidemodus</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Auto-zelfmoordende doelrondes:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Auto-lanceringsinstellingen</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Kies kleur</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Display -instellingen</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Angle tonen</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Lijnen konden niet worden ontleed:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Taal</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Instellingen</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Instellingen...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Configuratie</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Bekijk configuratie</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Instellingen wijzigen</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Gebruik geavanceerde instellingen</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Geavanceerde instellingen documenten</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Laden</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Waarschuwing</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Toevoegen</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Aanvullende instellingen</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Dekking</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Tonen snelheid</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Deens</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Duits</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Engels (Verenigd Koninkrijk)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Engels (Verenigde Staten)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Spaans</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Spaans (Latijns -Amerika)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Frans</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Kroatisch</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Italiaans</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Litouws</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Hongaars</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Nederlands</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Noors</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Pools</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugees (Brazilië)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Roemeense</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Fins</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Zweeds</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Vietnamees</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Turks</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thais</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Grieks</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bulgaars</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Russisch</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Oekraïens</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.pl.resx
+++ b/Infrastructure/Resources/Strings.pl.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>Klucz API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Klucze API muszą mieć co najmniej 32 znaki.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Połączony</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Bezładny</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Ustawienia powiadomienia niezgody</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Szkoda:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Przedmiot:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>MAPA:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Typ okrągłego:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Chiński (uproszczony)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>angielski</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>japoński</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>koreański</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Port OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Ustawienia OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Błąd analizowania</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Ustawienia TonroundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud to usługa w chmurze, która może automatycznie synchronizować kody zapisywania na wielu urządzeniach.
+Wymagany jest klucz API.
+Uzyskaj klucz API ze strony internetowej.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Otwórz TonroundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>TonroundCounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL Webhook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Priorytetyzuj dźwięki przedmiotu</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Sztuczka muzyczna przedmiotów</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Pokaż niezbędne szczegóły terroru</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Import</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Okna</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Eksport</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Błąd</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Ustawienia nakładki</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Anulować</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Pokaż skróty</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Pokazać szkody</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terror</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Zamknij kolor terrorowy:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Pokaż terror</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Nazwa terroru</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Pokaż szczegóły terroru</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Temat</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Pokaż informacje o debugowaniu</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Plik</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Ustawienia filtru</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>PREDET:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Wstępnie zaimportowane.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Wstępnie wyeksportowane.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Prezydent uratowany.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Ustawienia okrągłego/terroru BGM</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Zagraj w BGM przez Round/Terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Priorytetyzuj okrągły BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Typ okrągłego</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Wyświetlanie statystyk typu okrągłego:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Pokaż historię typu okrągłego</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Okrągły dziennik</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Pokaż okrągły dziennik</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Okrągłe tło dziennika:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Okrągła nazwa</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Pokaż status okrągłego</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Skonfiguruj adres URL WebHook, aby wysłać wyniki okrągłe do Discord. Pozostaw puste, aby wyłączyć.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Pokaż okrągłe statystyki</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Zagraj w oba</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Ratować</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio do zagrania</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Występy</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Usunąć</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Przeglądać...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin na górze</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Odpiąć</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Uruchom aplikacje zewnętrzne automatycznie</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Wykonywalny</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Nazwa elementu docelowego</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Liczba historii:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumenty</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Informacja</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Tło panelu informacyjnego:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Pokaż zegar</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Dopasowanie rozmyte</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Maksymalna prędkość</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Min min</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Włączony</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Błąd składni</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Pokaż następną prognozę rundy</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Zgony</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Pokaż timer mieszkań</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Odtwarzaj muzykę dla określonych przedmiotów</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Automatyczne samobójstwo nie będzie działać z bieżącymi ustawieniami.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Survivals</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Wskaźnik przeżycia</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Priorytet, gdy pojawiają się konflikty:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Wyjście</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Pokaż statystyki</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statystyka</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Tło panelu Stats:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Kolory tła</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Automatyczne samobójstwo jest wyłączone.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Włącz auto-samobójstwo</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Tryb automatycznego samobójstwa</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>ROZIĘCIA AUTORYBOCYJNEGO CELU:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Ustawienia automatycznego uruchamiania</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Wybierz kolor</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Ustawienia wyświetlania</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Pokaż kąt</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Nie można było przeanalizować linii:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Język</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Ustawienia</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Ustawienia ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Konfiguracja</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Przejrzyj konfigurację</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Zmień ustawienia</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Użyj ustawień zaawansowanych</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Zaawansowane dokumenty ustawień</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Obciążenie</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Ostrzeżenie</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Dodać</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Dodatkowe ustawienia</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Nieprzezroczystość</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Pokaż prędkość</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>duński</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>niemiecki</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Angielski (Wielka Brytania)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Angielski (Stany Zjednoczone)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>hiszpański</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Hiszpański (Ameryka Łacińska)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>francuski</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>chorwacki</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>włoski</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>litewski</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>węgierski</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Holenderski</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>norweski</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Polski</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugalski (Brazylia)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>rumuński</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>fiński</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>szwedzki</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>wietnamski</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>turecki</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>tajski</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>grecki</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>bułgarski</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>rosyjski</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ukraiński</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.pt-BR.resx
+++ b/Infrastructure/Resources/Strings.pt-BR.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>Chave da API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>As chaves da API devem ter pelo menos 32 caracteres.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Conectado</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Desconectado</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Configurações de notificação de discórdia</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Dano:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Item:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>MAPA:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Tipo redondo:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terror:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Chinês (simplificado)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Inglês</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>japonês</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>coreano</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Porta OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Configurações OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Erro de análise</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Configurações de clout-clout de tonRound</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>O TonRoundCounter-Cloud é um serviço em nuvem que pode sincronizar automaticamente códigos de salvar em vários dispositivos.
+Uma chave de API é necessária.
+Por favor, obtenha uma chave da API no site.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Aberta TonRoundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>TonRoundCounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL da webhook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Priorize sons do item</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Item Music Gimmick</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Mostre detalhes de terror não ligados</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Importar</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Windows</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Exportar</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Erro</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Configurações de sobreposição</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Cancelar</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Mostre atalhos</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Mostrar dano</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terror</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Lock Terror Name Color:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Mostrar terror</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Nome do terror</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Mostre detalhes do terror</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Tema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Mostre informações de depuração</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Arquivo</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Configurações de filtro</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Predefinição:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Predefinido importado.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Predefinido exportado.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Predefinido salvo.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Configurações redondas/terrorizadas BGM</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Jogue BGM por rodada/terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Priorize a redonda BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Tipo redondo</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Exibição de estatísticas do tipo redondo:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Mostrar história do tipo redondo</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Log redondo</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Mostre log redondo</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Round Log Background:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Nome redondo</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Mostre status de rodada</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Configure o URL da webhook para enviar resultados redondos para a discórdia. Deixe em branco para desativar.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Mostre estatísticas redondas</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Jogue os dois</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Salvar</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Áudio para jogar</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Aparências</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Remover</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Navegar...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin por cima</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Não</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Inicie aplicativos externos automaticamente</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Executável</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Nome do item de destino</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Contagem de história:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumentos</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Informação</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Painel de informações Antecedentes:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Mostrar relógio</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Combinação difusa</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Velocidade máxima</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Velocidade min</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Habilitado</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Erro de sintaxe</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Mostre a previsão da próxima rodada</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Mortes</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Mostrar temporizador de habitação</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Tocar música para itens específicos</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>O auto-suicídio não será executado com as configurações atuais.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Sobreviventes</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Taxa de sobrevivência</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioridade quando ocorrem conflitos:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Saída</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Mostrar estatísticas</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Estatística</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Painel de estatísticas.</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Cores de fundo</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-suicídio está desativado.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Habilitar suicídio automático</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Modo de suicídio automático</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Rodadas de destino de suicídio automático:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Configurações de lançamento automático</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Escolha a cor</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Configurações de exibição</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Mostrar ângulo</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Linhas não puderam ser analisadas:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Linguagem</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Configurações</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Configurações...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Configuração</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Revise a configuração</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Alterar configurações</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Use configurações avançadas</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Docros de configurações avançadas</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Carregar</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Aviso</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Adicionar</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Configurações adicionais</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacidade</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Mostre velocidade</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>dinamarquês</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Alemão</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Inglês (Reino Unido)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Inglês (Estados Unidos)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Espanhol</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Espanhol (América Latina)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Francês</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>croata</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>italiano</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>lituano</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>húngaro</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Holandês</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>norueguês</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>polonês</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Português (Brasil)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>romeno</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>finlandês</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>sueco</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>vietnamita</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>turco</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Tailandês</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>grego</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>búlgaro</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>russo</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ucraniano</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.resx
+++ b/Infrastructure/Resources/Strings.resx
@@ -12,19 +12,435 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>Round Type:</value>
+  <data name="APIキー:" xml:space="preserve">
+    <value>API Key:</value>
   </data>
-  <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+  <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
+    <value>API keys must be at least 32 characters long.</value>
   </data>
-  <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>Terror:</value>
+  <data name="Connected" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="Disconnected" xml:space="preserve">
+    <value>Disconnected</value>
+  </data>
+  <data name="Discord通知設定" xml:space="preserve">
+    <value>Discord Notification Settings</value>
+  </data>
+  <data name="InfoPanel_Damage" xml:space="preserve">
+    <value>Damage:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
     <value>Item:</value>
   </data>
-  <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>Damage:</value>
+  <data name="InfoPanel_Map" xml:space="preserve">
+    <value>MAP:</value>
+  </data>
+  <data name="InfoPanel_RoundType" xml:space="preserve">
+    <value>Round Type:</value>
+  </data>
+  <data name="InfoPanel_Terror" xml:space="preserve">
+    <value>Terror:</value>
+  </data>
+  <data name="Language_ChineseSimplified" xml:space="preserve">
+    <value>Chinese (Simplified)</value>
+  </data>
+  <data name="Language_English" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="Language_Japanese" xml:space="preserve">
+    <value>Japanese</value>
+  </data>
+  <data name="Language_Korean" xml:space="preserve">
+    <value>Korean</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="OSC接続ポート:" xml:space="preserve">
+    <value>OSC Port:</value>
+  </data>
+  <data name="OSC設定" xml:space="preserve">
+    <value>OSC Settings</value>
+  </data>
+  <data name="ParseError" xml:space="preserve">
+    <value>Parse Error</value>
+  </data>
+  <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
+    <value>ToNRoundCounter-Cloud Settings</value>
+  </data>
+  <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
+    <value>ToNRoundCounter-Cloud is a cloud service that can automatically sync save codes across multiple devices.
+An API key is required.
+Please obtain an API key from the website.</value>
+  </data>
+  <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
+    <value>Open ToNRoundCounter-Cloud</value>
+  </data>
+  <data name="ToNRoundCouter" xml:space="preserve">
+    <value>ToNRoundCounter</value>
+  </data>
+  <data name="WebSocket IP:" xml:space="preserve">
+    <value>WebSocket IP:</value>
+  </data>
+  <data name="Webhook URL:" xml:space="preserve">
+    <value>Webhook URL:</value>
+  </data>
+  <data name="アイテムサウンドを優先する" xml:space="preserve">
+    <value>Prioritize item sounds</value>
+  </data>
+  <data name="アイテム音楽ギミック" xml:space="preserve">
+    <value>Item Music Gimmick</value>
+  </data>
+  <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
+    <value>Show Unbound terror details</value>
+  </data>
+  <data name="インポート" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="ウィンドウ" xml:space="preserve">
+    <value>Windows</value>
+  </data>
+  <data name="エクスポート" xml:space="preserve">
+    <value>Export</value>
+  </data>
+  <data name="エラー" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="オーバーレイ設定" xml:space="preserve">
+    <value>Overlay Settings</value>
+  </data>
+  <data name="キャンセル" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="ショートカットを表示" xml:space="preserve">
+    <value>Show shortcuts</value>
+  </data>
+  <data name="ダメージを表示" xml:space="preserve">
+    <value>Show damage</value>
+  </data>
+  <data name="テラー" xml:space="preserve">
+    <value>Terror</value>
+  </data>
+  <data name="テラーの名前の色固定:" xml:space="preserve">
+    <value>Lock terror name color:</value>
+  </data>
+  <data name="テラーを表示" xml:space="preserve">
+    <value>Show terror</value>
+  </data>
+  <data name="テラー名" xml:space="preserve">
+    <value>Terror Name</value>
+  </data>
+  <data name="テラー詳細情報を表示" xml:space="preserve">
+    <value>Show terror details</value>
+  </data>
+  <data name="テーマ" xml:space="preserve">
+    <value>Theme</value>
+  </data>
+  <data name="デバッグ情報表示" xml:space="preserve">
+    <value>Show debug info</value>
+  </data>
+  <data name="ファイル" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="フィルター設定" xml:space="preserve">
+    <value>Filter Settings</value>
+  </data>
+  <data name="プリセット:" xml:space="preserve">
+    <value>Preset:</value>
+  </data>
+  <data name="プリセットをインポートしました。" xml:space="preserve">
+    <value>Preset imported.</value>
+  </data>
+  <data name="プリセットをエクスポートしました。" xml:space="preserve">
+    <value>Preset exported.</value>
+  </data>
+  <data name="プリセットを保存しました。" xml:space="preserve">
+    <value>Preset saved.</value>
+  </data>
+  <data name="ラウンド/テラーBGM設定" xml:space="preserve">
+    <value>Round/Terror BGM Settings</value>
+  </data>
+  <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
+    <value>Play BGM by round/terror</value>
+  </data>
+  <data name="ラウンドBGMを優先する" xml:space="preserve">
+    <value>Prioritize round BGM</value>
+  </data>
+  <data name="ラウンドタイプ" xml:space="preserve">
+    <value>Round Type</value>
+  </data>
+  <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
+    <value>Round type stats display:</value>
+  </data>
+  <data name="ラウンドタイプ推移を表示" xml:space="preserve">
+    <value>Show round type history</value>
+  </data>
+  <data name="ラウンドログ" xml:space="preserve">
+    <value>Round Log</value>
+  </data>
+  <data name="ラウンドログを表示する" xml:space="preserve">
+    <value>Show round log</value>
+  </data>
+  <data name="ラウンドログ背景色:" xml:space="preserve">
+    <value>Round log background:</value>
+  </data>
+  <data name="ラウンド名" xml:space="preserve">
+    <value>Round Name</value>
+  </data>
+  <data name="ラウンド状況を表示" xml:space="preserve">
+    <value>Show round status</value>
+  </data>
+  <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
+    <value>Configure the Webhook URL to send round results to Discord. Leave blank to disable.</value>
+  </data>
+  <data name="ラウンド統計を表示" xml:space="preserve">
+    <value>Show round stats</value>
+  </data>
+  <data name="両方とも再生する" xml:space="preserve">
+    <value>Play both</value>
+  </data>
+  <data name="保存" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="再生する音声" xml:space="preserve">
+    <value>Audio to play</value>
+  </data>
+  <data name="出現回数" xml:space="preserve">
+    <value>Appearances</value>
+  </data>
+  <data name="削除" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="参照..." xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="固定する" xml:space="preserve">
+    <value>Pin on top</value>
+  </data>
+  <data name="固定解除" xml:space="preserve">
+    <value>Unpin</value>
+  </data>
+  <data name="外部アプリを自動起動する" xml:space="preserve">
+    <value>Launch external apps automatically</value>
+  </data>
+  <data name="実行ファイル" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="対象アイテム名" xml:space="preserve">
+    <value>Target item name</value>
+  </data>
+  <data name="履歴表示数:" xml:space="preserve">
+    <value>History count:</value>
+  </data>
+  <data name="引数" xml:space="preserve">
+    <value>Arguments</value>
+  </data>
+  <data name="情報" xml:space="preserve">
+    <value>Information</value>
+  </data>
+  <data name="情報表示欄背景色:" xml:space="preserve">
+    <value>Info panel background:</value>
+  </data>
+  <data name="時計を表示" xml:space="preserve">
+    <value>Show clock</value>
+  </data>
+  <data name="曖昧マッチング" xml:space="preserve">
+    <value>Fuzzy matching</value>
+  </data>
+  <data name="最大速度" xml:space="preserve">
+    <value>Max speed</value>
+  </data>
+  <data name="最小速度" xml:space="preserve">
+    <value>Min speed</value>
+  </data>
+  <data name="有効" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="構文エラー" xml:space="preserve">
+    <value>Syntax error</value>
+  </data>
+  <data name="次ラウンド予測を表示" xml:space="preserve">
+    <value>Show next round prediction</value>
+  </data>
+  <data name="死亡回数" xml:space="preserve">
+    <value>Deaths</value>
+  </data>
+  <data name="滞在タイマーを表示" xml:space="preserve">
+    <value>Show dwell timer</value>
+  </data>
+  <data name="特定アイテムで音楽を再生する" xml:space="preserve">
+    <value>Play music for specific items</value>
+  </data>
+  <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
+    <value>Auto-suicide will not run with the current settings.</value>
+  </data>
+  <data name="生存回数" xml:space="preserve">
+    <value>Survivals</value>
+  </data>
+  <data name="生存率" xml:space="preserve">
+    <value>Survival rate</value>
+  </data>
+  <data name="競合時の優先設定:" xml:space="preserve">
+    <value>Priority when conflicts occur:</value>
+  </data>
+  <data name="終了" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="統計情報を表示する" xml:space="preserve">
+    <value>Show statistics</value>
+  </data>
+  <data name="統計情報表示欄" xml:space="preserve">
+    <value>Statistics</value>
+  </data>
+  <data name="統計表示欄背景色:" xml:space="preserve">
+    <value>Stats panel background:</value>
+  </data>
+  <data name="背景色設定" xml:space="preserve">
+    <value>Background colors</value>
+  </data>
+  <data name="自動自殺は無効になっています" xml:space="preserve">
+    <value>Auto-suicide is disabled.</value>
+  </data>
+  <data name="自動自殺を有効にする" xml:space="preserve">
+    <value>Enable auto-suicide</value>
+  </data>
+  <data name="自動自殺モード" xml:space="preserve">
+    <value>Auto-suicide mode</value>
+  </data>
+  <data name="自動自殺対象ラウンド:" xml:space="preserve">
+    <value>Auto-suicide target rounds:</value>
+  </data>
+  <data name="自動起動設定" xml:space="preserve">
+    <value>Auto-launch settings</value>
+  </data>
+  <data name="色選択" xml:space="preserve">
+    <value>Choose color</value>
+  </data>
+  <data name="表示設定" xml:space="preserve">
+    <value>Display settings</value>
+  </data>
+  <data name="角度を表示" xml:space="preserve">
+    <value>Show angle</value>
+  </data>
+  <data name="解析できなかった行があります:" xml:space="preserve">
+    <value>Lines could not be parsed:</value>
+  </data>
+  <data name="言語" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="設定" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="設定..." xml:space="preserve">
+    <value>Settings...</value>
+  </data>
+  <data name="設定内容" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="設定内容確認" xml:space="preserve">
+    <value>Review configuration</value>
+  </data>
+  <data name="設定変更" xml:space="preserve">
+    <value>Change settings</value>
+  </data>
+  <data name="詳細設定を利用する" xml:space="preserve">
+    <value>Use advanced settings</value>
+  </data>
+  <data name="詳細設定ドキュメント" xml:space="preserve">
+    <value>Advanced settings docs</value>
+  </data>
+  <data name="読み込み" xml:space="preserve">
+    <value>Load</value>
+  </data>
+  <data name="警告" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="追加" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="追加設定" xml:space="preserve">
+    <value>Additional settings</value>
+  </data>
+  <data name="透明度" xml:space="preserve">
+    <value>Opacity</value>
+  </data>
+  <data name="速度を表示" xml:space="preserve">
+    <value>Show speed</value>
+  </data>
+  <data name="Language_Danish" xml:space="preserve">
+    <value>Danish</value>
+  </data>
+  <data name="Language_German" xml:space="preserve">
+    <value>German</value>
+  </data>
+  <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
+    <value>English (United Kingdom)</value>
+  </data>
+  <data name="Language_EnglishUnitedStates" xml:space="preserve">
+    <value>English (United States)</value>
+  </data>
+  <data name="Language_Spanish" xml:space="preserve">
+    <value>Spanish</value>
+  </data>
+  <data name="Language_SpanishLatinAmerica" xml:space="preserve">
+    <value>Spanish (Latin America)</value>
+  </data>
+  <data name="Language_French" xml:space="preserve">
+    <value>French</value>
+  </data>
+  <data name="Language_Croatian" xml:space="preserve">
+    <value>Croatian</value>
+  </data>
+  <data name="Language_Italian" xml:space="preserve">
+    <value>Italian</value>
+  </data>
+  <data name="Language_Lithuanian" xml:space="preserve">
+    <value>Lithuanian</value>
+  </data>
+  <data name="Language_Hungarian" xml:space="preserve">
+    <value>Hungarian</value>
+  </data>
+  <data name="Language_Dutch" xml:space="preserve">
+    <value>Dutch</value>
+  </data>
+  <data name="Language_Norwegian" xml:space="preserve">
+    <value>Norwegian</value>
+  </data>
+  <data name="Language_Polish" xml:space="preserve">
+    <value>Polish</value>
+  </data>
+  <data name="Language_PortugueseBrazil" xml:space="preserve">
+    <value>Portuguese (Brazil)</value>
+  </data>
+  <data name="Language_Romanian" xml:space="preserve">
+    <value>Romanian</value>
+  </data>
+  <data name="Language_Finnish" xml:space="preserve">
+    <value>Finnish</value>
+  </data>
+  <data name="Language_Swedish" xml:space="preserve">
+    <value>Swedish</value>
+  </data>
+  <data name="Language_Vietnamese" xml:space="preserve">
+    <value>Vietnamese</value>
+  </data>
+  <data name="Language_Turkish" xml:space="preserve">
+    <value>Turkish</value>
+  </data>
+  <data name="Language_Thai" xml:space="preserve">
+    <value>Thai</value>
+  </data>
+  <data name="Language_Greek" xml:space="preserve">
+    <value>Greek</value>
+  </data>
+  <data name="Language_Bulgarian" xml:space="preserve">
+    <value>Bulgarian</value>
+  </data>
+  <data name="Language_Russian" xml:space="preserve">
+    <value>Russian</value>
+  </data>
+  <data name="Language_Ukrainian" xml:space="preserve">
+    <value>Ukrainian</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.ro.resx
+++ b/Infrastructure/Resources/Strings.ro.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>Cheie API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Cheile API trebuie să aibă cel puțin 32 de caractere.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Conectat</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Deconectat</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Setări de notificare a discordiei</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Deteriora:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Articol:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>HARTĂ:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Tip rotund:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Teroare:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Chineză (simplificată)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Engleză</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>japonez</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>coreean</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>Bine</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Portul OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Setări OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Eroare parse</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Setări de cloud TonroundCounter</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud este un serviciu cloud care poate sincroniza automat codurile de salvare pe mai multe dispozitive.
+Este necesară o cheie API.
+Vă rugăm să obțineți o cheie API de pe site -ul web.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Deschideți TonroundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>TonroundCounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL -ul Webhook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Prioritizează sunetele articolului</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Item Music Gimmick</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Arată detalii despre teroare nelimitate</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Import</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Ferestre</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Export</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Eroare</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Setări de suprapunere</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Anula</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Afișați comenzile rapide</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Arată daune</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Teroare</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Blochează numele teroristului culoarea:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Arată teroare</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Numele terorii</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Arată detalii despre teroare</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Temă</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Afișați informațiile de depanare</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Fişier</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Setări de filtrare</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Presetați:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Presetat importat.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Presetat exportat.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Presetat salvat.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Setări BGM rotunde/teroare</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Joacă BGM prin rotundă/teroare</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Prioritizează BGM rotund</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Tip rotund</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Afișare de statistici de tip rotund:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Afișați istoricul tipului rotund</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Jurnal rotund</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Afișați jurnalul rotund</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Fundal rotund de jurnal:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Numele rotund</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Afișați statutul rotund</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Configurați adresa URL WebHook pentru a trimite rezultate rotunde la Discord. Lăsați gol pentru a dezactiva.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Arată statistici rotunde</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Joacă ambele</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Salva</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Audio pentru a reda</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Apariții</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Elimina</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Căutați ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Pin deasupra</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Unpin</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Lansați automat aplicații externe</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Executabil</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Numele articolului țintă</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Număr de istorie:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argumente</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Informaţii</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Fundal panoul de informații:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Arată ceas</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Potrivire fuzzy</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Viteză maximă</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Min viteză</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Activat</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Eroare de sintaxă</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Arată predicția următoarei runde</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Decese</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Arată cronometrul de locuit</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Redați muzică pentru anumite articole</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-Suicid nu va rula cu setările curente.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Supraviețuiri</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Rata de supraviețuire</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioritate când apar conflicte:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Ieșire</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Arată statistici</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistici</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Fundal al panoului de statistici:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Culori de fundal</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-Suicid este dezactivat.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Activați auto-suicid</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Mod auto-Suicid</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Rundele țintă auto-sinucidere:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Setări de lansare automată</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Alegeți culoarea</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Setări de afișare</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Arată unghiul</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Liniile nu au putut fi analizate:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Limbă</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Setări</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Setări ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Configurație</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Revizuirea configurației</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Schimbați setările</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Utilizați setări avansate</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Setări avansate documente</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Încărca</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Avertizare</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Adăuga</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Setări suplimentare</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacitate</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Arată viteza</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>danez</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>german</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Engleză (Regatul Unit)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Engleză (Statele Unite)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Spaniolă</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Spaniolă (America Latină)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>franceză</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>croat</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>italian</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>lituanian</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Maghiar</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Olandez</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>norvegian</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Lustrui</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugheză (Brazilia)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>România</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>finlandeză</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>suedez</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Vietnameză</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>turc</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thailandez</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Grec</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>bulgar</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Rusă</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ucrainean</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.ru.resx
+++ b/Infrastructure/Resources/Strings.ru.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API -ключ:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Ключи API должны быть не менее 32 символов длиной.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Подключенный</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Отключен</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Настройки уведомления о разборе</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Повреждать:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Элемент:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>Карта:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Круглый тип:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Террор:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Китайский (упрощен)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Английский</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Японский</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>корейский</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>ХОРОШО</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Порт OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Настройки OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Ошибка разбора</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Настройки TONROUNDCOUNTER-CLOUD</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud-это облачная служба, которая может автоматически синхронизировать коды сохранения на нескольких устройствах.
+Требуется ключ API.
+Пожалуйста, получите ключ API с сайта.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Open TonroundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>TonroundCounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>Url webhook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Расстановите приоритеты звука предмета</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>МУЗЫКА МУЗЫКА</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Показать невыносимые детали террора</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Импорт</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Окна</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Экспорт</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Ошибка</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Настройки наложения</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Отмена</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Показать ярлыки</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Показать урон</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Террор</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Замок террор. Цвет:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Показать ужас</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Название террора</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Показать детали террора</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Тема</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Показать информацию отладки</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Файл</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Настройки фильтра</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>ПРЕДУПРЕТНАЯ:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Предварительно установлен.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Предварительно установлен.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Предустановлена ​​сохранена.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Круглый/террор настройки BGM</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Играть в BGM по кругу/ужасу</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Распределите приоритеты круглой BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Круглый тип</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Отображение статистики круглого типа:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Показать историю типа типа</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Круглый журнал</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Показать круглый журнал</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Круглый фон журнал:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Круглый название</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Показать статус раунда</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Настройте URL -адрес webhook, чтобы отправить результаты округа для раздора. Оставить пустым, чтобы отключить.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Показать круглую статистику</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Играйте оба</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Сохранять</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Аудио, чтобы играть</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Появления</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Удалять</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Просматривать...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Пятника сверху</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Не</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Автоматически запустить внешние приложения</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Исполняемый файл</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Целевое название элемента</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>История подсчет:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Аргументы</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Информация</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Информационная панель фон:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Показать часы</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Нечеткое сочетание</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Максимальная скорость</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Мин скорость</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Включено</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Синтаксическая ошибка</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Показать предсказание следующего раунда</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Летальные исходы</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Показать таймер Dwell</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Воспроизвести музыку для определенных предметов</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Авто-самоубийство не будет работать с текущими настройками.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Выживания</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Выживаемость</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Приоритет, когда возникают конфликты:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Выход</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Показать статистику</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Статистика</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Статистическая панель фон:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Фоновые цвета</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Автофюйд инвалид.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Включить авто-самоубийство</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Автофюдюйд режим</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Автофюдюцидные раунды:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Настройки автоматического запуска</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Выберите цвет</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Настройки отображения</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Показать угол</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Линии не могут быть проанализированы:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Язык</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Настройки</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Настройки...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Конфигурация</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Просмотрите конфигурацию</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Изменить настройки</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Используйте расширенные настройки</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Усовершенствованные настройки документов</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Нагрузка</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Предупреждение</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Добавлять</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Дополнительные настройки</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Непрозрачность</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Показать скорость</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Датский</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>немецкий</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Английский (Великобритания)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Английский (Соединенные Штаты)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>испанский</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Испанский (Латинская Америка)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Французский</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>хорватский</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Итальянский</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>литовский</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>венгерский</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Голландский</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>норвежский</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Лак</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Португальский (Бразилия)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>румынский</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Финский</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Шведский</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>вьетнамский</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>турецкий</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Тайский</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Греческий</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>болгарский</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Русский</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Украинский</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.sv.resx
+++ b/Infrastructure/Resources/Strings.sv.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,72 +13,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API -nyckel:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API -nycklar måste vara minst 32 tecken långa.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Ansluten</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Osammanhängande</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Inställningar för oenighetsmeddelande</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Skada:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Punkt:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>KARTA:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Rundtyp:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Skräck:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Kinesiska (förenklade)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Engelska</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Japansk</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Koreansk</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC -port:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC -inställningar</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Analysera fel</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>TonroundCounter-Cloud-inställningar</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud är en molntjänst som automatiskt kan synkronisera spara koder över flera enheter.
+En API -nyckel krävs.
+Få en API -nyckel från webbplatsen.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Öppna tonroundmolnmoln</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroskant</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
@@ -87,360 +87,360 @@ APIキーはwebサイトから取得してください。</value>
     <value>Webhook URL:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Prioritera artiklarljud</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Objektmusik gimmick</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Visa obundna terrorinformation</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Importera</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Fönster</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Exportera</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Fel</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Överläggningsinställningar</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Avboka</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Visa genvägar</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Uppvisning</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Skräck</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Lås terrornamn Färg:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Visa terror</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Skräcknamn</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Visa terrorinformation</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Tema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Visa felsökningsinfo</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Fil</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Filterinställningar</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Förinställa:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Förinställd importerad.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Förinställd exporterad.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Förinställd sparad.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Rund/terror BGM -inställningar</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Spela BGM av Round/Terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Prioritera runda BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Rundtyp</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Statistik om rundtyp:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Visa rundtyp historia</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Runda stock</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Visa runda logg</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Rund loggbakgrund:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Runda namn</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Visa rund status</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Konfigurera Webhook URL för att skicka runda resultat till oenighet. Lämna tomt för att inaktivera.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Visa runda statistik</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Spela båda</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Spara</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Ljud att spela</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Utseende</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Ta bort</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Bläddra...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Stift på toppen</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Lutande</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Starta externa appar automatiskt</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Körbar</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Målobjektnamn</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Historikantal:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argument</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Information</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Info -panelbakgrund:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Visningsklocka</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Fuzzy matchning</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Maxhastighet</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Minhastighet</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Aktiverad</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Syntaxfel</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Visa nästa omgång förutsägelse</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Dödsfall</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Visa Dwell Timer</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Spela musik för specifika föremål</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Auto-självmord körs inte med de aktuella inställningarna.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Överlevande</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Överlevnad</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Prioritet när konflikter inträffar:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Utgång</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Visa statistik</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Statistik</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Statspanelbakgrund:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Bakgrundsfärger</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Auto-självmord är inaktiverad.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Aktivera automatisk självmord</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Auto-självmordsläge</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Auto-självmordsmålrundor:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Auto-lanseringsinställningar</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Välj färg</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Visningsinställningar</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Visningsvinkel</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Linjer kunde inte analyseras:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Språk</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Inställningar</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Inställningar ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Konfiguration</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Granska konfiguration</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Ändra inställningar</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Använd avancerade inställningar</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Avancerade inställningsdokument</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Ladda</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Varning</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Tillägga</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Ytterligare inställningar</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Opacitet</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Visningshastighet</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Dansk</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Tysk</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Engelska (Storbritannien)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Engelska (USA)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Spansk</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Spanska (Latinamerika)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Franska</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Kroatisk</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Italienare</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Litauiska</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Ungerska</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Holländsk</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Norsk</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Polera</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portugisiska (Brasilien)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Rumänsk</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Finska</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Svensk</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Vietnamesisk</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Turkisk</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thailändare</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Grekisk</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bulgarisk</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Rysk</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Ukrainare</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.th.resx
+++ b/Infrastructure/Resources/Strings.th.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>คีย์ API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>ปุ่ม API ต้องมีความยาวอย่างน้อย 32 อักขระ</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>ซึ่งเชื่อมต่อกัน</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>ตัดการเชื่อมต่อ</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>การตั้งค่าการแจ้งเตือนความไม่ลงรอยกัน</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>ความเสียหาย:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>รายการ:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>แผนที่:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>ประเภทรอบ:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>ความหวาดกลัว:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>ภาษาจีน (ง่าย)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>ภาษาอังกฤษ</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>ญี่ปุ่น</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>เกาหลี</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>ตกลง</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>พอร์ต OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>การตั้งค่า OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>ข้อผิดพลาดในการแยกวิเคราะห์</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>การตั้งค่า TonroundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCounter-Cloud เป็นบริการคลาวด์ที่สามารถซิงค์รหัสบันทึกรหัสผ่านอุปกรณ์หลายเครื่องโดยอัตโนมัติ
+จำเป็นต้องมีคีย์ API
+โปรดรับคีย์ API จากเว็บไซต์</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>เปิด tonroundcounter-cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL WebHook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>จัดลำดับความสำคัญของรายการเสียง</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>กลไกเพลงไอเท็ม</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>แสดงรายละเอียดความหวาดกลัวที่ไม่ได้ผูกมัด</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>นำเข้า</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>หน้าต่าง</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>ส่งออก</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>ข้อผิดพลาด</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>การตั้งค่าซ้อนทับ</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>ยกเลิก</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>แสดงทางลัด</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>แสดงความเสียหาย</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>ความหวาดกลัว</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>ล็อคชื่อก่อการร้ายสี:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>แสดงความหวาดกลัว</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>ชื่อก่อการร้าย</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>แสดงรายละเอียดความหวาดกลัว</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>ธีม</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>แสดงข้อมูลการดีบัก</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>ไฟล์</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>การตั้งค่าตัวกรอง</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>ที่ตั้งไว้ล่วงหน้า:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>นำเข้าล่วงหน้า</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>ส่งออกล่วงหน้า</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>บันทึกไว้ล่วงหน้า</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>การตั้งค่า BGM แบบกลม/ก่อการร้าย</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>เล่น BGM โดย Round/Terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>จัดลำดับความสำคัญรอบ BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>ประเภทกลม</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>การแสดงสถิติประเภทกลม:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>แสดงประวัติประเภทรอบ</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>บันทึกรอบ</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>แสดง Round Log</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>พื้นหลังบันทึกรอบ:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>ชื่อรอบ</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>แสดงสถานะรอบ</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>กำหนดค่า URL WebHook เพื่อส่งผลลัพธ์รอบไปยัง Discord เว้นว่างเพื่อปิดการใช้งาน</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>แสดงสถิติรอบ</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>เล่นทั้งสอง</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>บันทึก</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>เสียงที่จะเล่น</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>การปรากฏตัว</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>ลบ</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>เรียกดู ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>พินด้านบน</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>คลาย</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>เปิดแอพภายนอกโดยอัตโนมัติ</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>ที่ปฏิบัติการได้</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>ชื่อรายการเป้าหมาย</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>จำนวนประวัติศาสตร์:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>ข้อโต้แย้ง</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>ข้อมูล</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>พื้นหลังแผงข้อมูล:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>แสดงนาฬิกา</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>การจับคู่ที่คลุมเครือ</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>ความเร็วสูงสุด</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>ความเร็วต่ำสุด</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>เปิดใช้งาน</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>ข้อผิดพลาดทางไวยากรณ์</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>แสดงการคาดการณ์รอบต่อไป</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>ผู้เสียชีวิต</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>แสดงตัวจับเวลาที่อยู่อาศัย</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>เล่นเพลงสำหรับรายการเฉพาะ</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>การฆ่าตัวตายอัตโนมัติจะไม่ทำงานกับการตั้งค่าปัจจุบัน</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>ผู้รอดชีวิต</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>อัตราการรอดชีวิต</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>ลำดับความสำคัญเมื่อความขัดแย้งเกิดขึ้น:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>การออก</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>แสดงสถิติ</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>สถิติ</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>ความเป็นมาของแผงสถิติ:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>สีพื้นหลัง</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>การฆ่าตัวตายอัตโนมัติถูกปิดใช้งาน</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>เปิดใช้งานการฆ่าตัวตายอัตโนมัติ</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>โหมดการฆ่าตัวตายอัตโนมัติ</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>เป้าหมายการฆ่าตัวตายอัตโนมัติรอบ:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>การตั้งค่าการเปิดตัวอัตโนมัติ</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>เลือกสี</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>แสดงการตั้งค่า</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>แสดงมุม</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>เส้นไม่สามารถแยกวิเคราะห์ได้:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>ภาษา</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>การตั้งค่า</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>การตั้งค่า...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>การกำหนดค่า</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>ตรวจสอบการกำหนดค่า</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>เปลี่ยนการตั้งค่า</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>ใช้การตั้งค่าขั้นสูง</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>เอกสารการตั้งค่าขั้นสูง</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>โหลด</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>คำเตือน</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>เพิ่ม</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>การตั้งค่าเพิ่มเติม</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>ความทึบแสง</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>แสดงความเร็ว</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>เกี่ยวกับเดนมาร์ก</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>ชาวเยอรมัน</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>ภาษาอังกฤษ (สหราชอาณาจักร)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>ภาษาอังกฤษ (สหรัฐอเมริกา)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>เกี่ยวกับภาษาสเปน</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>สเปน (ละตินอเมริกา)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>ภาษาฝรั่งเศส</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>เกี่ยวกับภาษาโครเอเชีย</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>อิตาลี</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>เกี่ยวกับลิทัวเนีย</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>ชาวฮังการี</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>ชาวดัตช์</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>นอร์เวย์</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>ขัด</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>โปรตุเกส (บราซิล)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>เกี่ยวกับโรมาเนีย</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>ภาษาฟินแลนด์</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>ภาษาสวีเดน</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>เวียดนาม</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>ตุรกี</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>แบบไทย</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>กรีก</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>ชาวบัลแกเรีย</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>ชาวรัสเซีย</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>ชาวยูเครน</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.tr.resx
+++ b/Infrastructure/Resources/Strings.tr.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API Anahtarı:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API anahtarları en az 32 karakter uzunluğunda olmalıdır.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Bağlı</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Bağlantısı kesilmiş</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Uyuşmazlık Bildirim Ayarları</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Zarar:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Öğe:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>HARİTA:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Yuvarlak Tür:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Terör:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Çince (basitleştirilmiş)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>İngilizce</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Japonca</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Koreli</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>TAMAM</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC bağlantı noktası:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC ayarları</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Ayrıştırma Hatası</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Tonroundcounter-Cloud ayarları</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>Tonroundcounter-Cloud, kodları birden çok cihazda otomatik olarak senkronize edebilen bir bulut hizmetidir.
+Bir API anahtarı gereklidir.
+Lütfen web sitesinden bir API anahtarı alın.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Tonroundcounter-bulut</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Tonroundcounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>WebHook URL'si:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Öğe seslerine öncelik ver</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Öğe müziği hile</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Bağlanmamış terör detaylarını göster</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>İçe aktarmak</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Pencere</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>İhracat</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Hata</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Kaplama Ayarları</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>İptal etmek</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Kısayolları Göster</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Hasar göster</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Terör</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Terör Adı Rengi Kilite:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Terör göster</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Terör adı</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Terör Detaylarını Göster</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Tema</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Hata Ayıklama Bilgilerini Göster</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Dosya</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Filtre Ayarları</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Ön ayar:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Önceden ayarlanmış.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Önceden ayarlanmış ihraç edildi.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Önceden ayarlanmış kaydedildi.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Yuvarlak/terör bgm ayarları</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>BGM'yi yuvarlak/terörle oynayın</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Yuvarlak BGM'ye öncelik ver</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Yuvarlak tip</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Yuvarlak Tip İstatistikler Ekran:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Yuvarlak Tip Geçmişi Göster</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Yuvarlak kütük</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Yuvarlak Günlük Göster</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Yuvarlak kütük arka plan:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Yuvarlak isim</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Tur Durumunu Göster</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>WebHook URL'sini anlaşmazlığa yuvarlak sonuçlar gönderecek şekilde yapılandırın. Devre dışı bırakmak için boş bırakın.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Tur istatistiklerini göster</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Her ikisini de oynamak</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Kaydetmek</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Oynamak için Ses</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Görünüş</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Kaldırmak</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Göz at ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Üstte PIN</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Bitirmek</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Harici uygulamaları otomatik olarak başlatın</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Yürütülebilir</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Hedef Öğe Adı</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Tarih Sayısı:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Argümanlar</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Bilgi</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Bilgi paneli arka plan:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Saat Göster</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Bulanık eşleşen</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Maksimum hız</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Min Hız</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Etkinleştirilmiş</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Sözdizimi hatası</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Sonraki Tur Tahmini Göster</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Ölümler</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Bekleme Zamanlayıcıyı Göster</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Belirli öğeler için müzik çalın</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Otomatik intihar geçerli ayarlarla çalışmaz.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Hayatta kalanlar</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Hayatta kalma oranı</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Çatışmalar meydana geldiğinde öncelik:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Çıkış</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>İstatistikleri Göster</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>İstatistik</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>İstatistikler paneli arka plan:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Arka plan renkleri</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Otomatik intihar devre dışı bırakıldı.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Otomatik İntihar Etkinleştir</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Otomatik eğitim modu</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Otomatik intihar hedef turları:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Otomatik Önlem Ayarları</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Renk Seçin</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Ekran Ayarları</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Gösteren açı</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Çizgiler ayrıştırılamadı:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Dil</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Ayarlar</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Ayarlar ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Konfigürasyon</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Yapılandırmayı inceleyin</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Ayarları Değiştir</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Gelişmiş ayarları kullanın</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Gelişmiş Ayarlar Dokümanlar</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Yük</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Uyarı</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Eklemek</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Ek Ayarlar</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Açıklık</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Hızı göster</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Danimarkalı</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Almanca</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>İngilizce (Birleşik Krallık)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>İngilizce (Amerika Birleşik Devletleri)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>İspanyol</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>İspanyolca (Latin Amerika)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Fransızca</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Hırvat</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>İtalyan</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Litvanya</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Macarca</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Flemenkçe</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Norveççe</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Cila</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Portekizce (Brezilya)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Romanya</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Fince</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>İsveççe</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Vietnam</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Türkçe</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Tayland</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Yunan</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bulgarca</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Rusça</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Ukrayna</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.uk.resx
+++ b/Infrastructure/Resources/Strings.uk.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>Ключ API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Клавіші API повинні бути не менше 32 символів.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>З'єднаний</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Роз'єднаний</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Налаштування сповіщення</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Пошкодження:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Пункт:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>Карта:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Круглий тип:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Терор:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Китайська (спрощена)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Англійська мова</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Японський</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Корейський</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>Добре</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Порт OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Налаштування OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Помилка розбору</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>Налаштування Tonroundcounter</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>Tonroundcounter-Cloud-це хмарна послуга, яка може автоматично синхронізувати коди збереження на декількох пристроях.
+Потрібен ключ API.
+Будь ласка, отримайте з веб -сайту ключ API.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Відкрийте Tonroundcounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>Тона</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL -адреса WebHook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Пріоритетні звуки елементів</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Музична трюк</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Показати незв'язані деталі терору</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Імпорт</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Вікна</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Експорт</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Помилка</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Налаштування накладки</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Скасувати</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Показати ярлики</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Виявити шкоду</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Терор</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Блокування терору Ім'я Колір:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Показувати терор</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Назва терору</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Покажіть деталі терору</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Тема</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Показати інформацію про налагодження</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Файл</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Налаштування фільтра</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Попередньо встановлено:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Попередньо встановлено.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Попередньо встановлений експортований.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Попередньо врятовано.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Налаштування круглих/терору BGM</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Грайте в BGM за круглим/терором</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Пріоритетний круглий BGM</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Круглий тип</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Дисплей статистики круглого типу:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Показати історію круглого типу</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Круглий журнал</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Показати круглий журнал</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Фон круглого журналу:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Круглий назва</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Показати статус круглих</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Налаштуйте URL -адресу WebHook, щоб надсилати результати круглих для розбрату. Залиште порожнім, щоб відключити.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Показати статистику круглої</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Грати і те, і інше</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Заощадити</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Аудіо для гри</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Зовнішність</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Видалити</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Переглянути ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Зверху зверху</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Розмивати</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Автоматично запустіть зовнішні програми</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Виконавчий</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Назва цільового елемента</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Кількість історії:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Аргументи</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Інформація</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Інформаційна панель Фон:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Показати годинник</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Нечітка відповідність</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Максимальна швидкість</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Мінівка швидкість</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Увімкнено</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Помилка синтаксису</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Показати наступний раунд прогнозування</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Смерті</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Показати таймер зупинки</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Грайте музику для конкретних предметів</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Авто-самогубство не буде працювати з поточними налаштуваннями.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Вижили</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Швидкість виживання</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Пріоритет, коли виникають конфлікти:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Вихід</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Показати статистику</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Статистика</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Фон панелі статистики:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Фонові кольори</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Авто-самогубство відключається.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Увімкнути авто-самогубство</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Автоматичний режим</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Автоматичні цільові раунди:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Налаштування автоматичного запуску</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Виберіть колір</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Налаштування відображення</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Показати кут</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Лінії не можна було проаналізувати:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Мова</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Налаштування</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Налаштування ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Конфігурація</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Перегляньте конфігурацію</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Змінити налаштування</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Використовуйте розширені налаштування</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Додаткові документи про налаштування</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Навантаження</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>УВАГА</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Додавання</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Додаткові налаштування</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Непрозорість</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Показати швидкість</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Датський</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Німецький</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Англійська (Великобританія)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Англійська (США)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Іспанська мова</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Іспанська (Латинська Америка)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Французький</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Хорватський</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Італійський</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Литовський</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Угорський</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Голландський</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Норвезький</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Польський</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Португальська (Бразилія)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Румунський</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Фінський</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Шведський</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>В'єтнамський</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Турецький</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Тайський</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Грецький</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Болгарський</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Російський</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Український</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.vi.resx
+++ b/Infrastructure/Resources/Strings.vi.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,434 +13,434 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>Khóa API:</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>Khóa API phải dài ít nhất 32 ký tự.</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>Kết nối</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>Mất kết nối</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Cài đặt thông báo bất hòa</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>Hư hại:</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>Mục:</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>BẢN ĐỒ:</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>Loại tròn:</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>Khủng bố:</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>Trung Quốc (đơn giản hóa)</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>Tiếng Anh</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>Nhật Bản</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>Hàn Quốc</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>ĐƯỢC RỒI</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>Cổng OSC:</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>Cài đặt OSC</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>Lỗi phân tích cú pháp</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>TonroundCount Cài đặt đám mây</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>TonroundCount-Cloud là một dịch vụ đám mây có thể tự động đồng bộ hóa mã lưu trên nhiều thiết bị.
+Một khóa API là bắt buộc.
+Vui lòng lấy khóa API từ trang web.</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>Mở TonroundCount-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
-    <value>ToNRoundCounter</value>
+    <value>TonroundCount</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
     <value>WebSocket IP:</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>URL Webhook:</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>Ưu tiên âm thanh vật phẩm</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>Mục âm nhạc mánh lới quảng cáo</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>Hiển thị các chi tiết khủng bố không bị ràng buộc</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>Nhập khẩu</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>Windows</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>Xuất khẩu</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>Lỗi</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>Cài đặt lớp phủ</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Hủy bỏ</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>Hiển thị các phím tắt</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>Hiển thị thiệt hại</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>Khủng bố</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>Khóa tên khủng bố màu:</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>Hiển thị khủng bố</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>Tên khủng bố</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>Hiển thị chi tiết khủng bố</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>Chủ đề</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>Hiển thị thông tin gỡ lỗi</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>Tài liệu</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>Cài đặt bộ lọc</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>Đặt trước:</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>Đặt trước nhập khẩu.</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>Đặt trước xuất khẩu.</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>Đặt trước được lưu.</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>Cài đặt tròn/khủng bố BGM</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>Chơi BGM bởi Round/Terror</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>Ưu tiên BGM tròn</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>Loại tròn</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>Hiển thị số liệu thống kê loại tròn:</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>Hiển thị lịch sử loại tròn</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>Nhật ký tròn</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>Hiển thị nhật ký vòng</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>Nền nhật ký tròn:</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>Tên tròn</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>Hiển thị trạng thái tròn</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>Định cấu hình URL Webhook để gửi kết quả tròn đến Discord. Để trống để vô hiệu hóa.</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>Hiển thị số liệu thống kê tròn</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>Chơi cả hai</value>
   </data>
   <data name="保存" xml:space="preserve">
-    <value>保存</value>
+    <value>Cứu</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>Âm thanh để chơi</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>Xuất hiện</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>Di dời</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>Duyệt ...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>Ghim trên đầu</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>Giải nén</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>Khởi chạy các ứng dụng bên ngoài tự động</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>Thực thi</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>Tên mục đích</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>Số lượng lịch sử:</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>Lập luận</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>Thông tin</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>Bối cảnh bảng thông tin:</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>Hiển thị đồng hồ</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>Phù hợp mờ</value>
   </data>
   <data name="最大速度" xml:space="preserve">
-    <value>最大速度</value>
+    <value>Tốc độ tối đa</value>
   </data>
   <data name="最小速度" xml:space="preserve">
-    <value>最小速度</value>
+    <value>Tốc độ tối thiểu</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>Đã bật</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>Lỗi cú pháp</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>Hiển thị dự đoán vòng tiếp theo</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>Cái chết</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>Hiển thị bộ đếm thời gian Dwell</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>Chơi nhạc cho các mục cụ thể</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>Tự động tự động sẽ không chạy với các cài đặt hiện tại.</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>Sống sót</value>
   </data>
   <data name="生存率" xml:space="preserve">
-    <value>生存率</value>
+    <value>Tỷ lệ sống</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>Ưu tiên khi xung đột xảy ra:</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>Ra</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>Hiển thị số liệu thống kê</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>Thống kê</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>Bối cảnh bảng thống kê:</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>Màu nền</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>Tự động tự động bị vô hiệu hóa.</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>Bật tự động tự động</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>Chế độ tự động tự sát</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>Vòng mục tiêu tự động tự tử:</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>Cài đặt tự động ra mắt</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>Chọn màu</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>Cài đặt hiển thị</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>Hiển thị góc</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>Các dòng không thể được phân tích cú pháp:</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>Ngôn ngữ</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>Cài đặt</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>Cài đặt ...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>Cấu hình</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>Xem xét cấu hình</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>Thay đổi cài đặt</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>Sử dụng cài đặt nâng cao</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>Cài đặt nâng cao Tài liệu</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>Trọng tải</value>
   </data>
   <data name="警告" xml:space="preserve">
-    <value>警告</value>
+    <value>Cảnh báo</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>Thêm vào</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>Cài đặt bổ sung</value>
   </data>
   <data name="透明度" xml:space="preserve">
-    <value>透明度</value>
+    <value>Độ mờ</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>Hiển thị tốc độ</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>Đan Mạch</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>Đức</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>Tiếng Anh (Vương quốc Anh)</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>Tiếng Anh (Hoa Kỳ)</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>Tiếng Tây Ban Nha</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>Tây Ban Nha (Mỹ Latinh)</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>Tiếng Pháp</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>Croatia</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>Ý</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>Litva</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>Hungary</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>Hà Lan</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>Na Uy</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>Đánh bóng</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>Bồ Đào Nha (Brazil)</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>Rumani</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>Tiếng Phần Lan</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>Thụy Điển</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>Việt Nam</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>Thổ Nhĩ Kỳ</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>Thái</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>Hy Lạp</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>Bulgaria</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>Tiếng Nga</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>Ukraine</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.zh-Hans.resx
+++ b/Infrastructure/Resources/Strings.zh-Hans.resx
@@ -13,240 +13,240 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>APIキー:</value>
+    <value>API 密钥：</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>APIキーは32文字以上である必要があります。</value>
+    <value>API 密钥长度必须至少为 32 个字符。</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>接続済み</value>
+    <value>已连接</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>切断</value>
+    <value>已断开</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord通知設定</value>
+    <value>Discord 通知设置</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>ダメージ:</value>
+    <value>伤害：</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
-    <value>アイテム:</value>
+    <value>道具：</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>MAP:</value>
+    <value>地图：</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>ラウンドタイプ:</value>
+    <value>回合类型：</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>テラー:</value>
+    <value>恐惧：</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>中国語(簡体字)</value>
+    <value>简体中文</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英語</value>
+    <value>英语</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日本語</value>
+    <value>日语</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韓国語</value>
+    <value>韩语</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>确定</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
-    <value>OSC接続ポート:</value>
+    <value>OSC 端口：</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC設定</value>
+    <value>OSC 设置</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析エラー</value>
+    <value>解析错误</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudの設定</value>
+    <value>ToNRoundCounter-Cloud 设置</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。
-利用にはAPIキーが必要です。
-APIキーはwebサイトから取得してください。</value>
+    <value>ToNRoundCounter-Cloud 是一项可在多台设备间自动同步存档代码的云服务。
+需要提供 API 密钥。
+请从网站获取 API 密钥。</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>ToNRoundCounter-Cloudを開く</value>
+    <value>打开 ToNRoundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
     <value>ToNRoundCounter</value>
   </data>
   <data name="WebSocket IP:" xml:space="preserve">
-    <value>WebSocket IP:</value>
+    <value>WebSocket IP：</value>
   </data>
   <data name="Webhook URL:" xml:space="preserve">
-    <value>Webhook URL:</value>
+    <value>Webhook URL：</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>アイテムサウンドを優先する</value>
+    <value>物品音效优先</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>アイテム音楽ギミック</value>
+    <value>物品音乐机关</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>アンバウンドのテラー内容を表示</value>
+    <value>显示无拘束恐惧详情</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>インポート</value>
+    <value>导入</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
-    <value>ウィンドウ</value>
+    <value>窗口</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>エクスポート</value>
+    <value>导出</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>エラー</value>
+    <value>错误</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>オーバーレイ設定</value>
+    <value>叠加层设置</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>取消</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>ショートカットを表示</value>
+    <value>显示快捷键</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>ダメージを表示</value>
+    <value>显示伤害</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>テラー</value>
+    <value>恐惧</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>テラーの名前の色固定:</value>
+    <value>固定恐惧名称颜色：</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>テラーを表示</value>
+    <value>显示恐惧</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>テラー名</value>
+    <value>恐惧名称</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>テラー詳細情報を表示</value>
+    <value>显示恐惧详细信息</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>テーマ</value>
+    <value>主题</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>デバッグ情報表示</value>
+    <value>显示调试信息</value>
   </data>
   <data name="ファイル" xml:space="preserve">
-    <value>ファイル</value>
+    <value>文件</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>フィルター設定</value>
+    <value>筛选设置</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>プリセット:</value>
+    <value>预设：</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>プリセットをインポートしました。</value>
+    <value>已导入预设。</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>プリセットをエクスポートしました。</value>
+    <value>已导出预设。</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>プリセットを保存しました。</value>
+    <value>已保存预设。</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>ラウンド/テラーBGM設定</value>
+    <value>回合/恐惧 BGM 设置</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>ラウンド/テラーごとのBGMを再生する</value>
+    <value>按回合/恐惧播放 BGM</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>ラウンドBGMを優先する</value>
+    <value>回合 BGM 优先</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>ラウンドタイプ</value>
+    <value>回合类型</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>ラウンドタイプごとの統計表示設定:</value>
+    <value>回合类型统计显示设置：</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>ラウンドタイプ推移を表示</value>
+    <value>显示回合类型变化</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>ラウンドログ</value>
+    <value>回合日志</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>ラウンドログを表示する</value>
+    <value>显示回合日志</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>ラウンドログ背景色:</value>
+    <value>回合日志背景色：</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>ラウンド名</value>
+    <value>回合名称</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>ラウンド状況を表示</value>
+    <value>显示回合状态</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。</value>
+    <value>设置将回合结果发送到 Discord 的 Webhook URL。留空则禁用。</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>ラウンド統計を表示</value>
+    <value>显示回合统计</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>両方とも再生する</value>
+    <value>同时播放</value>
   </data>
   <data name="保存" xml:space="preserve">
     <value>保存</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>再生する音声</value>
+    <value>要播放的音频</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出現回数</value>
+    <value>出现次数</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>削除</value>
+    <value>删除</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>参照...</value>
+    <value>浏览...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>固定する</value>
+    <value>置顶</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>固定解除</value>
+    <value>取消置顶</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>外部アプリを自動起動する</value>
+    <value>自动启动外部应用程序</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>実行ファイル</value>
+    <value>可执行文件</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>対象アイテム名</value>
+    <value>目标物品名称</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>履歴表示数:</value>
+    <value>历史显示数量：</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>引数</value>
+    <value>参数</value>
   </data>
   <data name="情報" xml:space="preserve">
-    <value>情報</value>
+    <value>信息</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>情報表示欄背景色:</value>
+    <value>信息显示区域背景色：</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>時計を表示</value>
+    <value>显示时钟</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
-    <value>曖昧マッチング</value>
+    <value>模糊匹配</value>
   </data>
   <data name="最大速度" xml:space="preserve">
     <value>最大速度</value>
@@ -255,192 +255,192 @@ APIキーはwebサイトから取得してください。</value>
     <value>最小速度</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>有効</value>
+    <value>启用</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>構文エラー</value>
+    <value>语法错误</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>次ラウンド予測を表示</value>
+    <value>显示下回合预测</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡回数</value>
+    <value>死亡次数</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>滞在タイマーを表示</value>
+    <value>显示停留计时器</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>特定アイテムで音楽を再生する</value>
+    <value>针对特定物品播放音乐</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>現在の設定では自動自殺を行いません</value>
+    <value>当前设置下不会执行自动自杀。</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存回数</value>
+    <value>生存次数</value>
   </data>
   <data name="生存率" xml:space="preserve">
     <value>生存率</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>競合時の優先設定:</value>
+    <value>冲突时的优先级：</value>
   </data>
   <data name="終了" xml:space="preserve">
-    <value>終了</value>
+    <value>退出</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>統計情報を表示する</value>
+    <value>显示统计信息</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>統計情報表示欄</value>
+    <value>统计信息区域</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>統計表示欄背景色:</value>
+    <value>统计显示区域背景色：</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色設定</value>
+    <value>背景色设置</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自動自殺は無効になっています</value>
+    <value>自动自杀已禁用。</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>自動自殺を有効にする</value>
+    <value>启用自动自杀</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自動自殺モード</value>
+    <value>自动自杀模式</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自動自殺対象ラウンド:</value>
+    <value>自动自杀目标回合：</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自動起動設定</value>
+    <value>自动启动设置</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>色選択</value>
+    <value>选择颜色</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>表示設定</value>
+    <value>显示设置</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>角度を表示</value>
+    <value>显示角度</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>解析できなかった行があります:</value>
+    <value>存在无法解析的行：</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>言語</value>
+    <value>语言</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>設定</value>
+    <value>设置</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>設定...</value>
+    <value>设置...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
-    <value>設定内容</value>
+    <value>配置</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>設定内容確認</value>
+    <value>检查配置</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>設定変更</value>
+    <value>更改设置</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>詳細設定を利用する</value>
+    <value>使用高级设置</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>詳細設定ドキュメント</value>
+    <value>高级设置文档</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>読み込み</value>
+    <value>加载</value>
   </data>
   <data name="警告" xml:space="preserve">
     <value>警告</value>
   </data>
   <data name="追加" xml:space="preserve">
-    <value>追加</value>
+    <value>添加</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>追加設定</value>
+    <value>附加设置</value>
   </data>
   <data name="透明度" xml:space="preserve">
     <value>透明度</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>速度を表示</value>
+    <value>显示速度</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>デンマーク語</value>
+    <value>丹麦语</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>ドイツ語</value>
+    <value>德语</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英語, イギリス</value>
+    <value>英语（英国）</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英語, アメリカ</value>
+    <value>英语（美国）</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>スペイン語</value>
+    <value>西班牙语</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>スペイン語 (ラテンアメリカ)</value>
+    <value>西班牙语（拉丁美洲）</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>フランス語</value>
+    <value>法语</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>クロアチア語</value>
+    <value>克罗地亚语</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>イタリア語</value>
+    <value>意大利语</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>リトアニア語</value>
+    <value>立陶宛语</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>ハンガリー語</value>
+    <value>匈牙利语</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>オランダ語</value>
+    <value>荷兰语</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>ノルウェー語</value>
+    <value>挪威语</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>ポーランド語</value>
+    <value>波兰语</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>ポルトガル語, ブラジル</value>
+    <value>葡萄牙语（巴西）</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>ルーマニア語</value>
+    <value>罗马尼亚语</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>フィンランド語</value>
+    <value>芬兰语</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>スウェーデン語</value>
+    <value>瑞典语</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>ベトナム語</value>
+    <value>越南语</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>トルコ語</value>
+    <value>土耳其语</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>タイ語</value>
+    <value>泰语</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>ギリシャ語</value>
+    <value>希腊语</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>ブルガリア語</value>
+    <value>保加利亚语</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>ロシア語</value>
+    <value>俄语</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>ウクライナ語</value>
+    <value>乌克兰语</value>
   </data>
 </root>

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -251,7 +251,7 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Infrastructure\Resources\Strings.resx" />
-    <EmbeddedResource Include="Infrastructure\Resources\Strings.ja.resx" />
+    <EmbeddedResource Include="Infrastructure\Resources\Strings.*.resx" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>

--- a/UI/InfoPanel.cs
+++ b/UI/InfoPanel.cs
@@ -134,5 +134,14 @@ namespace ToNRoundCounter.UI
                 ctrl.ForeColor = Theme.Current.Foreground;
             }
         }
+
+        public void ApplyLanguage()
+        {
+            RoundTypeTitle.Text = LanguageManager.Translate("InfoPanel_RoundType");
+            MapTitle.Text = LanguageManager.Translate("InfoPanel_Map");
+            TerrorTitle.Text = LanguageManager.Translate("InfoPanel_Terror");
+            ItemTitle.Text = LanguageManager.Translate("InfoPanel_Item");
+            DamageTitle.Text = LanguageManager.Translate("InfoPanel_Damage");
+        }
     }
 }

--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -20,6 +20,8 @@ namespace ToNRoundCounter.UI
         private readonly IAppSettings _settings;
 
 
+        private Label languageLabel = null!;
+        public ComboBox LanguageComboBox { get; private set; } = null!;
         public NumericUpDown oscPortNumericUpDown { get; private set; } = null!;
         public TextBox webSocketIpTextBox { get; private set; } = null!;
         // 統計情報表示・デバッグ情報チェック
@@ -124,6 +126,39 @@ namespace ToNRoundCounter.UI
         private const string RoundBgmTerrorColumnName = "RoundBgmTerror";
         private const string RoundBgmPathColumnName = "RoundBgmPath";
 
+        private static readonly (string Code, string ResourceKey)[] LanguageDisplayKeys = new[]
+        {
+            ("ja", "Language_Japanese"),
+            ("en", "Language_English"),
+            ("en-US", "Language_EnglishUnitedStates"),
+            ("en-GB", "Language_EnglishUnitedKingdom"),
+            ("ko", "Language_Korean"),
+            ("zh-Hans", "Language_ChineseSimplified"),
+            ("da", "Language_Danish"),
+            ("de", "Language_German"),
+            ("es", "Language_Spanish"),
+            ("es-419", "Language_SpanishLatinAmerica"),
+            ("fr", "Language_French"),
+            ("hr", "Language_Croatian"),
+            ("it", "Language_Italian"),
+            ("lt", "Language_Lithuanian"),
+            ("hu", "Language_Hungarian"),
+            ("nl", "Language_Dutch"),
+            ("nb", "Language_Norwegian"),
+            ("pl", "Language_Polish"),
+            ("pt-BR", "Language_PortugueseBrazil"),
+            ("ro", "Language_Romanian"),
+            ("fi", "Language_Finnish"),
+            ("sv", "Language_Swedish"),
+            ("vi", "Language_Vietnamese"),
+            ("tr", "Language_Turkish"),
+            ("th", "Language_Thai"),
+            ("el", "Language_Greek"),
+            ("bg", "Language_Bulgarian"),
+            ("ru", "Language_Russian"),
+            ("uk", "Language_Ukrainian"),
+        };
+
 
         public SettingsPanel(IAppSettings settings)
         {
@@ -142,6 +177,20 @@ namespace ToNRoundCounter.UI
             int thirdColumnY = margin;
             int thirdColumnX = margin * 3 + columnWidth * 2;
             int innerMargin = 10;
+
+            languageLabel = new Label();
+            languageLabel.Text = LanguageManager.Translate("言語");
+            languageLabel.AutoSize = true;
+            languageLabel.Location = new Point(margin, currentY + 4);
+            this.Controls.Add(languageLabel);
+
+            LanguageComboBox = new ComboBox();
+            LanguageComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            LanguageComboBox.Location = new Point(languageLabel.Right + 10, currentY);
+            LanguageComboBox.Width = columnWidth - (LanguageComboBox.Left - margin);
+            this.Controls.Add(LanguageComboBox);
+            LoadLanguageOptions(_settings.Language);
+            currentY += LanguageComboBox.Height + margin;
 
             Label themeLabel = new Label();
             themeLabel.Text = LanguageManager.Translate("テーマ");
@@ -1575,6 +1624,38 @@ namespace ToNRoundCounter.UI
 
         }
 
+        public void LoadLanguageOptions(string? selectedLanguage)
+        {
+            if (LanguageComboBox == null)
+            {
+                return;
+            }
+
+            var items = new List<LanguageOption>();
+            foreach (var (code, resourceKey) in LanguageDisplayKeys)
+            {
+                var displayName = LanguageManager.Translate(resourceKey);
+                items.Add(new LanguageOption(code, displayName));
+            }
+
+            LanguageComboBox.DisplayMember = nameof(LanguageOption.DisplayName);
+            LanguageComboBox.ValueMember = nameof(LanguageOption.Code);
+            LanguageComboBox.DataSource = items;
+
+            var normalized = LanguageManager.NormalizeCulture(selectedLanguage);
+            var selected = items.FirstOrDefault(i => string.Equals(i.Code, normalized, StringComparison.OrdinalIgnoreCase));
+            if (selected != null)
+            {
+                LanguageComboBox.SelectedValue = selected.Code;
+            }
+            else if (items.Count > 0)
+            {
+                LanguageComboBox.SelectedIndex = 0;
+            }
+        }
+
+        public string SelectedLanguage => LanguageComboBox?.SelectedValue as string ?? LanguageManager.DefaultCulture;
+
         public void LoadThemeOptions(IEnumerable<ThemeDescriptor> themes, string selectedThemeKey)
         {
             if (ThemeComboBox == null)
@@ -1715,6 +1796,21 @@ namespace ToNRoundCounter.UI
             }
 
             OverlayOpacityValueLabel.Text = $"{OverlayOpacityTrackBar.Value}%";
+        }
+
+        private sealed class LanguageOption
+        {
+            public LanguageOption(string code, string displayName)
+            {
+                Code = code;
+                DisplayName = displayName;
+            }
+
+            public string Code { get; }
+
+            public string DisplayName { get; }
+
+            public override string ToString() => DisplayName;
         }
 
         private sealed class ThemeListItem


### PR DESCRIPTION
## Summary
- expand the language manager with canonical codes and aliases for the requested locales
- expose every new locale in the settings language selector and add display strings for them
- add localized resource files covering Danish, German, English (US/UK), Spanish (Spain/Latin America), French, Croatian, Italian, Lithuanian, Hungarian, Dutch, Norwegian, Polish, Portuguese (Brazil), Romanian, Finnish, Swedish, Vietnamese, Turkish, Thai, Greek, Bulgarian, Russian, and Ukrainian

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e34c9367148329830d621974eea408