### PR TITLE
Fix closure of out parameter in StateService

### DIFF
--- a/Application/StateService.cs
+++ b/Application/StateService.cs
@@ -228,8 +228,9 @@ namespace ToNRoundCounter.Application
             {
                 if (_terrorAggregates.TryGetRound(round, out var dict))
                 {
-                    terrorDict = new Dictionary<string, TerrorAggregate>(dict);
-                    _logger?.LogEvent("StateService", () => $"Terror aggregates retrieval succeeded for round '{round}' with {terrorDict.Count} entries.", LogEventLevel.Debug);
+                    var terrorDictSnapshot = new Dictionary<string, TerrorAggregate>(dict);
+                    terrorDict = terrorDictSnapshot;
+                    _logger?.LogEvent("StateService", () => $"Terror aggregates retrieval succeeded for round '{round}' with {terrorDictSnapshot.Count} entries.", LogEventLevel.Debug);
                     return true;
                 }
                 terrorDict = null;


### PR DESCRIPTION
## Summary
- prevent `TryGetTerrorAggregates` from capturing the out parameter in a logging lambda by using a local snapshot before assignment

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e37950c5188329bfcd8acb1c58331b