### PR TITLE
Remove external recording command options from settings

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -661,9 +661,7 @@ namespace ToNRoundCounter.UI
                     _settings.AutoLaunchEntries = settingsForm.SettingsPanel.GetAutoLaunchEntries();
                     _settings.AutoRecordingEnabled = settingsForm.SettingsPanel.AutoRecordingEnabledCheckBox.Checked;
                     _settings.AutoRecordingWindowTitle = settingsForm.SettingsPanel.AutoRecordingWindowTitleTextBox.Text?.Trim() ?? string.Empty;
-                    _settings.AutoRecordingCommand = settingsForm.SettingsPanel.AutoRecordingCommandTextBox.Text?.Trim() ?? string.Empty;
                     _settings.AutoRecordingFrameRate = (int)settingsForm.SettingsPanel.AutoRecordingFrameRateNumeric.Value;
-                    _settings.AutoRecordingArguments = settingsForm.SettingsPanel.AutoRecordingArgumentsTextBox.Text?.Trim() ?? string.Empty;
                     _settings.AutoRecordingOutputDirectory = settingsForm.SettingsPanel.AutoRecordingOutputDirectoryTextBox.Text?.Trim() ?? string.Empty;
                     _settings.AutoRecordingOutputExtension = settingsForm.SettingsPanel.GetAutoRecordingOutputExtension();
                     _settings.AutoRecordingRoundTypes = settingsForm.SettingsPanel.GetAutoRecordingRoundTypes();

--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -114,15 +114,12 @@ namespace ToNRoundCounter.UI
         public TextBox DiscordWebhookUrlTextBox { get; private set; } = null!;
         public CheckBox AutoRecordingEnabledCheckBox { get; private set; } = null!;
         public TextBox AutoRecordingWindowTitleTextBox { get; private set; } = null!;
-        public TextBox AutoRecordingCommandTextBox { get; private set; } = null!;
-        public TextBox AutoRecordingArgumentsTextBox { get; private set; } = null!;
         public NumericUpDown AutoRecordingFrameRateNumeric { get; private set; } = null!;
         public TextBox AutoRecordingOutputDirectoryTextBox { get; private set; } = null!;
         public ComboBox AutoRecordingFormatComboBox { get; private set; } = null!;
         public CheckedListBox AutoRecordingRoundTypesListBox { get; private set; } = null!;
         public TextBox AutoRecordingTerrorNamesTextBox { get; private set; } = null!;
         private Button autoRecordingBrowseOutputButton = null!;
-        private Button autoRecordingBrowseCommandButton = null!;
         private Button roundLogExportButton = null!;
 
         private const string AutoLaunchEnabledColumnName = "AutoLaunchEnabled";
@@ -1047,52 +1044,6 @@ namespace ToNRoundCounter.UI
 
             autoRecordingInnerY = AutoRecordingFrameRateNumeric.Bottom + 10;
 
-            Label autoRecordingCommandLabel = new Label();
-            autoRecordingCommandLabel.Text = LanguageManager.Translate("録画コマンド");
-            autoRecordingCommandLabel.AutoSize = true;
-            autoRecordingCommandLabel.Location = new Point(innerMargin, autoRecordingInnerY);
-            grpAutoRecording.Controls.Add(autoRecordingCommandLabel);
-
-            AutoRecordingCommandTextBox = new TextBox();
-            AutoRecordingCommandTextBox.Location = new Point(innerMargin, autoRecordingCommandLabel.Bottom + 4);
-            AutoRecordingCommandTextBox.Width = columnWidth - innerMargin * 3 - 90;
-            grpAutoRecording.Controls.Add(AutoRecordingCommandTextBox);
-
-            autoRecordingBrowseCommandButton = new Button();
-            autoRecordingBrowseCommandButton.Text = LanguageManager.Translate("参照...");
-            autoRecordingBrowseCommandButton.AutoSize = true;
-            autoRecordingBrowseCommandButton.Location = new Point(AutoRecordingCommandTextBox.Right + 10, AutoRecordingCommandTextBox.Top - 2);
-            autoRecordingBrowseCommandButton.Click += (s, e) =>
-            {
-                BrowseForAutoRecordingExecutable();
-                RefreshAutoRecordingControlsState();
-            };
-            grpAutoRecording.Controls.Add(autoRecordingBrowseCommandButton);
-
-            autoRecordingInnerY = AutoRecordingCommandTextBox.Bottom + 8;
-
-            Label autoRecordingArgumentsLabel = new Label();
-            autoRecordingArgumentsLabel.Text = LanguageManager.Translate("録画引数");
-            autoRecordingArgumentsLabel.AutoSize = true;
-            autoRecordingArgumentsLabel.Location = new Point(innerMargin, autoRecordingInnerY);
-            grpAutoRecording.Controls.Add(autoRecordingArgumentsLabel);
-
-            AutoRecordingArgumentsTextBox = new TextBox();
-            AutoRecordingArgumentsTextBox.Location = new Point(innerMargin, autoRecordingArgumentsLabel.Bottom + 4);
-            AutoRecordingArgumentsTextBox.Width = columnWidth - innerMargin * 2;
-            grpAutoRecording.Controls.Add(AutoRecordingArgumentsTextBox);
-
-            autoRecordingInnerY = AutoRecordingArgumentsTextBox.Bottom + 4;
-
-            Label autoRecordingArgumentsHelpLabel = new Label();
-            autoRecordingArgumentsHelpLabel.Text = LanguageManager.Translate("録画引数の説明");
-            autoRecordingArgumentsHelpLabel.AutoSize = true;
-            autoRecordingArgumentsHelpLabel.MaximumSize = new Size(columnWidth - innerMargin * 2, 0);
-            autoRecordingArgumentsHelpLabel.Location = new Point(innerMargin, autoRecordingInnerY);
-            grpAutoRecording.Controls.Add(autoRecordingArgumentsHelpLabel);
-
-            autoRecordingInnerY = autoRecordingArgumentsHelpLabel.Bottom + 8;
-
             Label autoRecordingOutputLabel = new Label();
             autoRecordingOutputLabel.Text = LanguageManager.Translate("出力フォルダー");
             autoRecordingOutputLabel.AutoSize = true;
@@ -1179,9 +1130,7 @@ namespace ToNRoundCounter.UI
 
             AutoRecordingEnabledCheckBox.CheckedChanged += (s, e) => RefreshAutoRecordingControlsState();
             AutoRecordingWindowTitleTextBox.Text = _settings.AutoRecordingWindowTitle;
-            AutoRecordingCommandTextBox.Text = _settings.AutoRecordingCommand ?? string.Empty;
             AutoRecordingFrameRateNumeric.Value = Math.Min(Math.Max(_settings.AutoRecordingFrameRate, 5), 60);
-            AutoRecordingArgumentsTextBox.Text = _settings.AutoRecordingArguments ?? string.Empty;
             AutoRecordingOutputDirectoryTextBox.Text = _settings.AutoRecordingOutputDirectory;
             AutoRecordingEnabledCheckBox.Checked = _settings.AutoRecordingEnabled;
             SetAutoRecordingFormat(_settings.AutoRecordingOutputExtension);
@@ -2558,29 +2507,6 @@ namespace ToNRoundCounter.UI
             }
         }
 
-        private void BrowseForAutoRecordingExecutable()
-        {
-            if (AutoRecordingCommandTextBox == null)
-            {
-                return;
-            }
-
-            using (OpenFileDialog dialog = new OpenFileDialog())
-            {
-                dialog.Filter = "実行ファイル|*.exe;*.bat;*.cmd;*.com|すべてのファイル|*.*";
-                string current = AutoRecordingCommandTextBox.Text ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(current))
-                {
-                    dialog.FileName = current;
-                }
-
-                if (dialog.ShowDialog() == DialogResult.OK)
-                {
-                    AutoRecordingCommandTextBox.Text = dialog.FileName;
-                }
-            }
-        }
-
         private void BrowseForAutoRecordingOutputDirectory()
         {
             if (AutoRecordingOutputDirectoryTextBox == null)
@@ -2635,17 +2561,9 @@ namespace ToNRoundCounter.UI
             {
                 AutoRecordingWindowTitleTextBox.Enabled = enabled;
             }
-            if (AutoRecordingCommandTextBox != null)
-            {
-                AutoRecordingCommandTextBox.Enabled = enabled;
-            }
             if (AutoRecordingFrameRateNumeric != null)
             {
                 AutoRecordingFrameRateNumeric.Enabled = enabled;
-            }
-            if (AutoRecordingArgumentsTextBox != null)
-            {
-                AutoRecordingArgumentsTextBox.Enabled = enabled;
             }
             if (AutoRecordingOutputDirectoryTextBox != null)
             {
@@ -2658,10 +2576,6 @@ namespace ToNRoundCounter.UI
             if (autoRecordingBrowseOutputButton != null)
             {
                 autoRecordingBrowseOutputButton.Enabled = enabled;
-            }
-            if (autoRecordingBrowseCommandButton != null)
-            {
-                autoRecordingBrowseCommandButton.Enabled = enabled;
             }
             if (AutoRecordingRoundTypesListBox != null)
             {


### PR DESCRIPTION
## Summary
- remove the auto recording command and argument inputs from the settings panel UI
- stop persisting those fields when saving settings from the form

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e3c39389f88329ab4fa84b7984b2e9