### PR TITLE
Localize auto recording strings across locales

### DIFF
--- a/Infrastructure/Resources/Strings.bg.resx
+++ b/Infrastructure/Resources/Strings.bg.resx
@@ -443,4 +443,85 @@
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Украински</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Изходната папка</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Изходно разширение</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Автоматичен запис</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Запишете VRChat автоматично, когато съвпада с тригерите</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Запис на изпълним файл</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Записване на аргументи</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Използвайте {output} за пътя на файла и {window} за заглавието на прозореца.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Заглавие на прозореца</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Целев прозорец</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Можете да посочите част от заглавието на прозореца или името на процеса.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Честота на кадрите</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Формат на изхода</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (Некомпресирано видео)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 Видео)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 Видео)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (програмен поток)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 Видео)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 Видео)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (контейнер за Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (програмен поток MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (анимирано изображение)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI създава записи без загуби, но води до големи файлове. MP4, MOV, MKV и FLV използват H.264 за размера и съвместимостта на баланса. WMV и ASF продуцират видео файлове на Windows Media. MPG и VOB генерират програмни потоци MPEG-2. GIF произвежда леки анимирани изображения с ограничени цветове и честота на кадрите.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Задейства имена на терористи</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Задействайте типове кръгли видове</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Въведете едно име на терор на ред. Съпоставянето е нечувствително към случая.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.da.resx
+++ b/Infrastructure/Resources/Strings.da.resx
@@ -443,4 +443,85 @@ Få en API -nøgle fra webstedet.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Ukrainsk</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Outputmappe</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Output -udvidelse</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Autooptagelse</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Optag VRChat automatisk, når triggers matcher</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Optagelse af eksekverbar</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Registrering af argumenter</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Brug {output} til filstien og {window} til vinduetitlen.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Vinduetitel</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Målvindue</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Du kan specificere en del af vinduestitel eller procesnavn.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Billedhastighed</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Outputformat</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (ukomprimeret video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 VIDEO)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (programstrøm)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 -video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 -video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2-programstrøm)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animeret billede)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI skaber tabsløse optagelser, men resulterer i store filer. MP4, MOV, MKV og FLV bruger H.264 til at afbalancere størrelse og kompatibilitet. WMV og ASF producerer Windows Media -videofiler. MPG og VOB genererer MPEG-2-programstrømme. GIF producerer lette animerede billeder med begrænsede farver og billedhastighed.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Trigger terrornavne</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Trigger runde typer</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Indtast et terrornavn pr. Linje. Matching er case-følsom.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.de.resx
+++ b/Infrastructure/Resources/Strings.de.resx
@@ -443,4 +443,85 @@ Bitte erhalten Sie einen API -Schlüssel von der Website.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ukrainisch</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Ausgangsordner</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Ausgangserweiterung</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Autoaufnahme</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Nehmen Sie VRchat automatisch auf, wenn Trigger übereinstimmen</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Aufzeichnung der ausführbaren Datei</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Argumente aufzeichnen</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Verwenden Sie {output} für den Dateipfad und {window} für den Fenstertitel.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Fenstertitel</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Zielfenster</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Sie können einen Teil des Fenstertitels oder des Prozessnamens angeben.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Bildrate</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Ausgangsformat</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (unkomprimiertes Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (Programmstream)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2-Programmstream)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animiertes Bild)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI erstellt verlustfreie Aufnahmen, führt jedoch zu großen Dateien. MP4, MOV, MKV und FLV verwenden H.264, um die Größe und Kompatibilität auszugleichen. WMV und ASF produzieren Windows Media -Videodateien. MPG und VOB generieren MPEG-2-Programmströme. GIF produziert leichte animierte Bilder mit begrenzten Farben und Bildrate.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Terroramen auslösen</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Runde Typen auslösen</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Geben Sie einen Terroramen pro Zeile ein. Die Übereinstimmung ist unempfindlich.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.el.resx
+++ b/Infrastructure/Resources/Strings.el.resx
@@ -443,4 +443,85 @@
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Ουκρανός</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Φάκελος εξόδου</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Επέκταση εξόδου</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Αυτόματη εγγραφή</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Καταγράψτε αυτόματα το VRChat όταν ενεργοποιεί τον αγώνα</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Καταγραφή εκτελέσιμου</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Επιχειρήματα εγγραφής</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Χρησιμοποιήστε {output} για τη διαδρομή αρχείου και {window} για τον τίτλο του παραθύρου.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Τίτλος παραθύρου</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Παράθυρο στόχου</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Μπορείτε να καθορίσετε μέρος του ονόματος του τίτλου ή της διαδικασίας του παραθύρου.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Ρυθμός πλαισίου</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Μορφή εξόδου</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (μη συμπιεσμένο βίντεο)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (βίντεο H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (βίντεο H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (βίντεο Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (ροή προγράμματος)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (βίντεο H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (βίντεο H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (ροή προγράμματος MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (κινούμενη εικόνα)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>Το AVI δημιουργεί εγγραφές χωρίς απώλειες, αλλά έχει ως αποτέλεσμα μεγάλα αρχεία. MP4, MOV, MKV και FLV χρησιμοποιούν H.264 για να ισορροπήσουν το μέγεθος και τη συμβατότητα. Τα WMV και ASF παράγουν αρχεία βίντεο Windows Media. Τα MPG και VOB δημιουργούν ροές προγραμμάτων MPEG-2. Το GIF παράγει ελαφρές κινούμενες εικόνες με περιορισμένα χρώματα και ρυθμό καρέ.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Ενεργοποιήστε τα ονόματα τρομοκρατίας</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Τύποι στρογγυλών ενεργοποίησης</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Εισαγάγετε ένα όνομα τρόμου ανά γραμμή. Η αντιστοίχιση είναι ευαίσθητη στην περίπτωση.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.en-GB.resx
+++ b/Infrastructure/Resources/Strings.en-GB.resx
@@ -443,4 +443,85 @@ Please obtain an API key from the website.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Ukrainian</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Output folder</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Output extension</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Auto recording</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Record VRChat automatically when triggers match</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Recording executable</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Recording arguments</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Use {output} for the file path and {window} for the window title.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Window title</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Target window</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>You can specify part of the window title or process name.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Frame rate</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Output format</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (uncompressed video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (Program Stream)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2 program stream)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animated image)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI creates lossless recordings but results in large files. MP4, MOV, MKV, and FLV use H.264 to balance size and compatibility. WMV and ASF produce Windows Media Video files. MPG and VOB generate MPEG-2 program streams. GIF produces lightweight animated images with limited colors and frame rate.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Trigger terror names</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Trigger round types</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Enter one terror name per line. Matching is case-insensitive.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.en-US.resx
+++ b/Infrastructure/Resources/Strings.en-US.resx
@@ -443,4 +443,85 @@ Please obtain an API key from the website.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Ukrainian</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Output folder</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Output extension</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Auto recording</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Record VRChat automatically when triggers match</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Recording executable</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Recording arguments</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Use {output} for the file path and {window} for the window title.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Window title</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Target window</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>You can specify part of the window title or process name.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Frame rate</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Output format</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (uncompressed video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (Program Stream)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2 program stream)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animated image)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI creates lossless recordings but results in large files. MP4, MOV, MKV, and FLV use H.264 to balance size and compatibility. WMV and ASF produce Windows Media Video files. MPG and VOB generate MPEG-2 program streams. GIF produces lightweight animated images with limited colors and frame rate.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Trigger terror names</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Trigger round types</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Enter one terror name per line. Matching is case-insensitive.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.es-419.resx
+++ b/Infrastructure/Resources/Strings.es-419.resx
@@ -443,4 +443,85 @@ Obtenga una clave API del sitio web.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ucranio</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Carpeta de salida</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Extensión de salida</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Grabación automática</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Registre a VRChat automáticamente cuando se dispara</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Registro ejecutable</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Grabando argumentos</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Use {output} para la ruta del archivo y {window} para el título de la ventana.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Título de ventana</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Ventana objetivo</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Puede especificar parte del título de la ventana o el nombre del proceso.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Velocidad de cuadro</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Formato de salida</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (video sin comprimir)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (VIDEO H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Video de Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (transmisión del programa)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (Video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (Video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (transmisión del programa MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (imagen animada)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI crea grabaciones sin pérdidas pero da como resultado archivos grandes. MP4, MOV, MKV y FLV usan H.264 para equilibrar el tamaño y la compatibilidad. WMV y ASF producen archivos de video Windows Media. MPG y VOB generan transmisiones del programa MPEG-2. GIF produce imágenes animadas livianas con colores limitados y velocidad de cuadro.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Desencadenar nombres de terror</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Tipos redondos de activación</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Ingrese un nombre de terror por línea. La coincidencia es insensible al caso.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.es.resx
+++ b/Infrastructure/Resources/Strings.es.resx
@@ -443,4 +443,85 @@ Obtenga una clave API del sitio web.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ucranio</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Carpeta de salida</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Extensión de salida</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Grabación automática</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Registre a VRChat automáticamente cuando se dispara</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Registro ejecutable</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Grabando argumentos</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Use {output} para la ruta del archivo y {window} para el título de la ventana.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Título de ventana</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Ventana objetivo</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Puede especificar parte del título de la ventana o el nombre del proceso.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Velocidad de cuadro</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Formato de salida</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (video sin comprimir)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (VIDEO H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Video de Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (transmisión del programa)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (Video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (Video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (transmisión del programa MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (imagen animada)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI crea grabaciones sin pérdidas pero da como resultado archivos grandes. MP4, MOV, MKV y FLV usan H.264 para equilibrar el tamaño y la compatibilidad. WMV y ASF producen archivos de video Windows Media. MPG y VOB generan transmisiones del programa MPEG-2. GIF produce imágenes animadas livianas con colores limitados y velocidad de cuadro.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Desencadenar nombres de terror</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Tipos redondos de activación</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Ingrese un nombre de terror por línea. La coincidencia es insensible al caso.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.fi.resx
+++ b/Infrastructure/Resources/Strings.fi.resx
@@ -443,4 +443,85 @@ Hanki API -avain verkkosivustolta.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Ukrainalainen</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Lähtökansio</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Lähtölaajennus</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Automaattinen tallennus</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Tallenna VRChat automaattisesti, kun liipaisimet vastaavat</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Tallenna suoritettava</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Nauhoitusargumentit</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Käytä {output} tiedostopolulle ja {window} ikkunan otsikkoon.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Ikkunan otsikko</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Kohdeikkuna</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Voit määrittää osan ikkunan otsikosta tai prosessin nimestä.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Kehysnopeus</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Lähtömuoto</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (pakkaamattoman videon)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (Program Stream)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2-ohjelmAVIrta)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animoitu kuva)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI luo häviöttomia nauhoituksia, mutta johtaa suuriin tiedostoihin. MP4, MOV, MKV ja FLV käyttävät H.264: tä tasapainottamaan koon ja yhteensopivuuden. WMV ja ASF tuottavat Windows Media -videotiedostoja. MPG ja VOB tuottavat MPEG-2-ohjelmAVIrrat. GIF tuottaa kevyitä animoituja kuvia, joilla on rajoitetut värit ja runko -opeus.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Laukaista terrorinimet</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Laukaista pyöreät tyypit</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Kirjoita yksi terrorin nimi riviä kohti. Yhteensopivuus on koteloa.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.fr.resx
+++ b/Infrastructure/Resources/Strings.fr.resx
@@ -443,4 +443,85 @@ Veuillez obtenir une clé API sur le site Web.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ukrainien</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Dossier de sortie</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Extension de sortie</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Enregistrement automatique</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Enregistrez automatiquement VRChat lorsque les déclencheurs correspondent</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Exécutable d'enregistrement</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Paramètres d'enregistrement</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Utilisez {output} pour le chemin de fichier et {window} pour le titre de la fenêtre.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Titre de fenêtre</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Fenêtre cible</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Vous pouvez spécifier une partie du titre ou du nom du processus de fenêtre.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Fréquence d'images</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Format de sortie</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (vidéo non compressée)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (vidéo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (vidéo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (vidéo Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (flux de programme)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (vidéo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (vidéo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (flux de programme MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (image animée)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI crée des enregistrements sans perte mais entraîne des fichiers volumineux. MP4, MOV, MKV et FLV utilisent H.264 pour équilibrer la taille et la compatibilité. WMV et ASF produisent des fichiers vidéo Windows Media. MPG et VOB génèrent des flux de programme MPEG-2. GIF produit des images animées légères avec des couleurs limitées et une fréquence d'images.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Déclencher les noms de terreur</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Déclencher les types ronds</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Saisissez un nom de terreur par ligne. La correspondance ne tient pas compte de la casse.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.hi.resx
+++ b/Infrastructure/Resources/Strings.hi.resx
@@ -1,0 +1,96 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>आउटपुट फ़ोल्डर</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>आउटपुट फ़ाइल एक्सटेंशन</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>स्वचालित रिकॉर्डिंग सेटिंग</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>जब ट्रिगर शर्तें मेल खाएँ तो VRChat को स्वतः रिकॉर्ड करें</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>रिकॉर्डिंग एक्ज़िक्यूटेबल</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>रिकॉर्डिंग आर्ग्युमेंट्स</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>फ़ाइल पथ के लिए {output} और विंडो शीर्षक के लिए {window} का उपयोग करें।</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>विंडो शीर्षक</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>लक्ष्य विंडो</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>आप विंडो शीर्षक या प्रोसेस नाम का कुछ हिस्सा निर्दिष्ट कर सकते हैं।</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>रिकॉर्डिंग फ़्रेम दर</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>आउटपुट फ़ॉर्मेट</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (असंपीडित वीडियो)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 वीडियो)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 वीडियो)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (विंडोज मीडिया वीडियो)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (प्रोग्राम स्ट्रीम)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 वीडियो)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 वीडियो)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (विंडोज मीडिया कंटेनर)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2 प्रोग्राम स्ट्रीम)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (एनिमेटेड छवि)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI निर्लॉस रिकॉर्डिंग बनाता है लेकिन फ़ाइलें बड़ी होती हैं। MP4, MOV, MKV और FLV H.264 का उपयोग करके आकार और अनुकूलता में संतुलन रखते हैं। WMV और ASF विंडोज मीडिया वीडियो फ़ाइलें बनाते हैं। MPG और VOB MPEG-2 प्रोग्राम स्ट्रीम तैयार करते हैं। GIF सीमित रंगों और फ़्रेम दर वाली हल्की एनिमेटेड छवियाँ बनाता है।</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>रिकॉर्डिंग शुरू करने वाले टेरर के नाम</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>रिकॉर्डिंग शुरू करने वाले राउंड के प्रकार</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>प्रत्येक पंक्ति में एक टेरर का नाम दर्ज करें। मिलान केस-संवेदी नहीं है।</value>
+  </data>
+</root>

--- a/Infrastructure/Resources/Strings.hr.resx
+++ b/Infrastructure/Resources/Strings.hr.resx
@@ -443,4 +443,85 @@ Na web stranici dobijte API ključ.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ukrajinski</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Izlazna mapa</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Izlazno produženje</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Automatsko snimanje</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Zabilježite VRChat automatski kada se okidači podudaraju</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Snimanje izvršne datoteke</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Snimanje argumenata</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Upotrijebite {output} za put datoteke i {window} za naslov prozora.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Prozor</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Ciljani prozor</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Možete odrediti dio naslova prozora ili naziva procesa.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Brzina kadrova</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Izlazni format</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (nekomprimirani video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (programski tok)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2 programski tok)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animirana slika)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI stvara snimke bez gubitaka, ali rezultira velikim datotekama. MP4, MOV, MKV i FLV koriste H.264 za uravnoteženje veličine i kompatibilnosti. WMV i ASF proizvode Windows Media video datoteke. MPG i VOB generiraju MPEG-2 programskih tokova. GIF proizvodi lagane animirane slike s ograničenim bojama i brzinom kadrova.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Okidač teroriznih imena</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Okidač okruglih vrsta</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Unesite jedno ime terora po retku. Podudaranje je neosjetljivo na slučaj.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.hu.resx
+++ b/Infrastructure/Resources/Strings.hu.resx
@@ -443,4 +443,85 @@ Kérjük, szerezzen egy API -kulcsot a weboldalról.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ukrán</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Kimeneti mappa</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Kimeneti kiterjesztés</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Autófelvétel</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Rögzítse a VRChat -t automatikusan, amikor a Triggers egyezik</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Felvétel végrehajtható</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Érvek rögzítése</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Használja a {output} fájlt elérési úthoz és a {window} -hez az ablak címéhez.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Ablakcím</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Célablak</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Megadhatja az ablakcím vagy a folyamat nevének egy részét.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Képkaparék</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Kimeneti formátum</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (tömörítetlen videó)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 videó)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 videó)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (Program Stream)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 videó)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 videó)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2 programfolyam)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animációs kép)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>Az AVI veszteségmentes felvételeket hoz létre, de nagy fájlokat eredményez. MP4, MOV, MKV és FLV használja a H.264 -et az egyensúly és a kompatibilitás érdekében. A WMV és az ASF Windows Media videofájlokat állít elő. Az MPG és a VOB MPEG-2 programfolyamokat generál. A GIF könnyű animált képeket állít elő, korlátozott színekkel és képkockasebességgel.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Terrornevek kiváltása</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Kerek típusok kiváltása</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Írjon be egy terrornevet vonalonként. Az illesztés eset nem érzékeny.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.it.resx
+++ b/Infrastructure/Resources/Strings.it.resx
@@ -443,4 +443,85 @@ Si prega di ottenere una chiave API dal sito Web.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ucraino</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Cartella di output</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Estensione di uscita</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Registrazione automatica</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Registra VRChat automaticamente quando i trigger corrispondono</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Registrazione eseguibile</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Argomenti di registrazione</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Usa {output} per il percorso del file e {window} per il titolo della finestra.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Titolo della finestra</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Finestra target</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>È possibile specificare parte del titolo della finestra o del nome del processo.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Frame rate</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Formato di output</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (video non compresso)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (Stream del programma)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (contenitore Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (Stream del programma MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (immagine animata)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI crea registrazioni senza perdita ma si traduce in file di grandi dimensioni. MP4, MOV, MKV e FLV utilizzano H.264 per bilanciare dimensioni e compatibilità. WMV e ASF producono file video di Windows Media. MPG e VOB generano flussi di programmi MPEG-2. GIF produce immagini animate leggere con colori limitati e frame rate.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Innescare nomi terroristici</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Trigger tipi rotondi</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Immettere un nome terroristico per riga. La corrispondenza è insensibile al caso.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.ko.resx
+++ b/Infrastructure/Resources/Strings.ko.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -442,5 +442,86 @@ API 키가 필요합니다.
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>우크라이나어</value>
+  </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>출력 폴더</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>출력 확장자</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>자동 녹화 설정</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>트리거 조건이 일치하면 VRChat을 자동으로 녹화</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>녹화 실행 파일</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>녹화 실행 인수</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>파일 경로에는 {output}, 창 제목에는 {window}를 사용하세요.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>창 제목</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>대상 창</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>창 제목이나 프로세스 이름의 일부를 지정할 수 있습니다.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>녹화 프레임 레이트</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>출력 형식</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (비압축 영상)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 영상)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 영상)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media 영상)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (프로그램 스트림)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 영상)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 영상)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media 컨테이너)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2 프로그램 스트림)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (애니메이션 이미지)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI는 무손실로 녹화하지만 파일 크기가 큽니다. MP4, MOV, MKV, FLV는 H.264를 사용하여 용량과 호환성을 균형 있게 유지합니다. WMV와 ASF는 Windows Media 영상 파일을 생성합니다. MPG와 VOB는 MPEG-2 프로그램 스트림을 생성합니다. GIF는 제한된 색상과 프레임 속도의 가벼운 애니메이션 이미지를 생성합니다.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>녹화를 시작할 테러 이름</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>녹화를 시작할 라운드 유형</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>줄마다 하나의 테러 이름을 입력하세요. 대소문자는 구분하지 않습니다.</value>
   </data>
 </root>

--- a/Infrastructure/Resources/Strings.lt.resx
+++ b/Infrastructure/Resources/Strings.lt.resx
@@ -443,4 +443,85 @@ Gaukite API raktą iš svetainės.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Ukrainos</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Išvesties aplankas</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Išvesties pratęsimas</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Automatinis įrašymas</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Įrašykite „VRChat“ automatiškai, kai paleidimo sutapimai</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Įrašymas vykdomas</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Įrašyti argumentus</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Failo keliui ir {window} naudokite {output}.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Lango pavadinimas</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Tikslo langas</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Galite nurodyti lango pavadinimo dalį arba proceso pavadinimą.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Kadrų dažnis</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Išvesties formatas</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (nesuspaustas vaizdo įrašas)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 vaizdo įrašas)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 vaizdo įrašas)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV („Windows Media“ vaizdo įrašas)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (programos srautas)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 vaizdo įrašas)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 vaizdo įrašas)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF („Windows Media“ konteineris)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2 programos srautas)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animacinis vaizdas)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI sukuria be nuostolių įrašus, tačiau lemia didelius failus. MP4, MOV, MKV ir FLV naudoja H.264, kad subalansuotų dydį ir suderinamumą. WMV ir ASF gamina „Windows Media“ vaizdo failus. MPG ir VOB generuoja MPEG-2 programos srautus. GIF sukuria lengvus animacinius vaizdus su ribotomis spalvomis ir kadrų dažniu.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Suaktyvinti teroro pavadinimus</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Triggerio apvalių tipai</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Įveskite vieną teroro vardą vienoje eilutėje. Atitikimas yra nejautrus atvejams.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.nb.resx
+++ b/Infrastructure/Resources/Strings.nb.resx
@@ -443,4 +443,85 @@ Vennligst skaff deg en API -nøkkel fra nettstedet.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Ukrainsk</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Utgangsmappe</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Utforlengelse</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Autoopptak</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Registrer VRChat automatisk når utløser samsvarer</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Innspilling av kjørbar</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Innspilling av argumenter</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Bruk {output} for filstien og {window} for vindusittelen.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Vinduetittel</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Målvindu</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Du kan spesifisere en del av vinduetittelen eller prosessnavnet.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Bildefrekvens</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Utgangsformat</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (ukomprimert video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (programstrøm)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2 Programstrøm)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animert bilde)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI oppretter tapsfrie opptak, men resulterer i store filer. MP4, MOV, MKV og FLV bruker H.264 for å balansere størrelse og kompatibilitet. WMV og ASF produserer Windows Media -videofiler. MPG og VOB genererer MPEG-2-programstrømmer. GIF produserer lette animerte bilder med begrensede farger og bildefrekvens.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Utløser terrornavn</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Utløs runde typer</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Skriv inn ett terrornavn per linje. Matching er case-ufølsom.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.nl.resx
+++ b/Infrastructure/Resources/Strings.nl.resx
@@ -443,4 +443,85 @@ Krijg een API -sleutel van de website.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Oekraïens</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Uitvoermap</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Uitvoerverlenging</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Auto -opname</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Noteer VRChat automatisch wanneer triggers overeenkomen</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Uitschakeling uitvoerbaar</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Opname argumenten</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Gebruik {output} voor het bestandspad en {window} voor de venstertitel.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Raamtitel</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Doelvenster</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>U kunt een deel van de venstertitel of procesnaam opgeven.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Framesnelheid</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Uitvoerformaat</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (niet -gecomprimeerde video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (h.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (programmastream)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2-programmastream)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (geanimeerde afbeelding)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI maakt verliesloze opnames maar resulteert in grote bestanden. MP4, MOV, MKV en FLV gebruiken H.264 om de grootte en compatibiliteit in evenwicht te brengen. WMV en ASF produceren Windows Media -videobestanden. MPG en VOB genereren MPEG-2-programmastreams. GIF produceert lichtgewicht geanimeerde afbeeldingen met beperkte kleuren en framesnelheid.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Trigger terreurnamen</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Trigger round types</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Voer één terreurnaam per regel in. Matching is case-ongevoelig.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.pl.resx
+++ b/Infrastructure/Resources/Strings.pl.resx
@@ -443,4 +443,85 @@ Uzyskaj klucz API ze strony internetowej.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ukraiński</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Folder wyjściowy</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Rozszerzenie wyjściowe</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Nagrywanie samochodów</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Nagrywać VRChat automatycznie, gdy wyzwalacze pasują</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Nagrywanie wykonywalne</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Rejestrowanie argumentów</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Użyj {output} dla ścieżki pliku i {window} dla tytułu okna.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Tytuł okna</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Okno docelowe</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Możesz określić część tytułu lub nazwy procesu okna.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Ramka klatek</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Format wyjściowy</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (nieskompresowane wideo)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (wideo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (strumień programu)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (wideo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (wideo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (kontener multimedialny)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (strumień programu MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (obraz animowany)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI tworzy bezstratne nagrania, ale daje duże pliki. MP4, MOV, MKV i FLV Użyj H.264 do równowagi wielkości i kompatybilności. WMV i ASF produkują pliki wideo Windows Media. MPG i VOB generują strumienie programu MPEG-2. GIF wytwarza lekkie animowane obrazy o ograniczonej kolorze i szybkości klatek na sekundę.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Wywołuj nazwy terroru</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Wyzwalają typy okrągłych</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Wprowadź jedną nazwę terroru na wiersz. Dopasowanie jest wrażliwe na przypadek.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.pt-BR.resx
+++ b/Infrastructure/Resources/Strings.pt-BR.resx
@@ -443,4 +443,85 @@ Por favor, obtenha uma chave da API no site.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ucraniano</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Pasta de saída</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Extensão de saída</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Gravação automática</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Grave o VRChat automaticamente quando os gatilhos combinam</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Gravação executável</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Registrando argumentos</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Use {output} para o caminho do arquivo e {window} para o título da janela.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Título da janela</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Janela de destino</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Você pode especificar parte do título da janela ou nome do processo.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Taxa de quadros</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Formato de saída</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (vídeo não compactado)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (vídeo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (vídeo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (vídeo do Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (fluxo de programas)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (vídeo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (vídeo H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (contêiner de mídia do Windows)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (fluxo do programa MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (imagem animada)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>A AVI cria gravações sem perdas, mas resulta em arquivos grandes. MP4, MOV, MKV e FLV usam H.264 para equilibrar o tamanho e a compatibilidade. WMV e ASF produzem arquivos de vídeo de mídia do Windows. MPG e VOB geram fluxos de programa MPEG-2. O GIF produz imagens animadas leves com cores limitadas e taxa de quadros.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Desencadear nomes de terror</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>TIGER TIPOS ROUTOS</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Digite um nome de terror por linha. A correspondência é insensível a minúsculas.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.ro.resx
+++ b/Infrastructure/Resources/Strings.ro.resx
@@ -443,4 +443,85 @@ Vă rugăm să obțineți o cheie API de pe site -ul web.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ucrainean</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Folder de ieșire</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Extensie de ieșire</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Înregistrare automată</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Înregistrați automat VRChat atunci când declanșatorii se potrivesc</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Înregistrarea executabilă</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Argumente de înregistrare</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Utilizați {output} pentru calea fișierului și {window} pentru titlul ferestrei.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Titlul ferestrei</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Fereastra țintă</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Puteți specifica o parte din titlul ferestrei sau numele procesului.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Rata cadrului</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Format de ieșire</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (videoclip necomprimat)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (flux de programe)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (flux de program MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (imagine animată)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI creează înregistrări fără pierderi, dar are ca rezultat fișiere mari. MP4, MOV, MKV și FLV utilizează H.264 pentru a echilibra dimensiunea și compatibilitatea. WMV și ASF produc fișiere video Windows Media. MPG și VOB generează fluxuri de programe MPEG-2. GIF produce imagini animate ușoare, cu culori limitate și rată de cadru.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Declanșează numele de teroare</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Tipuri rotunde de declanșare</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Introduceți un nume de teroare pe linie. Potrivirea este insensibilă la caz.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.ru.resx
+++ b/Infrastructure/Resources/Strings.ru.resx
@@ -443,4 +443,85 @@
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Украинский</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Выводная папка</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Выходное расширение</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Автозаписи</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Запишите VRChat автоматически при совпадении триггеров</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Запись исполняемого файла</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Запись аргументов</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Используйте {output} для пути файла и {window} для заголовка окна.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Название окон</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Целевое окно</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Вы можете указать часть заголовка окна или имени процесса.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Частота кадров</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Выходной формат</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (несомненное видео)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (видео H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (видео H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (видео Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (программный поток)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 Видео)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (видео H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (контейнер Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2 программный поток)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (анимированное изображение)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI создает записи без потерь, но приводит к большим файлам. MP4, MOV, MKV и FLV используют H.264 для баланса и совместимости. WMV и ASF создают видеофайлы Windows Media. MPG и VOB генерируют потоки программ MPEG-2. GIF создает легкие анимированные изображения с ограниченной частотой и частотой кадров.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Триггер имена террора</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Триггерные типы</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Введите одно название террора на строку. Сопоставление нечувствительно.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.sv.resx
+++ b/Infrastructure/Resources/Strings.sv.resx
@@ -443,4 +443,85 @@ Få en API -nyckel från webbplatsen.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Ukrainare</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Utgångsmapp</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Utgångsförlängning</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Bilinspelning</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Spela in VRChat automatiskt när triggers matchar</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Inspelning av körbar</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Inspelningsargument</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Använd {output} för filvägen och {window} för fönstertiteln.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Fönstertitel</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Målfönster</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Du kan ange en del av fönstertiteln eller processnamnet.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Bildhastighet</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Utgångsformat</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (okomprimerad video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 VIDEO)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (programström)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 VIDEO)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2-programström)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animerad bild)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI skapar förlustfria inspelningar men resulterar i stora filer. MP4, MOV, MKV och FLV använder H.264 för att balansera storlek och kompatibilitet. WMV och ASF producerar Windows Media Video Files. MPG och VOB genererar MPEG-2-programströmmar. GIF producerar lätta animerade bilder med begränsade färger och bildhastighet.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Trigger terrornamn</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Trigger runda typer</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Ange ett terrornamn per rad. Matchning är fallkänslig.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.th.resx
+++ b/Infrastructure/Resources/Strings.th.resx
@@ -443,4 +443,85 @@
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>ชาวยูเครน</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>โฟลเดอร์เอาต์พุต</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>นามสกุลไฟล์เอาต์พุต</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>การตั้งค่าการบันทึกอัตโนมัติ</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>บันทึก VRChat โดยอัตโนมัติเมื่อเงื่อนไขทริกเกอร์ตรงกัน</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>ไฟล์ปฏิบัติการสำหรับบันทึก</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>อาร์กิวเมนต์คำสั่งสำหรับการบันทึก</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>ใช้ {output} สำหรับเส้นทางไฟล์ และ {window} สำหรับชื่อหน้าต่าง</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>ชื่อหน้าต่าง</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>หน้าต่างเป้าหมาย</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>สามารถระบุส่วนหนึ่งของชื่อหน้าต่างหรือชื่อโพรเซสได้</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>อัตราเฟรมของการบันทึก</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>รูปแบบเอาต์พุต</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (วิดีโอไม่บีบอัด)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (วิดีโอ H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (วิดีโอ H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (วิดีโอ Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (สตรีมของโปรแกรม)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (วิดีโอ H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (วิดีโอ H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (คอนเทนเนอร์ Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (สตรีมของโปรแกรม MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (ภาพเคลื่อนไหว)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI สร้างไฟล์ที่ไม่สูญเสียคุณภาพแต่มีขนาดใหญ่ MP4, MOV, MKV และ FLV ใช้ H.264 เพื่อรักษาสมดุลระหว่างขนาดไฟล์และความเข้ากันได้ WMV และ ASF สร้างไฟล์วิดีโอแบบ Windows Media MPG และ VOB สร้างสตรีมของโปรแกรมแบบ MPEG-2 GIF สร้างภาพเคลื่อนไหวขนาดเล็กที่มีจำนวนสีและอัตราเฟรมจำกัด</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>ชื่อเทอร์เรอร์สำหรับเริ่มการบันทึก</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>ประเภทของรอบที่จะเริ่มบันทึก</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>ใส่ชื่อเทอร์เรอร์หนึ่งรายการต่อบรรทัด โดยไม่แยกแยะตัวพิมพ์เล็กใหญ่</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.tr.resx
+++ b/Infrastructure/Resources/Strings.tr.resx
@@ -443,4 +443,85 @@ Lütfen web sitesinden bir API anahtarı alın.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Ukrayna</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Çıktı klasörü</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Çıktı Uzatma</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Otomatik Kayıt</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Tetikleyiciler eşleştiğinde VRChat'i otomatik olarak kaydedin</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Kayıt yürütülebilir</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Kayıt argümanları</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Dosya yolu için {output} ve pencere başlığı için {window} kullanın.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Pencere başlığı</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Hedef pencere</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Pencere başlığının veya işlem adının bir kısmını belirleyebilirsiniz.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Kare oranı</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Çıktı biçimi</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (sıkıştırılmamış video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Windows Media Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (program akışı)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (H.264 Video)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (Windows Media Container)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (MPEG-2 program akışı)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (animasyonlu resim)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI kayıpsız kayıtlar oluşturur, ancak büyük dosyalarla sonuçlanır. MP4, MOV, MKV ve FLV, boyutu ve uyumluluğu dengelemek için H.264 kullanır. WMV ve ASF, Windows Media Video dosyaları üretir. MPG ve VOB MPEG-2 program akışları oluşturur. GIF, sınırlı renklere ve kare hızına sahip hafif animasyonlu görüntüler üretir.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Terör isimlerini tetikle</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Tetikleme Yuvarlak Türleri</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Satır başına bir terör adı girin. Eşleme, vaka duyarsızdır.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.uk.resx
+++ b/Infrastructure/Resources/Strings.uk.resx
@@ -443,4 +443,85 @@
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Український</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Папка виведення</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Розширення файлу виводу</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Налаштування автозапису</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Автоматично записувати VRChat, коли умови тригерів виконано</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Виконуваний файл запису</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Параметри запуску запису</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Використовуйте {output} для шляху до файлу та {window} для заголовка вікна.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Заголовок вікна</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Цільове вікно</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Можна вказати частину заголовка вікна або назви процесу.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Частота кадрів запису</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Формат виводу</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (нестиснене відео)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (відео H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (відео H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (відео Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (потік програми)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (відео H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (відео H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (контейнер Windows Media)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (потік програми MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (анімаційне зображення)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI створює без втрат записи, але файли великі. MP4, MOV, MKV і FLV використовують H.264 для балансу розміру та сумісності. WMV і ASF генерують відеофайли Windows Media. MPG і VOB створюють потоки програм MPEG-2. GIF створює легкі анімовані зображення з обмеженою кількістю кольорів та частотою кадрів.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Назви терорів-тригерів</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Типи раундів-тригерів</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Вводьте по одному імені терора в рядок. Порівняння нечутливе до регістру.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.vi.resx
+++ b/Infrastructure/Resources/Strings.vi.resx
@@ -443,4 +443,85 @@ Vui lòng lấy khóa API từ trang web.</value>
   <data name="Language_Ukrainian" xml:space="preserve">
     <value>Ukraine</value>
   </data>
+  <data name="出力フォルダー" xml:space="preserve">
+    <value>Thư mục đầu ra</value>
+  </data>
+  <data name="出力拡張子" xml:space="preserve">
+    <value>Mở rộng đầu ra</value>
+  </data>
+  <data name="自動録画設定" xml:space="preserve">
+    <value>Tự động ghi</value>
+  </data>
+  <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
+    <value>Ghi lại VRChat tự động khi các kích hoạt khớp</value>
+  </data>
+  <data name="録画コマンド" xml:space="preserve">
+    <value>Ghi lại thực thi</value>
+  </data>
+  <data name="録画引数" xml:space="preserve">
+    <value>Ghi lại đối số</value>
+  </data>
+  <data name="録画引数の説明" xml:space="preserve">
+    <value>Sử dụng {output} cho đường dẫn tệp và {window} cho tiêu đề cửa sổ.</value>
+  </data>
+  <data name="ウィンドウタイトル" xml:space="preserve">
+    <value>Tiêu đề cửa sổ</value>
+  </data>
+  <data name="録画対象ウィンドウ" xml:space="preserve">
+    <value>Cửa sổ mục tiêu</value>
+  </data>
+  <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
+    <value>Bạn có thể chỉ định một phần của tiêu đề cửa sổ hoặc tên quy trình.</value>
+  </data>
+  <data name="録画フレームレート" xml:space="preserve">
+    <value>Tốc độ khung hình</value>
+  </data>
+  <data name="fps" xml:space="preserve">
+    <value>fps</value>
+  </data>
+  <data name="AutoRecording_FormatLabel" xml:space="preserve">
+    <value>Định dạng đầu ra</value>
+  </data>
+  <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
+    <value>AVI (video không nén)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
+    <value>MP4 (Video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
+    <value>MOV (Video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
+    <value>WMV (Video phương tiện Windows)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
+    <value>MPEG-2 (luồng chương trình)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
+    <value>MKV (video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
+    <value>FLV (Video H.264)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
+    <value>ASF (hộp chứa phương tiện Windows)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
+    <value>VOB (luồng chương trình MPEG-2)</value>
+  </data>
+  <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
+    <value>GIF (hình ảnh hoạt hình)</value>
+  </data>
+  <data name="AutoRecording_FormatHelp" xml:space="preserve">
+    <value>AVI tạo ra các bản ghi lossless nhưng dẫn đến các tệp lớn. MP4, MOV, MKV và FLV sử dụng H.264 để cân bằng kích thước và khả năng tương thích. WMV và ASF tạo ra các tệp video Windows Media. MPG và VOB tạo ra các luồng chương trình MPEG-2. GIF tạo ra hình ảnh hoạt hình nhẹ với màu sắc và tốc độ khung hình hạn chế.</value>
+  </data>
+  <data name="録画開始テラー" xml:space="preserve">
+    <value>Kích hoạt tên khủng bố</value>
+  </data>
+  <data name="録画開始ラウンド" xml:space="preserve">
+    <value>Kích hoạt các loại tròn</value>
+  </data>
+  <data name="複数テラーの入力説明" xml:space="preserve">
+    <value>Nhập một tên khủng bố trên mỗi dòng. Phù hợp là trường hợp không nhạy cảm.</value>
+  </data>
 </root>

--- a/Infrastructure/Resources/Strings.zh-Hant.resx
+++ b/Infrastructure/Resources/Strings.zh-Hant.resx
@@ -13,69 +13,69 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="APIキー:" xml:space="preserve">
-    <value>API 密钥：</value>
+    <value>API 密鑰：</value>
   </data>
   <data name="APIキーは32文字以上である必要があります。" xml:space="preserve">
-    <value>API 密钥长度必须至少为 32 个字符。</value>
+    <value>API 密鑰長度必須至少爲 32 個字符。</value>
   </data>
   <data name="Connected" xml:space="preserve">
-    <value>已连接</value>
+    <value>已連接</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
-    <value>已断开</value>
+    <value>已斷開</value>
   </data>
   <data name="Discord通知設定" xml:space="preserve">
-    <value>Discord 通知设置</value>
+    <value>Discord 通知設置</value>
   </data>
   <data name="InfoPanel_Damage" xml:space="preserve">
-    <value>伤害：</value>
+    <value>傷害：</value>
   </data>
   <data name="InfoPanel_Item" xml:space="preserve">
     <value>道具：</value>
   </data>
   <data name="InfoPanel_Map" xml:space="preserve">
-    <value>地图：</value>
+    <value>地圖：</value>
   </data>
   <data name="InfoPanel_RoundType" xml:space="preserve">
-    <value>回合类型：</value>
+    <value>回合類型：</value>
   </data>
   <data name="InfoPanel_Terror" xml:space="preserve">
-    <value>恐惧：</value>
+    <value>恐懼：</value>
   </data>
   <data name="Language_ChineseSimplified" xml:space="preserve">
-    <value>简体中文</value>
+    <value>簡體中文</value>
   </data>
   <data name="Language_English" xml:space="preserve">
-    <value>英语</value>
+    <value>英語</value>
   </data>
   <data name="Language_Japanese" xml:space="preserve">
-    <value>日语</value>
+    <value>日語</value>
   </data>
   <data name="Language_Korean" xml:space="preserve">
-    <value>韩语</value>
+    <value>韓語</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>确定</value>
+    <value>確定</value>
   </data>
   <data name="OSC接続ポート:" xml:space="preserve">
     <value>OSC 端口：</value>
   </data>
   <data name="OSC設定" xml:space="preserve">
-    <value>OSC 设置</value>
+    <value>OSC 設置</value>
   </data>
   <data name="ParseError" xml:space="preserve">
-    <value>解析错误</value>
+    <value>解析錯誤</value>
   </data>
   <data name="ToNRoundCounter-Cloudの設定" xml:space="preserve">
-    <value>ToNRoundCounter-Cloud 设置</value>
+    <value>ToNRoundCounter-Cloud 設置</value>
   </data>
   <data name="ToNRoundCounter-Cloudはセーブコードの複数端末間での全自動同期などの機能を持つクラウドサービスです。\n利用にはAPIキーが必要です。\nAPIキーはwebサイトから取得してください。" xml:space="preserve">
-    <value>ToNRoundCounter-Cloud 是一项可在多台设备间自动同步存档代码的云服务。
-需要提供 API 密钥。
-请从网站获取 API 密钥。</value>
+    <value>ToNRoundCounter-Cloud 是一項可在多臺設備間自動同步存檔代碼的雲服務。
+需要提供 API 密鑰。
+請從網站獲取 API 密鑰。</value>
   </data>
   <data name="ToNRoundCounter-Cloudを開く" xml:space="preserve">
-    <value>打开 ToNRoundCounter-Cloud</value>
+    <value>打開 ToNRoundCounter-Cloud</value>
   </data>
   <data name="ToNRoundCouter" xml:space="preserve">
     <value>ToNRoundCounter</value>
@@ -87,163 +87,163 @@
     <value>Webhook URL：</value>
   </data>
   <data name="アイテムサウンドを優先する" xml:space="preserve">
-    <value>物品音效优先</value>
+    <value>物品音效優先</value>
   </data>
   <data name="アイテム音楽ギミック" xml:space="preserve">
-    <value>物品音乐机关</value>
+    <value>物品音樂機關</value>
   </data>
   <data name="アンバウンドのテラー内容を表示" xml:space="preserve">
-    <value>显示无拘束恐惧详情</value>
+    <value>顯示無拘束恐懼詳情</value>
   </data>
   <data name="インポート" xml:space="preserve">
-    <value>导入</value>
+    <value>導入</value>
   </data>
   <data name="ウィンドウ" xml:space="preserve">
     <value>窗口</value>
   </data>
   <data name="エクスポート" xml:space="preserve">
-    <value>导出</value>
+    <value>導出</value>
   </data>
   <data name="エラー" xml:space="preserve">
-    <value>错误</value>
+    <value>錯誤</value>
   </data>
   <data name="オーバーレイ設定" xml:space="preserve">
-    <value>叠加层设置</value>
+    <value>疊加層設置</value>
   </data>
   <data name="キャンセル" xml:space="preserve">
     <value>取消</value>
   </data>
   <data name="ショートカットを表示" xml:space="preserve">
-    <value>显示快捷键</value>
+    <value>顯示快捷鍵</value>
   </data>
   <data name="ダメージを表示" xml:space="preserve">
-    <value>显示伤害</value>
+    <value>顯示傷害</value>
   </data>
   <data name="テラー" xml:space="preserve">
-    <value>恐惧</value>
+    <value>恐懼</value>
   </data>
   <data name="テラーの名前の色固定:" xml:space="preserve">
-    <value>固定恐惧名称颜色：</value>
+    <value>固定恐懼名稱顏色：</value>
   </data>
   <data name="テラーを表示" xml:space="preserve">
-    <value>显示恐惧</value>
+    <value>顯示恐懼</value>
   </data>
   <data name="テラー名" xml:space="preserve">
-    <value>恐惧名称</value>
+    <value>恐懼名稱</value>
   </data>
   <data name="テラー詳細情報を表示" xml:space="preserve">
-    <value>显示恐惧详细信息</value>
+    <value>顯示恐懼詳細信息</value>
   </data>
   <data name="テーマ" xml:space="preserve">
-    <value>主题</value>
+    <value>主題</value>
   </data>
   <data name="デバッグ情報表示" xml:space="preserve">
-    <value>显示调试信息</value>
+    <value>顯示調試信息</value>
   </data>
   <data name="ファイル" xml:space="preserve">
     <value>文件</value>
   </data>
   <data name="フィルター設定" xml:space="preserve">
-    <value>筛选设置</value>
+    <value>篩選設置</value>
   </data>
   <data name="プリセット:" xml:space="preserve">
-    <value>预设：</value>
+    <value>預設：</value>
   </data>
   <data name="プリセットをインポートしました。" xml:space="preserve">
-    <value>已导入预设。</value>
+    <value>已導入預設。</value>
   </data>
   <data name="プリセットをエクスポートしました。" xml:space="preserve">
-    <value>已导出预设。</value>
+    <value>已導出預設。</value>
   </data>
   <data name="プリセットを保存しました。" xml:space="preserve">
-    <value>已保存预设。</value>
+    <value>已保存預設。</value>
   </data>
   <data name="ラウンド/テラーBGM設定" xml:space="preserve">
-    <value>回合/恐惧 BGM 设置</value>
+    <value>回合/恐懼 BGM 設置</value>
   </data>
   <data name="ラウンド/テラーごとのBGMを再生する" xml:space="preserve">
-    <value>按回合/恐惧播放 BGM</value>
+    <value>按回合/恐懼播放 BGM</value>
   </data>
   <data name="ラウンドBGMを優先する" xml:space="preserve">
-    <value>回合 BGM 优先</value>
+    <value>回合 BGM 優先</value>
   </data>
   <data name="ラウンドタイプ" xml:space="preserve">
-    <value>回合类型</value>
+    <value>回合類型</value>
   </data>
   <data name="ラウンドタイプごとの統計表示設定:" xml:space="preserve">
-    <value>回合类型统计显示设置：</value>
+    <value>回合類型統計顯示設置：</value>
   </data>
   <data name="ラウンドタイプ推移を表示" xml:space="preserve">
-    <value>显示回合类型变化</value>
+    <value>顯示回合類型變化</value>
   </data>
   <data name="ラウンドログ" xml:space="preserve">
-    <value>回合日志</value>
+    <value>回合日誌</value>
   </data>
   <data name="ラウンドログを表示する" xml:space="preserve">
-    <value>显示回合日志</value>
+    <value>顯示回合日誌</value>
   </data>
   <data name="ラウンドログ背景色:" xml:space="preserve">
-    <value>回合日志背景色：</value>
+    <value>回合日誌背景色：</value>
   </data>
   <data name="ラウンド名" xml:space="preserve">
-    <value>回合名称</value>
+    <value>回合名稱</value>
   </data>
   <data name="ラウンド状況を表示" xml:space="preserve">
-    <value>显示回合状态</value>
+    <value>顯示回合狀態</value>
   </data>
   <data name="ラウンド結果をDiscordに送信するWebhook URLを設定します。空欄で無効化されます。" xml:space="preserve">
-    <value>设置将回合结果发送到 Discord 的 Webhook URL。留空则禁用。</value>
+    <value>設置將回合結果發送到 Discord 的 Webhook URL。留空則禁用。</value>
   </data>
   <data name="ラウンド統計を表示" xml:space="preserve">
-    <value>显示回合统计</value>
+    <value>顯示回合統計</value>
   </data>
   <data name="両方とも再生する" xml:space="preserve">
-    <value>同时播放</value>
+    <value>同時播放</value>
   </data>
   <data name="保存" xml:space="preserve">
     <value>保存</value>
   </data>
   <data name="再生する音声" xml:space="preserve">
-    <value>要播放的音频</value>
+    <value>要播放的音頻</value>
   </data>
   <data name="出現回数" xml:space="preserve">
-    <value>出现次数</value>
+    <value>出現次數</value>
   </data>
   <data name="削除" xml:space="preserve">
-    <value>删除</value>
+    <value>刪除</value>
   </data>
   <data name="参照..." xml:space="preserve">
-    <value>浏览...</value>
+    <value>瀏覽...</value>
   </data>
   <data name="固定する" xml:space="preserve">
-    <value>置顶</value>
+    <value>置頂</value>
   </data>
   <data name="固定解除" xml:space="preserve">
-    <value>取消置顶</value>
+    <value>取消置頂</value>
   </data>
   <data name="外部アプリを自動起動する" xml:space="preserve">
-    <value>自动启动外部应用程序</value>
+    <value>自動啓動外部應用程序</value>
   </data>
   <data name="実行ファイル" xml:space="preserve">
-    <value>可执行文件</value>
+    <value>可執行文件</value>
   </data>
   <data name="対象アイテム名" xml:space="preserve">
-    <value>目标物品名称</value>
+    <value>目標物品名稱</value>
   </data>
   <data name="履歴表示数:" xml:space="preserve">
-    <value>历史显示数量：</value>
+    <value>歷史顯示數量：</value>
   </data>
   <data name="引数" xml:space="preserve">
-    <value>参数</value>
+    <value>參數</value>
   </data>
   <data name="情報" xml:space="preserve">
     <value>信息</value>
   </data>
   <data name="情報表示欄背景色:" xml:space="preserve">
-    <value>信息显示区域背景色：</value>
+    <value>信息顯示區域背景色：</value>
   </data>
   <data name="時計を表示" xml:space="preserve">
-    <value>显示时钟</value>
+    <value>顯示時鐘</value>
   </data>
   <data name="曖昧マッチング" xml:space="preserve">
     <value>模糊匹配</value>
@@ -255,103 +255,103 @@
     <value>最小速度</value>
   </data>
   <data name="有効" xml:space="preserve">
-    <value>启用</value>
+    <value>啓用</value>
   </data>
   <data name="構文エラー" xml:space="preserve">
-    <value>语法错误</value>
+    <value>語法錯誤</value>
   </data>
   <data name="次ラウンド予測を表示" xml:space="preserve">
-    <value>显示下回合预测</value>
+    <value>顯示下回合預測</value>
   </data>
   <data name="死亡回数" xml:space="preserve">
-    <value>死亡次数</value>
+    <value>死亡次數</value>
   </data>
   <data name="滞在タイマーを表示" xml:space="preserve">
-    <value>显示停留计时器</value>
+    <value>顯示停留計時器</value>
   </data>
   <data name="特定アイテムで音楽を再生する" xml:space="preserve">
-    <value>针对特定物品播放音乐</value>
+    <value>針對特定物品播放音樂</value>
   </data>
   <data name="現在の設定では自動自殺を行いません" xml:space="preserve">
-    <value>当前设置下不会执行自动自杀。</value>
+    <value>當前設置下不會執行自動自殺。</value>
   </data>
   <data name="生存回数" xml:space="preserve">
-    <value>生存次数</value>
+    <value>生存次數</value>
   </data>
   <data name="生存率" xml:space="preserve">
     <value>生存率</value>
   </data>
   <data name="競合時の優先設定:" xml:space="preserve">
-    <value>冲突时的优先级：</value>
+    <value>衝突時的優先級：</value>
   </data>
   <data name="終了" xml:space="preserve">
     <value>退出</value>
   </data>
   <data name="統計情報を表示する" xml:space="preserve">
-    <value>显示统计信息</value>
+    <value>顯示統計信息</value>
   </data>
   <data name="統計情報表示欄" xml:space="preserve">
-    <value>统计信息区域</value>
+    <value>統計信息區域</value>
   </data>
   <data name="統計表示欄背景色:" xml:space="preserve">
-    <value>统计显示区域背景色：</value>
+    <value>統計顯示區域背景色：</value>
   </data>
   <data name="背景色設定" xml:space="preserve">
-    <value>背景色设置</value>
+    <value>背景色設置</value>
   </data>
   <data name="自動自殺は無効になっています" xml:space="preserve">
-    <value>自动自杀已禁用。</value>
+    <value>自動自殺已禁用。</value>
   </data>
   <data name="自動自殺を有効にする" xml:space="preserve">
-    <value>启用自动自杀</value>
+    <value>啓用自動自殺</value>
   </data>
   <data name="自動自殺モード" xml:space="preserve">
-    <value>自动自杀模式</value>
+    <value>自動自殺模式</value>
   </data>
   <data name="自動自殺対象ラウンド:" xml:space="preserve">
-    <value>自动自杀目标回合：</value>
+    <value>自動自殺目標回合：</value>
   </data>
   <data name="自動起動設定" xml:space="preserve">
-    <value>自动启动设置</value>
+    <value>自動啓動設置</value>
   </data>
   <data name="色選択" xml:space="preserve">
-    <value>选择颜色</value>
+    <value>選擇顏色</value>
   </data>
   <data name="表示設定" xml:space="preserve">
-    <value>显示设置</value>
+    <value>顯示設置</value>
   </data>
   <data name="角度を表示" xml:space="preserve">
-    <value>显示角度</value>
+    <value>顯示角度</value>
   </data>
   <data name="解析できなかった行があります:" xml:space="preserve">
-    <value>存在无法解析的行：</value>
+    <value>存在無法解析的行：</value>
   </data>
   <data name="言語" xml:space="preserve">
-    <value>语言</value>
+    <value>語言</value>
   </data>
   <data name="設定" xml:space="preserve">
-    <value>设置</value>
+    <value>設置</value>
   </data>
   <data name="設定..." xml:space="preserve">
-    <value>设置...</value>
+    <value>設置...</value>
   </data>
   <data name="設定内容" xml:space="preserve">
     <value>配置</value>
   </data>
   <data name="設定内容確認" xml:space="preserve">
-    <value>检查配置</value>
+    <value>檢查配置</value>
   </data>
   <data name="設定変更" xml:space="preserve">
-    <value>更改设置</value>
+    <value>更改設置</value>
   </data>
   <data name="詳細設定を利用する" xml:space="preserve">
-    <value>使用高级设置</value>
+    <value>使用高級設置</value>
   </data>
   <data name="詳細設定ドキュメント" xml:space="preserve">
-    <value>高级设置文档</value>
+    <value>高級設置文檔</value>
   </data>
   <data name="読み込み" xml:space="preserve">
-    <value>加载</value>
+    <value>加載</value>
   </data>
   <data name="警告" xml:space="preserve">
     <value>警告</value>
@@ -360,168 +360,168 @@
     <value>添加</value>
   </data>
   <data name="追加設定" xml:space="preserve">
-    <value>附加设置</value>
+    <value>附加設置</value>
   </data>
   <data name="透明度" xml:space="preserve">
     <value>透明度</value>
   </data>
   <data name="速度を表示" xml:space="preserve">
-    <value>显示速度</value>
+    <value>顯示速度</value>
   </data>
   <data name="Language_Danish" xml:space="preserve">
-    <value>丹麦语</value>
+    <value>丹麥語</value>
   </data>
   <data name="Language_German" xml:space="preserve">
-    <value>德语</value>
+    <value>德語</value>
   </data>
   <data name="Language_EnglishUnitedKingdom" xml:space="preserve">
-    <value>英语（英国）</value>
+    <value>英語（英國）</value>
   </data>
   <data name="Language_EnglishUnitedStates" xml:space="preserve">
-    <value>英语（美国）</value>
+    <value>英語（美國）</value>
   </data>
   <data name="Language_Spanish" xml:space="preserve">
-    <value>西班牙语</value>
+    <value>西班牙語</value>
   </data>
   <data name="Language_SpanishLatinAmerica" xml:space="preserve">
-    <value>西班牙语（拉丁美洲）</value>
+    <value>西班牙語（拉丁美洲）</value>
   </data>
   <data name="Language_French" xml:space="preserve">
-    <value>法语</value>
+    <value>法語</value>
   </data>
   <data name="Language_Croatian" xml:space="preserve">
-    <value>克罗地亚语</value>
+    <value>克羅地亞語</value>
   </data>
   <data name="Language_Italian" xml:space="preserve">
-    <value>意大利语</value>
+    <value>意大利語</value>
   </data>
   <data name="Language_Lithuanian" xml:space="preserve">
-    <value>立陶宛语</value>
+    <value>立陶宛語</value>
   </data>
   <data name="Language_Hungarian" xml:space="preserve">
-    <value>匈牙利语</value>
+    <value>匈牙利語</value>
   </data>
   <data name="Language_Dutch" xml:space="preserve">
-    <value>荷兰语</value>
+    <value>荷蘭語</value>
   </data>
   <data name="Language_Norwegian" xml:space="preserve">
-    <value>挪威语</value>
+    <value>挪威語</value>
   </data>
   <data name="Language_Polish" xml:space="preserve">
-    <value>波兰语</value>
+    <value>波蘭語</value>
   </data>
   <data name="Language_PortugueseBrazil" xml:space="preserve">
-    <value>葡萄牙语（巴西）</value>
+    <value>葡萄牙語（巴西）</value>
   </data>
   <data name="Language_Romanian" xml:space="preserve">
-    <value>罗马尼亚语</value>
+    <value>羅馬尼亞語</value>
   </data>
   <data name="Language_Finnish" xml:space="preserve">
-    <value>芬兰语</value>
+    <value>芬蘭語</value>
   </data>
   <data name="Language_Swedish" xml:space="preserve">
-    <value>瑞典语</value>
+    <value>瑞典語</value>
   </data>
   <data name="Language_Vietnamese" xml:space="preserve">
-    <value>越南语</value>
+    <value>越南語</value>
   </data>
   <data name="Language_Turkish" xml:space="preserve">
-    <value>土耳其语</value>
+    <value>土耳其語</value>
   </data>
   <data name="Language_Thai" xml:space="preserve">
-    <value>泰语</value>
+    <value>泰語</value>
   </data>
   <data name="Language_Greek" xml:space="preserve">
-    <value>希腊语</value>
+    <value>希臘語</value>
   </data>
   <data name="Language_Bulgarian" xml:space="preserve">
-    <value>保加利亚语</value>
+    <value>保加利亞語</value>
   </data>
   <data name="Language_Russian" xml:space="preserve">
-    <value>俄语</value>
+    <value>俄語</value>
   </data>
   <data name="Language_Ukrainian" xml:space="preserve">
-    <value>乌克兰语</value>
+    <value>烏克蘭語</value>
   </data>
   <data name="出力フォルダー" xml:space="preserve">
-    <value>输出文件夹</value>
+    <value>輸出文件夾</value>
   </data>
   <data name="出力拡張子" xml:space="preserve">
-    <value>输出文件扩展名</value>
+    <value>輸出文件擴展名</value>
   </data>
   <data name="自動録画設定" xml:space="preserve">
-    <value>自动录制设置</value>
+    <value>自動錄製設定</value>
   </data>
   <data name="指定条件でVRChatを自動録画する" xml:space="preserve">
-    <value>当触发条件满足时自动录制 VRChat</value>
+    <value>當觸發條件符合時自動錄製 VRChat</value>
   </data>
   <data name="録画コマンド" xml:space="preserve">
-    <value>录制可执行文件</value>
+    <value>錄製執行檔</value>
   </data>
   <data name="録画引数" xml:space="preserve">
-    <value>录制启动参数</value>
+    <value>錄製啟動參數</value>
   </data>
   <data name="録画引数の説明" xml:space="preserve">
-    <value>使用{output}作为文件路径，{window}用于窗口标题。</value>
+    <value>使用 {output} 作為檔案路徑，{window} 作為視窗標題。</value>
   </data>
   <data name="ウィンドウタイトル" xml:space="preserve">
-    <value>窗口标题</value>
+    <value>窗口標題</value>
   </data>
   <data name="録画対象ウィンドウ" xml:space="preserve">
-    <value>目标窗口</value>
+    <value>目標視窗</value>
   </data>
   <data name="ウィンドウ名またはプロセス名の一部を指定できます" xml:space="preserve">
-    <value>您可以指定窗口标题或过程名称的一部分。</value>
+    <value>可以指定視窗標題或程序名稱的一部分。</value>
   </data>
   <data name="録画フレームレート" xml:space="preserve">
-    <value>录制帧率</value>
+    <value>錄製幀率</value>
   </data>
   <data name="fps" xml:space="preserve">
     <value>fps</value>
   </data>
   <data name="AutoRecording_FormatLabel" xml:space="preserve">
-    <value>输出格式</value>
+    <value>輸出格式</value>
   </data>
   <data name="AutoRecording_FormatOption_AVI" xml:space="preserve">
-    <value>AVI（未压缩视频）</value>
+    <value>AVI（未壓縮影片）</value>
   </data>
   <data name="AutoRecording_FormatOption_MP4" xml:space="preserve">
-    <value>MP4（H.264 视频）</value>
+    <value>MP4（H.264 影片）</value>
   </data>
   <data name="AutoRecording_FormatOption_MOV" xml:space="preserve">
-    <value>MOV（H.264 视频）</value>
+    <value>MOV（H.264 影片）</value>
   </data>
   <data name="AutoRecording_FormatOption_WMV" xml:space="preserve">
-    <value>WMV（Windows Media 视频）</value>
+    <value>WMV（Windows Media 影片）</value>
   </data>
   <data name="AutoRecording_FormatOption_MPG" xml:space="preserve">
-    <value>MPEG-2（程序流）</value>
+    <value>MPEG-2（節目串流）</value>
   </data>
   <data name="AutoRecording_FormatOption_MKV" xml:space="preserve">
-    <value>MKV（H.264 视频）</value>
+    <value>MKV（H.264 影片）</value>
   </data>
   <data name="AutoRecording_FormatOption_FLV" xml:space="preserve">
-    <value>FLV（H.264 视频）</value>
+    <value>FLV（H.264 影片）</value>
   </data>
   <data name="AutoRecording_FormatOption_ASF" xml:space="preserve">
     <value>ASF（Windows Media 容器）</value>
   </data>
   <data name="AutoRecording_FormatOption_VOB" xml:space="preserve">
-    <value>VOB（MPEG-2 程序流）</value>
+    <value>VOB（MPEG-2 節目串流）</value>
   </data>
   <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
-    <value>GIF（动画图像）</value>
+    <value>GIF（動畫圖像）</value>
   </data>
   <data name="AutoRecording_FormatHelp" xml:space="preserve">
-    <value>AVI 会生成无损录制，但文件较大。MP4、MOV、MKV 和 FLV 使用 H.264 在文件大小与兼容性之间取得平衡。WMV 和 ASF 会生成 Windows Media 视频文件。MPG 和 VOB 会生成 MPEG-2 程序流。GIF 会生成色彩数量和帧率受限的轻量动画图像。</value>
+    <value>AVI 會產生無失真錄製，但檔案較大。MP4、MOV、MKV 與 FLV 使用 H.264 以在檔案大小與相容性之間取得平衡。WMV 與 ASF 會產生 Windows Media 影片檔。MPG 與 VOB 會建立 MPEG-2 節目串流。GIF 會建立色彩數量與幀率受限的輕量動畫影像。</value>
   </data>
   <data name="録画開始テラー" xml:space="preserve">
-    <value>触发录制的恐怖名称</value>
+    <value>觸發錄製的恐怖名稱</value>
   </data>
   <data name="録画開始ラウンド" xml:space="preserve">
-    <value>触发录制的回合类型</value>
+    <value>觸發錄製的回合類型</value>
   </data>
   <data name="複数テラーの入力説明" xml:space="preserve">
-    <value>每行输入一个恐怖名称，比较时不区分大小写。</value>
+    <value>每行輸入一個恐怖名稱，比對時不區分大小寫。</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- translate the auto recording UI strings across the existing locale resource files instead of leaving English fallbacks
- add dedicated Hindi and Traditional Chinese resource files so the new strings show up in those languages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3b8fec8308329961c14dc7a875892