### PR TITLE
Add auto recording command configuration

### DIFF
--- a/Application/IAppSettings.cs
+++ b/Application/IAppSettings.cs
@@ -68,7 +68,9 @@ namespace ToNRoundCounter.Application
         double ItemMusicMaxSpeed { get; set; }
         bool AutoRecordingEnabled { get; set; }
         string AutoRecordingWindowTitle { get; set; }
+        string AutoRecordingCommand { get; set; }
         int AutoRecordingFrameRate { get; set; }
+        string AutoRecordingArguments { get; set; }
         string AutoRecordingOutputDirectory { get; set; }
         string AutoRecordingOutputExtension { get; set; }
         List<string> AutoRecordingRoundTypes { get; set; }

--- a/Infrastructure/AppSettings.cs
+++ b/Infrastructure/AppSettings.cs
@@ -92,7 +92,9 @@ namespace ToNRoundCounter.Infrastructure
         public double ItemMusicMaxSpeed { get; set; }
         public bool AutoRecordingEnabled { get; set; }
         public string AutoRecordingWindowTitle { get; set; } = "VRChat";
+        public string AutoRecordingCommand { get; set; } = string.Empty;
         public int AutoRecordingFrameRate { get; set; } = 30;
+        public string AutoRecordingArguments { get; set; } = string.Empty;
         public string AutoRecordingOutputDirectory { get; set; } = "recordings";
         public string AutoRecordingOutputExtension { get; set; } = "avi";
         public List<string> AutoRecordingRoundTypes { get; set; } = new List<string>();
@@ -372,7 +374,13 @@ namespace ToNRoundCounter.Infrastructure
             AutoRecordingWindowTitle = string.IsNullOrWhiteSpace(AutoRecordingWindowTitle)
                 ? "VRChat"
                 : AutoRecordingWindowTitle.Trim();
+            AutoRecordingCommand = string.IsNullOrWhiteSpace(AutoRecordingCommand)
+                ? string.Empty
+                : AutoRecordingCommand.Trim();
             AutoRecordingFrameRate = NormalizeRecordingFrameRate(AutoRecordingFrameRate);
+            AutoRecordingArguments = string.IsNullOrWhiteSpace(AutoRecordingArguments)
+                ? string.Empty
+                : AutoRecordingArguments.Trim();
             AutoRecordingOutputDirectory = string.IsNullOrWhiteSpace(AutoRecordingOutputDirectory)
                 ? "recordings"
                 : AutoRecordingOutputDirectory.Trim();
@@ -551,7 +559,9 @@ namespace ToNRoundCounter.Infrastructure
                 RoundBgmItemConflictBehavior = RoundBgmItemConflictBehavior,
                 AutoRecordingEnabled = AutoRecordingEnabled,
                 AutoRecordingWindowTitle = AutoRecordingWindowTitle,
+                AutoRecordingCommand = AutoRecordingCommand,
                 AutoRecordingFrameRate = AutoRecordingFrameRate,
+                AutoRecordingArguments = AutoRecordingArguments,
                 AutoRecordingOutputDirectory = AutoRecordingOutputDirectory,
                 AutoRecordingOutputExtension = AutoRecordingOutputExtension,
                 AutoRecordingRoundTypes = AutoRecordingRoundTypes,
@@ -644,7 +654,9 @@ namespace ToNRoundCounter.Infrastructure
         public RoundBgmItemConflictBehavior RoundBgmItemConflictBehavior { get; set; } = RoundBgmItemConflictBehavior.PlayBoth;
         public bool AutoRecordingEnabled { get; set; }
         public string AutoRecordingWindowTitle { get; set; } = "VRChat";
+        public string AutoRecordingCommand { get; set; } = string.Empty;
         public int AutoRecordingFrameRate { get; set; } = 30;
+        public string AutoRecordingArguments { get; set; } = string.Empty;
         public string AutoRecordingOutputDirectory { get; set; } = "recordings";
         public string AutoRecordingOutputExtension { get; set; } = "avi";
         public List<string> AutoRecordingRoundTypes { get; set; } = new List<string>();

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -661,7 +661,9 @@ namespace ToNRoundCounter.UI
                     _settings.AutoLaunchEntries = settingsForm.SettingsPanel.GetAutoLaunchEntries();
                     _settings.AutoRecordingEnabled = settingsForm.SettingsPanel.AutoRecordingEnabledCheckBox.Checked;
                     _settings.AutoRecordingWindowTitle = settingsForm.SettingsPanel.AutoRecordingWindowTitleTextBox.Text?.Trim() ?? string.Empty;
+                    _settings.AutoRecordingCommand = settingsForm.SettingsPanel.AutoRecordingCommandTextBox.Text?.Trim() ?? string.Empty;
                     _settings.AutoRecordingFrameRate = (int)settingsForm.SettingsPanel.AutoRecordingFrameRateNumeric.Value;
+                    _settings.AutoRecordingArguments = settingsForm.SettingsPanel.AutoRecordingArgumentsTextBox.Text?.Trim() ?? string.Empty;
                     _settings.AutoRecordingOutputDirectory = settingsForm.SettingsPanel.AutoRecordingOutputDirectoryTextBox.Text?.Trim() ?? string.Empty;
                     _settings.AutoRecordingOutputExtension = settingsForm.SettingsPanel.GetAutoRecordingOutputExtension();
                     _settings.AutoRecordingRoundTypes = settingsForm.SettingsPanel.GetAutoRecordingRoundTypes();

--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -114,12 +114,15 @@ namespace ToNRoundCounter.UI
         public TextBox DiscordWebhookUrlTextBox { get; private set; } = null!;
         public CheckBox AutoRecordingEnabledCheckBox { get; private set; } = null!;
         public TextBox AutoRecordingWindowTitleTextBox { get; private set; } = null!;
+        public TextBox AutoRecordingCommandTextBox { get; private set; } = null!;
+        public TextBox AutoRecordingArgumentsTextBox { get; private set; } = null!;
         public NumericUpDown AutoRecordingFrameRateNumeric { get; private set; } = null!;
         public TextBox AutoRecordingOutputDirectoryTextBox { get; private set; } = null!;
         public ComboBox AutoRecordingFormatComboBox { get; private set; } = null!;
         public CheckedListBox AutoRecordingRoundTypesListBox { get; private set; } = null!;
         public TextBox AutoRecordingTerrorNamesTextBox { get; private set; } = null!;
         private Button autoRecordingBrowseOutputButton = null!;
+        private Button autoRecordingBrowseCommandButton = null!;
         private Button roundLogExportButton = null!;
 
         private const string AutoLaunchEnabledColumnName = "AutoLaunchEnabled";
@@ -1055,16 +1058,16 @@ namespace ToNRoundCounter.UI
             AutoRecordingCommandTextBox.Width = columnWidth - innerMargin * 3 - 90;
             grpAutoRecording.Controls.Add(AutoRecordingCommandTextBox);
 
-            Button autoRecordingCommandBrowseButton = new Button();
-            autoRecordingCommandBrowseButton.Text = LanguageManager.Translate("参照...");
-            autoRecordingCommandBrowseButton.AutoSize = true;
-            autoRecordingCommandBrowseButton.Location = new Point(AutoRecordingCommandTextBox.Right + 10, AutoRecordingCommandTextBox.Top - 2);
-            autoRecordingCommandBrowseButton.Click += (s, e) =>
+            autoRecordingBrowseCommandButton = new Button();
+            autoRecordingBrowseCommandButton.Text = LanguageManager.Translate("参照...");
+            autoRecordingBrowseCommandButton.AutoSize = true;
+            autoRecordingBrowseCommandButton.Location = new Point(AutoRecordingCommandTextBox.Right + 10, AutoRecordingCommandTextBox.Top - 2);
+            autoRecordingBrowseCommandButton.Click += (s, e) =>
             {
                 BrowseForAutoRecordingExecutable();
                 RefreshAutoRecordingControlsState();
             };
-            grpAutoRecording.Controls.Add(autoRecordingCommandBrowseButton);
+            grpAutoRecording.Controls.Add(autoRecordingBrowseCommandButton);
 
             autoRecordingInnerY = AutoRecordingCommandTextBox.Bottom + 8;
 
@@ -1176,7 +1179,9 @@ namespace ToNRoundCounter.UI
 
             AutoRecordingEnabledCheckBox.CheckedChanged += (s, e) => RefreshAutoRecordingControlsState();
             AutoRecordingWindowTitleTextBox.Text = _settings.AutoRecordingWindowTitle;
+            AutoRecordingCommandTextBox.Text = _settings.AutoRecordingCommand ?? string.Empty;
             AutoRecordingFrameRateNumeric.Value = Math.Min(Math.Max(_settings.AutoRecordingFrameRate, 5), 60);
+            AutoRecordingArgumentsTextBox.Text = _settings.AutoRecordingArguments ?? string.Empty;
             AutoRecordingOutputDirectoryTextBox.Text = _settings.AutoRecordingOutputDirectory;
             AutoRecordingEnabledCheckBox.Checked = _settings.AutoRecordingEnabled;
             SetAutoRecordingFormat(_settings.AutoRecordingOutputExtension);
@@ -2553,6 +2558,29 @@ namespace ToNRoundCounter.UI
             }
         }
 
+        private void BrowseForAutoRecordingExecutable()
+        {
+            if (AutoRecordingCommandTextBox == null)
+            {
+                return;
+            }
+
+            using (OpenFileDialog dialog = new OpenFileDialog())
+            {
+                dialog.Filter = "実行ファイル|*.exe;*.bat;*.cmd;*.com|すべてのファイル|*.*";
+                string current = AutoRecordingCommandTextBox.Text ?? string.Empty;
+                if (!string.IsNullOrWhiteSpace(current))
+                {
+                    dialog.FileName = current;
+                }
+
+                if (dialog.ShowDialog() == DialogResult.OK)
+                {
+                    AutoRecordingCommandTextBox.Text = dialog.FileName;
+                }
+            }
+        }
+
         private void BrowseForAutoRecordingOutputDirectory()
         {
             if (AutoRecordingOutputDirectoryTextBox == null)
@@ -2607,9 +2635,17 @@ namespace ToNRoundCounter.UI
             {
                 AutoRecordingWindowTitleTextBox.Enabled = enabled;
             }
+            if (AutoRecordingCommandTextBox != null)
+            {
+                AutoRecordingCommandTextBox.Enabled = enabled;
+            }
             if (AutoRecordingFrameRateNumeric != null)
             {
                 AutoRecordingFrameRateNumeric.Enabled = enabled;
+            }
+            if (AutoRecordingArgumentsTextBox != null)
+            {
+                AutoRecordingArgumentsTextBox.Enabled = enabled;
             }
             if (AutoRecordingOutputDirectoryTextBox != null)
             {
@@ -2622,6 +2658,10 @@ namespace ToNRoundCounter.UI
             if (autoRecordingBrowseOutputButton != null)
             {
                 autoRecordingBrowseOutputButton.Enabled = enabled;
+            }
+            if (autoRecordingBrowseCommandButton != null)
+            {
+                autoRecordingBrowseCommandButton.Enabled = enabled;
             }
             if (AutoRecordingRoundTypesListBox != null)
             {


### PR DESCRIPTION
## Summary
- add UI fields that allow configuring an auto-recording command and arguments, including browse support
- persist the new auto-recording command settings in the app settings model and save workflow

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b952caec832982cfadb99ecd2943