### PR TITLE
Fix build errors for round log exporter and recording

### DIFF
--- a/Application/AutoRecordingService.cs
+++ b/Application/AutoRecordingService.cs
@@ -402,9 +402,9 @@ namespace ToNRoundCounter.Application
             }
 
             string sanitized = builder.ToString();
-            while (sanitized.Contains("__", StringComparison.Ordinal))
+            while (sanitized.Contains("__"))
             {
-                sanitized = sanitized.Replace("__", "_", StringComparison.Ordinal);
+                sanitized = sanitized.Replace("__", "_");
             }
 
             return sanitized.Trim('_');
@@ -602,13 +602,13 @@ namespace ToNRoundCounter.Application
                         break;
                     }
 
-                    var origin = new Point(rect.Left, rect.Top);
+                    var origin = new System.Drawing.Point(rect.Left, rect.Top);
 
                     try
                     {
                         using (var graphics = Graphics.FromImage(bitmap))
                         {
-                            graphics.CopyFromScreen(origin, Point.Empty, size, CopyPixelOperation.SourceCopy);
+                            graphics.CopyFromScreen(origin, System.Drawing.Point.Empty, size, CopyPixelOperation.SourceCopy);
                         }
 
                         _writer.WriteFrame(bitmap);

--- a/Infrastructure/AppSettings.cs
+++ b/Infrastructure/AppSettings.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using ToNRoundCounter.Application;

--- a/ToNRoundCounter.csproj
+++ b/ToNRoundCounter.csproj
@@ -210,6 +210,8 @@
     <Compile Include="Application\StateService.cs" />
     <Compile Include="Application\IMainView.cs" />
     <Compile Include="Application\MainPresenter.cs" />
+    <Compile Include="Application\RoundLogExportOptions.cs" />
+    <Compile Include="Application\RoundLogExporter.cs" />
     <Compile Include="Application\IEventLogger.cs" />
     <Compile Include="Application\IEventLogRepository.cs" />
     <Compile Include="Application\ICancellationProvider.cs" />


### PR DESCRIPTION
## Summary
- fix auto recording filename sanitation to avoid unavailable overloads
- disambiguate System.Drawing point usage in screen capture logic
- include round log exporter files in the project and add LINQ support for app settings parsing

## Testing
- Not run (environment missing `dotnet` SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e3a72744508329add23537422cc074