### PR TITLE
Handle disposed cancellation tokens in stats update

### DIFF
--- a/UI/MainForm.Stats.cs
+++ b/UI/MainForm.Stats.cs
@@ -240,8 +240,20 @@ namespace ToNRoundCounter.UI
                 target = newSource;
             }
 
-            previous?.Cancel();
-            previous?.Dispose();
+            if (previous != null)
+            {
+                try
+                {
+                    previous.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // If the token source has already been disposed by a previous operation,
+                    // we can safely ignore the exception and continue with the new source.
+                }
+
+                previous.Dispose();
+            }
             return newSource;
         }
 


### PR DESCRIPTION
## Summary
- guard aggregate stats token renewals against already disposed sources

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e37a922da88329bcdf474ab9445837