### PR TITLE
Fix Media Foundation type usage and guard against null round BGM entries

### DIFF
--- a/Application/AutoRecordingService.cs
+++ b/Application/AutoRecordingService.cs
@@ -1044,7 +1044,7 @@ namespace ToNRoundCounter.Application
                 { "vob", new FormatDescriptor(MediaFoundationInterop.MFVideoFormat_MPEG2, MediaFoundationInterop.MFTranscodeContainerType_MPEG2) },
             };
 
-            private readonly IMFSinkWriter _sinkWriter = null!;
+            private readonly MediaFoundationInterop.IMFSinkWriter _sinkWriter = null!;
             private readonly int _streamIndex;
             private readonly int _width;
             private readonly int _height;
@@ -1083,10 +1083,10 @@ namespace ToNRoundCounter.Application
                 MediaFoundationInterop.AddRef();
 
                 bool initialized = false;
-                IMFAttributes? attributes = null;
-                IMFMediaType? outputType = null;
-                IMFMediaType? inputType = null;
-                IMFSinkWriter? writer = null;
+                MediaFoundationInterop.IMFAttributes? attributes = null;
+                MediaFoundationInterop.IMFMediaType? outputType = null;
+                MediaFoundationInterop.IMFMediaType? inputType = null;
+                MediaFoundationInterop.IMFSinkWriter? writer = null;
 
                 try
                 {
@@ -1205,8 +1205,8 @@ namespace ToNRoundCounter.Application
 
             private void WriteFrameInternal(IntPtr scan0, int stride)
             {
-                IMFMediaBuffer? buffer = null;
-                IMFSample? sample = null;
+                MediaFoundationInterop.IMFMediaBuffer? buffer = null;
+                MediaFoundationInterop.IMFSample? sample = null;
                 IntPtr destination = IntPtr.Zero;
 
                 try

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1271,7 +1271,7 @@ namespace ToNRoundCounter.UI
 
                     if (string.IsNullOrWhiteSpace(statName) || valueToken == null)
                     {
-                        continue;
+                        return;
                     }
 
                     var statValue = valueToken.Type == JTokenType.Null ? null : valueToken.ToObject<object>();
@@ -2728,6 +2728,12 @@ namespace ToNRoundCounter.UI
                 return null;
             }
 
+            var roundBgmEntries = _settings.RoundBgmEntries;
+            if (roundBgmEntries == null)
+            {
+                return null;
+            }
+
             static string? NormalizeKey(string? value)
             {
                 if (string.IsNullOrWhiteSpace(value))
@@ -2798,7 +2804,7 @@ namespace ToNRoundCounter.UI
             var matchesTerrorOnly = new List<RoundBgmEntry>();
             var matchesWildcard = new List<RoundBgmEntry>();
 
-            foreach (var entry in _settings.RoundBgmEntries)
+            foreach (var entry in roundBgmEntries)
             {
                 if (entry == null || !entry.Enabled)
                 {


### PR DESCRIPTION
## Summary
- qualify Media Foundation interop interface usage to resolve missing type errors
- update STATS event handling to stop processing invalid payloads without using continue
- add null checks around round BGM configuration to satisfy nullable analysis

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a6709b5c8329922a4bcbd108ec9f