### PR TITLE
Resolve terror data naming conflict and null trim warning

### DIFF
--- a/Application/RoundLogExporter.cs
+++ b/Application/RoundLogExporter.cs
@@ -297,7 +297,7 @@ namespace ToNRoundCounter.Application
             int level = DetermineLevel(round.RoundType);
 
             var terrorNames = SplitTerrorNames(round.TerrorKey);
-            var terrorEntries = new List<RoundLogExportEntry.TerrorData>(capacity: 3);
+            var terrorEntries = new List<RoundLogExportEntry.TerrorEntry>(capacity: 3);
             var terrorIds = round.TerrorIds ?? Array.Empty<int>();
 
             for (int index = 0; index < 3; index++)
@@ -307,7 +307,7 @@ namespace ToNRoundCounter.Application
                 int group = ResolveGroup(round.RoundType, terrorName);
                 int? encounter = ResolveEncounter(terrorName);
 
-                var terrorData = new RoundLogExportEntry.TerrorData
+                var terrorData = new RoundLogExportEntry.TerrorEntry
                 {
                     Index = terrorId,
                     RoundType = roundTypeId,
@@ -459,7 +459,7 @@ namespace ToNRoundCounter.Application
             public int RoundTypeId { get; set; }
 
             [JsonProperty("TD")]
-            public List<TerrorData> TerrorData { get; set; } = new List<TerrorData>();
+            public List<TerrorEntry> TerrorData { get; set; } = new List<TerrorEntry>();
 
             [JsonProperty("MapID")]
             public int MapId { get; set; }
@@ -473,7 +473,7 @@ namespace ToNRoundCounter.Application
             [JsonProperty("RType")]
             public object? RoundType { get; set; }
 
-            public sealed class TerrorData
+            public sealed class TerrorEntry
             {
                 [JsonProperty("i")]
                 public int Index { get; set; }

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -2736,12 +2736,13 @@ namespace ToNRoundCounter.UI
 
             static string? NormalizeKey(string? value)
             {
-                if (string.IsNullOrWhiteSpace(value))
+                if (value is null)
                 {
                     return null;
                 }
 
-                return value.Trim();
+                var trimmed = value.Trim();
+                return trimmed.Length == 0 ? null : trimmed;
             }
 
             var comparer = StringComparer.OrdinalIgnoreCase;


### PR DESCRIPTION
## Summary
- rename the export entry terror data type to avoid a naming clash with the property on the same class
- tighten the round BGM key normalization helper to handle null and whitespace safely

## Testing
- not run (dotnet CLI is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e3a7f2ed3083299929e59bfd5b3657