### PR TITLE
Fix compatibility issues for .NET Framework build

### DIFF
--- a/Application/AutoRecordingService.cs
+++ b/Application/AutoRecordingService.cs
@@ -236,14 +236,14 @@ namespace ToNRoundCounter.Application
                 .ToList();
         }
 
-        private static IEnumerable<string> SplitTerrorNames(string terrorKey)
+        private static IEnumerable<string> SplitTerrorNames(string? terrorKey)
         {
             if (string.IsNullOrWhiteSpace(terrorKey))
             {
                 yield break;
             }
 
-            foreach (var part in terrorKey.Split(new[] { '&', ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var part in terrorKey!.Split(new[] { '&', ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
             {
                 var value = part.Trim();
                 if (!string.IsNullOrWhiteSpace(value))

--- a/Infrastructure/AppSettings.cs
+++ b/Infrastructure/AppSettings.cs
@@ -141,7 +141,7 @@ namespace ToNRoundCounter.Infrastructure
                 {
                     try
                     {
-                        var token = JObject.Parse(json);
+                        var token = JObject.Parse(json!);
                         if (token.TryGetValue("ThemeKey", out var themeKeyToken))
                         {
                             ThemeKey = NormalizeThemeKey(themeKeyToken?.Value<string>());
@@ -156,7 +156,7 @@ namespace ToNRoundCounter.Infrastructure
                         // Ignore malformed theme information and fall back to defaults.
                     }
 
-                    JsonConvert.PopulateObject(json, this);
+                    JsonConvert.PopulateObject(json!, this);
 
                     if (loadedFromRepository && !File.Exists(settingsFile))
                     {

--- a/Infrastructure/LanguageAssemblyResolver.cs
+++ b/Infrastructure/LanguageAssemblyResolver.cs
@@ -229,7 +229,7 @@ namespace ToNRoundCounter.Infrastructure
             return null;
         }
 
-        private static IEnumerable<string> BuildCandidateCultures(string cultureName)
+        private static IEnumerable<string> BuildCandidateCultures(string? cultureName)
         {
             var candidates = new LinkedList<string>();
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -242,6 +242,11 @@ namespace ToNRoundCounter.Infrastructure
                 }
 
                 candidates.AddLast(candidate);
+            }
+
+            if (string.IsNullOrEmpty(cultureName))
+            {
+                return candidates;
             }
 
             TryAdd(cultureName);


### PR DESCRIPTION
## Summary
- replace unsupported async file and SQLite disposal patterns in the round log exporter for .NET Framework compatibility
- add nullability annotations and checks in the auto-recording service and round exporter to silence analyzer warnings
- guard JSON and language resolution helpers against null inputs during settings load

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3ac6574788329abf450a5c66fa63e