### PR TITLE
Prefer NVENC adapters for Media Foundation encoding and add overlay capture toggle

### DIFF
--- a/Application/AutoRecordingService.cs
+++ b/Application/AutoRecordingService.cs
@@ -121,7 +121,9 @@ namespace ToNRoundCounter.Application
                 ? "VRChat"
                 : _settings.AutoRecordingWindowTitle.Trim();
 
-            if (!InternalScreenRecorder.TryCreate(windowHint, frameRate, outputPath, extension, out var recorder, out var error))
+            bool includeOverlay = _settings.AutoRecordingIncludeOverlay;
+
+            if (!InternalScreenRecorder.TryCreate(windowHint, frameRate, outputPath, extension, includeOverlay, out var recorder, out var error))
             {
                 _logger.LogEvent("AutoRecording", () => $"Failed to start built-in recorder: {error}", Serilog.Events.LogEventLevel.Error);
                 return;
@@ -130,7 +132,8 @@ namespace ToNRoundCounter.Application
             _recorder = recorder;
             _currentTriggerDescription = triggerDetails;
             recorder.Completion.ContinueWith(_ => HandleRecorderCompleted(recorder), TaskScheduler.Default);
-            _logger.LogEvent("AutoRecording", () => $"Recording started. Output: {outputPath}. Trigger: {triggerDetails}");
+            string encoderDescription = recorder.IsHardwareAccelerated ? "hardware-accelerated" : "software";
+            _logger.LogEvent("AutoRecording", () => $"Recording started. Output: {outputPath}. Trigger: {triggerDetails}. Encoder: {encoderDescription}.");
         }
 
         private void HandleRecorderCompleted(InternalScreenRecorder recorder)
@@ -430,6 +433,7 @@ namespace ToNRoundCounter.Application
             private readonly IntPtr _windowHandle;
             private readonly Rectangle _bounds;
             private readonly int _frameRate;
+            private readonly bool _includeOverlay;
             private readonly IFrameWriter _writer;
             private readonly CancellationTokenSource _cts;
             private readonly Task _captureTask;
@@ -439,14 +443,17 @@ namespace ToNRoundCounter.Application
             private bool _hasError;
             private bool _stopRequested;
             private bool _disposed;
+            private readonly bool _isHardwareAccelerated;
 
-            private InternalScreenRecorder(IntPtr windowHandle, Rectangle bounds, int frameRate, IFrameWriter writer)
+            private InternalScreenRecorder(IntPtr windowHandle, Rectangle bounds, int frameRate, bool includeOverlay, IFrameWriter writer)
             {
                 _windowHandle = windowHandle;
                 _bounds = bounds;
                 _frameRate = frameRate;
+                _includeOverlay = includeOverlay;
                 _cts = new CancellationTokenSource();
                 _writer = writer;
+                _isHardwareAccelerated = writer.IsHardwareAccelerated;
                 _captureTask = Task.Run(() => CaptureLoopAsync(_cts.Token));
             }
 
@@ -485,7 +492,9 @@ namespace ToNRoundCounter.Application
                 }
             }
 
-            public static bool TryCreate(string windowHint, int frameRate, string outputPath, string extension, out InternalScreenRecorder? recorder, out string? failureReason)
+            public bool IsHardwareAccelerated => _isHardwareAccelerated;
+
+            public static bool TryCreate(string windowHint, int frameRate, string outputPath, string extension, bool includeOverlay, out InternalScreenRecorder? recorder, out string? failureReason)
             {
                 recorder = null;
                 failureReason = null;
@@ -519,7 +528,7 @@ namespace ToNRoundCounter.Application
                 try
                 {
                     writer = CreateWriter(extension, outputPath, bounds.Width, bounds.Height, frameRate);
-                    recorder = new InternalScreenRecorder(handle, bounds, frameRate, writer);
+                    recorder = new InternalScreenRecorder(handle, bounds, frameRate, includeOverlay, writer);
                     return true;
                 }
                 catch (Exception ex)
@@ -577,41 +586,54 @@ namespace ToNRoundCounter.Application
             {
                 var frameInterval = TimeSpan.FromSeconds(1d / Math.Max(1, _frameRate));
                 var nextFrame = DateTime.UtcNow;
-                var size = _bounds.Size;
-                using var bitmap = new Bitmap(size.Width, size.Height, PixelFormat.Format32bppArgb);
+                var targetSize = _bounds.Size;
+                using var outputFrame = new Bitmap(targetSize.Width, targetSize.Height, PixelFormat.Format32bppArgb);
+                Bitmap? captureFrame = null;
 
-                while (!token.IsCancellationRequested)
+                try
                 {
+                    while (!token.IsCancellationRequested)
+                    {
                     if (!IsWindow(_windowHandle))
                     {
                         SetStopReason("Target window is no longer available.", true);
                         break;
                     }
 
-                    if (!GetWindowRect(_windowHandle, out var rect))
+                    if (!TryGetWindowBounds(_windowHandle, out var rect))
                     {
                         SetStopReason("Failed to retrieve window bounds.", true);
                         break;
                     }
 
-                    int width = rect.Right - rect.Left;
-                    int height = rect.Bottom - rect.Top;
-                    if (width != size.Width || height != size.Height)
+                    int width = Math.Max(1, rect.Right - rect.Left);
+                    int height = Math.Max(1, rect.Bottom - rect.Top);
+
+                    if (captureFrame == null || captureFrame.Width != width || captureFrame.Height != height)
                     {
-                        SetStopReason("Target window size changed during recording.", true);
-                        break;
+                        captureFrame?.Dispose();
+                        captureFrame = new Bitmap(width, height, PixelFormat.Format32bppArgb);
                     }
 
-                    var origin = new System.Drawing.Point(rect.Left, rect.Top);
+                    bool captured = TryCaptureWindow(_windowHandle, rect, captureFrame, _includeOverlay);
 
                     try
                     {
-                        using (var graphics = Graphics.FromImage(bitmap))
+                        using (var graphics = Graphics.FromImage(outputFrame))
                         {
-                            graphics.CopyFromScreen(origin, System.Drawing.Point.Empty, size, CopyPixelOperation.SourceCopy);
+                            graphics.Clear(Color.Black);
+                            graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+                            graphics.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.HighQuality;
+                            graphics.CompositingQuality = System.Drawing.Drawing2D.CompositingQuality.HighQuality;
+
+                            if (captured)
+                            {
+                                graphics.DrawImage(captureFrame, new Rectangle(System.Drawing.Point.Empty, targetSize),
+                                    new Rectangle(System.Drawing.Point.Empty, captureFrame.Size), GraphicsUnit.Pixel);
+                            }
                         }
 
-                        _writer.WriteFrame(bitmap);
+                        _writer.WriteFrame(outputFrame);
                     }
                     catch (Exception ex)
                     {
@@ -619,28 +641,33 @@ namespace ToNRoundCounter.Application
                         break;
                     }
 
-                    nextFrame += frameInterval;
-                    var delay = nextFrame - DateTime.UtcNow;
-                    if (delay > TimeSpan.Zero)
-                    {
-                        try
+                        nextFrame += frameInterval;
+                        var delay = nextFrame - DateTime.UtcNow;
+                        if (delay > TimeSpan.Zero)
                         {
-                            await Task.Delay(delay, token).ConfigureAwait(false);
+                            try
+                            {
+                                await Task.Delay(delay, token).ConfigureAwait(false);
+                            }
+                            catch (TaskCanceledException) when (token.IsCancellationRequested)
+                            {
+                                break;
+                            }
                         }
-                        catch (TaskCanceledException) when (token.IsCancellationRequested)
+                        else
                         {
-                            break;
+                            nextFrame = DateTime.UtcNow;
                         }
                     }
-                    else
+
+                    if (!_stopReasonSet)
                     {
-                        nextFrame = DateTime.UtcNow;
+                        SetStopReason("Recording completed", false);
                     }
                 }
-
-                if (!_stopReasonSet)
+                finally
                 {
-                    SetStopReason("Recording completed", false);
+                    captureFrame?.Dispose();
                 }
             }
 
@@ -693,66 +720,336 @@ namespace ToNRoundCounter.Application
 
             private static IntPtr FindTargetWindow(string hint)
             {
-                IntPtr found = IntPtr.Zero;
+                var hints = SplitHints(hint).ToArray();
+                var candidates = EnumerateWindows();
+                if (candidates.Count == 0)
+                {
+                    return IntPtr.Zero;
+                }
+
+                WindowCandidate? best = null;
+
+                foreach (var candidate in candidates)
+                {
+                    int score = ScoreCandidate(candidate, hints);
+                    if (score <= 0)
+                    {
+                        continue;
+                    }
+
+                    if (best == null || score > best.Score || (score == best.Score && candidate.ZOrder < best.ZOrder))
+                    {
+                        best = new WindowCandidate(candidate, score);
+                    }
+                }
+
+                return best?.Info.Handle ?? IntPtr.Zero;
+            }
+
+            private static IEnumerable<string> SplitHints(string hint)
+            {
+                if (string.IsNullOrWhiteSpace(hint))
+                {
+                    yield return "VRChat";
+                    yield break;
+                }
+
+                foreach (var part in hint.Split(new[] { '|', ';' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var value = part.Trim();
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        yield return value;
+                    }
+                }
+            }
+
+            private static int ScoreCandidate(WindowInfo info, IReadOnlyList<string> hints)
+            {
+                int best = 0;
+
+                if (hints.Count == 0)
+                {
+                    return info.IsVisible ? 1 : 0;
+                }
+
+                foreach (var hint in hints)
+                {
+                    int score = ScoreHint(info, hint);
+                    if (score > best)
+                    {
+                        best = score;
+                    }
+                }
+
+                return best;
+            }
+
+            private static int ScoreHint(WindowInfo info, string hint)
+            {
+                if (string.IsNullOrWhiteSpace(hint))
+                {
+                    return 0;
+                }
+
+                string value = hint;
+                string? qualifier = null;
+
+                int colonIndex = hint.IndexOf(':');
+                if (colonIndex > 0)
+                {
+                    qualifier = hint.Substring(0, colonIndex).Trim();
+                    value = hint.Substring(colonIndex + 1).Trim();
+                }
+
+                if (string.IsNullOrEmpty(value))
+                {
+                    return 0;
+                }
+
+                bool exact = false;
+                bool partial = false;
+
+                if (qualifier == null)
+                {
+                    exact |= EqualsIgnoreCase(info.Title, value);
+                    partial |= ContainsIgnoreCase(info.Title, value);
+
+                    exact |= EqualsIgnoreCase(info.ProcessName, value);
+                    partial |= ContainsIgnoreCase(info.ProcessName, value);
+
+                    exact |= EqualsIgnoreCase(info.ClassName, value);
+                    partial |= ContainsIgnoreCase(info.ClassName, value);
+                }
+                else
+                {
+                    switch (qualifier.ToLowerInvariant())
+                    {
+                        case "title":
+                            exact = EqualsIgnoreCase(info.Title, value);
+                            partial = ContainsIgnoreCase(info.Title, value);
+                            break;
+                        case "process":
+                            exact = EqualsIgnoreCase(info.ProcessName, value);
+                            partial = ContainsIgnoreCase(info.ProcessName, value);
+                            break;
+                        case "class":
+                            exact = EqualsIgnoreCase(info.ClassName, value);
+                            partial = ContainsIgnoreCase(info.ClassName, value);
+                            break;
+                        default:
+                            partial = ContainsIgnoreCase(info.Title, value) || ContainsIgnoreCase(info.ProcessName, value);
+                            break;
+                    }
+                }
+
+                if (exact)
+                {
+                    return info.IsVisible ? 200 : 150;
+                }
+
+                if (partial)
+                {
+                    return info.IsVisible ? 120 : 90;
+                }
+
+                return 0;
+            }
+
+            private static bool EqualsIgnoreCase(string a, string b) =>
+                string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+
+            private static bool ContainsIgnoreCase(string source, string value)
+            {
+                if (string.IsNullOrEmpty(source))
+                {
+                    return false;
+                }
+
+                return source.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+
+            private static List<WindowInfo> EnumerateWindows()
+            {
+                var list = new List<WindowInfo>();
+                int index = 0;
                 EnumWindows((handle, _) =>
                 {
-                    if (!IsWindowVisible(handle))
+                    index++;
+                    try
                     {
-                        return true;
+                        list.Add(CreateWindowInfo(handle, index));
                     }
-
-                    int length = GetWindowTextLength(handle);
-                    if (length <= 0)
+                    catch
                     {
-                        return true;
-                    }
-
-                    var builder = new StringBuilder(length + 1);
-                    if (GetWindowText(handle, builder, builder.Capacity) == 0)
-                    {
-                        return true;
-                    }
-
-                    var title = builder.ToString();
-                    if (title.IndexOf(hint, StringComparison.OrdinalIgnoreCase) >= 0)
-                    {
-                        found = handle;
-                        return false;
                     }
 
                     return true;
                 }, IntPtr.Zero);
 
-                if (found != IntPtr.Zero)
+                return list;
+            }
+
+            private static WindowInfo CreateWindowInfo(IntPtr handle, int zOrder)
+            {
+                string title = GetWindowTitle(handle);
+                string className = GetWindowClass(handle);
+                string processName = GetProcessName(handle);
+                bool visible = IsWindowVisible(handle);
+
+                return new WindowInfo(handle, title, className, processName, zOrder, visible);
+            }
+
+            private static string GetWindowTitle(IntPtr handle)
+            {
+                int length = GetWindowTextLength(handle);
+                if (length <= 0)
                 {
-                    return found;
+                    return string.Empty;
                 }
 
-                foreach (var process in Process.GetProcesses())
+                var builder = new StringBuilder(length + 1);
+                if (GetWindowText(handle, builder, builder.Capacity) == 0)
                 {
-                    using (process)
+                    return string.Empty;
+                }
+
+                return builder.ToString();
+            }
+
+            private static string GetWindowClass(IntPtr handle)
+            {
+                var builder = new StringBuilder(256);
+                if (GetClassName(handle, builder, builder.Capacity) == 0)
+                {
+                    return string.Empty;
+                }
+
+                return builder.ToString();
+            }
+
+            private static string GetProcessName(IntPtr handle)
+            {
+                try
+                {
+                    _ = GetWindowThreadProcessId(handle, out uint processId);
+                    if (processId == 0)
                     {
-                        try
-                        {
-                            if (process.MainWindowHandle == IntPtr.Zero)
-                            {
-                                continue;
-                            }
-
-                            string title = process.MainWindowTitle ?? string.Empty;
-                            if (title.IndexOf(hint, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                                process.ProcessName.Equals(hint, StringComparison.OrdinalIgnoreCase))
-                            {
-                                return process.MainWindowHandle;
-                            }
-                        }
-                        catch
-                        {
-                        }
+                        return string.Empty;
                     }
+
+                    using var process = Process.GetProcessById((int)processId);
+                    return process.ProcessName ?? string.Empty;
+                }
+                catch
+                {
+                    return string.Empty;
+                }
+            }
+
+            private static bool TryGetWindowBounds(IntPtr handle, out RECT rect)
+            {
+                if (DwmGetWindowAttribute(handle, DWMWA_EXTENDED_FRAME_BOUNDS, out var extendedRect, Marshal.SizeOf<RECT>()) == 0)
+                {
+                    rect = extendedRect;
+                    return true;
                 }
 
-                return IntPtr.Zero;
+                if (GetWindowRect(handle, out rect))
+                {
+                    return true;
+                }
+
+                rect = default;
+                return false;
+            }
+
+            private static bool TryCaptureWindow(IntPtr handle, RECT rect, Bitmap bitmap, bool includeOverlay)
+            {
+                if (bitmap == null)
+                {
+                    return false;
+                }
+
+                if (includeOverlay)
+                {
+                    if (TryCopyWindowFromScreen(rect, bitmap))
+                    {
+                        return true;
+                    }
+
+                    return TryCaptureWithPrintWindow(handle, bitmap);
+                }
+
+                if (TryCaptureWithPrintWindow(handle, bitmap))
+                {
+                    return true;
+                }
+
+                return TryCopyWindowFromScreen(rect, bitmap);
+            }
+
+            private static bool TryCaptureWithPrintWindow(IntPtr handle, Bitmap bitmap)
+            {
+                using var graphics = Graphics.FromImage(bitmap);
+                graphics.Clear(Color.Black);
+                IntPtr hdc = graphics.GetHdc();
+                try
+                {
+                    return PrintWindow(handle, hdc, PW_RENDERFULLCONTENT);
+                }
+                finally
+                {
+                    graphics.ReleaseHdc(hdc);
+                }
+            }
+
+            private static bool TryCopyWindowFromScreen(RECT rect, Bitmap bitmap)
+            {
+                var origin = new System.Drawing.Point(rect.Left, rect.Top);
+                try
+                {
+                    using var fallback = Graphics.FromImage(bitmap);
+                    fallback.CopyFromScreen(origin, System.Drawing.Point.Empty, bitmap.Size, CopyPixelOperation.SourceCopy);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            private readonly struct WindowInfo
+            {
+                public WindowInfo(IntPtr handle, string title, string className, string processName, int zOrder, bool isVisible)
+                {
+                    Handle = handle;
+                    Title = title;
+                    ClassName = className;
+                    ProcessName = processName;
+                    ZOrder = zOrder;
+                    IsVisible = isVisible;
+                }
+
+                public IntPtr Handle { get; }
+                public string Title { get; }
+                public string ClassName { get; }
+                public string ProcessName { get; }
+                public int ZOrder { get; }
+                public bool IsVisible { get; }
+            }
+
+            private readonly struct WindowCandidate
+            {
+                public WindowCandidate(WindowInfo info, int score)
+                {
+                    Info = info;
+                    Score = score;
+                }
+
+                public WindowInfo Info { get; }
+                public int Score { get; }
+                public int ZOrder => Info.ZOrder;
             }
 
             private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
@@ -774,11 +1071,28 @@ namespace ToNRoundCounter.Application
 
             [DllImport("user32.dll")]
             private static extern bool IsWindow(IntPtr hWnd);
+
+            [DllImport("user32.dll")]
+            private static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+            [DllImport("user32.dll")]
+            private static extern int GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+            [DllImport("user32.dll")]
+            private static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, uint nFlags);
+
+            [DllImport("dwmapi.dll")]
+            private static extern int DwmGetWindowAttribute(IntPtr hwnd, uint dwAttribute, out RECT pvAttribute, int cbAttribute);
+
+            private const uint PW_RENDERFULLCONTENT = 0x00000002;
+            private const uint DWMWA_EXTENDED_FRAME_BOUNDS = 9;
         }
 
         private interface IFrameWriter : IDisposable
         {
             void WriteFrame(Bitmap frame);
+
+            bool IsHardwareAccelerated { get; }
         }
 
         private sealed class SimpleAviWriter : IFrameWriter
@@ -868,6 +1182,8 @@ namespace ToNRoundCounter.Application
                     throw;
                 }
             }
+
+            public bool IsHardwareAccelerated => false;
 
             public void WriteFrame(Bitmap frame)
             {
@@ -1055,6 +1371,8 @@ namespace ToNRoundCounter.Application
             private long _timestamp;
             private long _durationAccumulator;
             private bool _disposed;
+            private readonly bool _isHardwareAccelerated;
+            private readonly HardwareDeviceContext? _hardwareContext;
 
             private MediaFoundationFrameWriter(string extension, string path, int width, int height, int frameRate, FormatDescriptor descriptor)
             {
@@ -1083,20 +1401,14 @@ namespace ToNRoundCounter.Application
                 MediaFoundationInterop.AddRef();
 
                 bool initialized = false;
-                MediaFoundationInterop.IMFAttributes? attributes = null;
                 MediaFoundationInterop.IMFMediaType? outputType = null;
                 MediaFoundationInterop.IMFMediaType? inputType = null;
                 MediaFoundationInterop.IMFSinkWriter? writer = null;
+                HardwareDeviceContext? hardwareContext = null;
 
                 try
                 {
-                    if (descriptor.ContainerType.HasValue)
-                    {
-                        attributes = MediaFoundationInterop.CreateAttributes(1);
-                        MediaFoundationInterop.CheckHr(attributes.SetGUID(MediaFoundationInterop.MF_TRANSCODE_CONTAINERTYPE, descriptor.ContainerType.Value), "IMFAttributes.SetGUID");
-                    }
-
-                    writer = MediaFoundationInterop.CreateSinkWriter(path, attributes);
+                    writer = CreateSinkWriterWithHardwareFallback(path, descriptor, out _isHardwareAccelerated, out hardwareContext);
 
                     outputType = MediaFoundationInterop.CreateMediaType();
                     MediaFoundationInterop.CheckHr(outputType.SetGUID(MediaFoundationInterop.MF_MT_MAJOR_TYPE, MediaFoundationInterop.MFMediaType_Video), "MF_MT_MAJOR_TYPE");
@@ -1123,6 +1435,8 @@ namespace ToNRoundCounter.Application
 
                     _sinkWriter = writer;
                     writer = null;
+                    _hardwareContext = hardwareContext;
+                    hardwareContext = null;
                     initialized = true;
                 }
                 catch
@@ -1136,11 +1450,6 @@ namespace ToNRoundCounter.Application
                 }
                 finally
                 {
-                    if (attributes != null)
-                    {
-                        Marshal.ReleaseComObject(attributes);
-                    }
-
                     if (outputType != null)
                     {
                         Marshal.ReleaseComObject(outputType);
@@ -1151,12 +1460,17 @@ namespace ToNRoundCounter.Application
                         Marshal.ReleaseComObject(inputType);
                     }
 
+                    hardwareContext?.Dispose();
+
                     if (!initialized)
                     {
+                        _hardwareContext?.Dispose();
                         MediaFoundationInterop.Release();
                     }
                 }
             }
+
+            public bool IsHardwareAccelerated => _isHardwareAccelerated;
 
             public static MediaFoundationFrameWriter Create(string extension, string path, int width, int height, int frameRate)
             {
@@ -1171,6 +1485,72 @@ namespace ToNRoundCounter.Application
                 }
 
                 return new MediaFoundationFrameWriter(extension, path, width, height, frameRate, descriptor);
+            }
+
+            private static MediaFoundationInterop.IMFSinkWriter CreateSinkWriterWithHardwareFallback(string path, FormatDescriptor descriptor, out bool hardwareEnabled, out HardwareDeviceContext? hardwareContext)
+            {
+                Exception? lastError = null;
+                hardwareContext = null;
+
+                foreach (bool requestHardware in new[] { true, false })
+                {
+                    MediaFoundationInterop.IMFAttributes? attributes = null;
+                    HardwareDeviceContext? context = null;
+
+                    try
+                    {
+                        int attributeCount = 1;
+                        if (descriptor.ContainerType.HasValue)
+                        {
+                            attributeCount++;
+                        }
+
+                        if (requestHardware)
+                        {
+                            attributeCount += 2;
+                        }
+
+                        attributes = MediaFoundationInterop.CreateAttributes(attributeCount);
+                        MediaFoundationInterop.CheckHr(attributes.SetUINT32(MediaFoundationInterop.MF_SINK_WRITER_DISABLE_THROTTLING, 1), "IMFAttributes.SetUINT32(MF_SINK_WRITER_DISABLE_THROTTLING)");
+
+                        if (descriptor.ContainerType.HasValue)
+                        {
+                            MediaFoundationInterop.CheckHr(attributes.SetGUID(MediaFoundationInterop.MF_TRANSCODE_CONTAINERTYPE, descriptor.ContainerType.Value), "IMFAttributes.SetGUID(MF_TRANSCODE_CONTAINERTYPE)");
+                        }
+
+                        if (requestHardware)
+                        {
+                            MediaFoundationInterop.CheckHr(attributes.SetUINT32(MediaFoundationInterop.MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS, 1), "IMFAttributes.SetUINT32(MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS)");
+                            context = HardwareDeviceContext.Create();
+                            MediaFoundationInterop.CheckHr(attributes.SetUnknown(ref MediaFoundationInterop.MF_SINK_WRITER_D3D_MANAGER, context.DeviceManager), "IMFAttributes.SetUnknown(MF_SINK_WRITER_D3D_MANAGER)");
+                        }
+
+                        var writer = MediaFoundationInterop.CreateSinkWriter(path, attributes);
+                        hardwareEnabled = requestHardware;
+                        hardwareContext = context;
+                        context = null;
+                        return writer;
+                    }
+                    catch (Exception ex)
+                    {
+                        lastError = ex;
+                        if (!requestHardware)
+                        {
+                            throw new InvalidOperationException("Failed to initialize Media Foundation sink writer.", ex);
+                        }
+                    }
+                    finally
+                    {
+                        context?.Dispose();
+
+                        if (attributes != null)
+                        {
+                            Marshal.ReleaseComObject(attributes);
+                        }
+                    }
+                }
+
+                throw new InvalidOperationException("Failed to initialize Media Foundation sink writer.", lastError ?? new InvalidOperationException("Unknown Media Foundation error."));
             }
 
             public void WriteFrame(Bitmap frame)
@@ -1292,8 +1672,482 @@ namespace ToNRoundCounter.Application
                 }
                 finally
                 {
+                    _hardwareContext?.Dispose();
                     MediaFoundationInterop.Release();
                 }
+            }
+
+            private sealed class HardwareDeviceContext : IDisposable
+            {
+                private IntPtr _device;
+                private IntPtr _deviceContext;
+                private MediaFoundationInterop.IMFDXGIDeviceManager? _deviceManager;
+                private bool _disposed;
+
+                private HardwareDeviceContext(IntPtr device, IntPtr deviceContext, MediaFoundationInterop.IMFDXGIDeviceManager deviceManager)
+                {
+                    _device = device;
+                    _deviceContext = deviceContext;
+                    _deviceManager = deviceManager;
+                }
+
+                public MediaFoundationInterop.IMFDXGIDeviceManager DeviceManager
+                {
+                    get
+                    {
+                        if (_disposed || _deviceManager == null)
+                        {
+                            throw new ObjectDisposedException(nameof(HardwareDeviceContext));
+                        }
+
+                        return _deviceManager;
+                    }
+                }
+
+                public static HardwareDeviceContext Create()
+                {
+                    IntPtr device = IntPtr.Zero;
+                    IntPtr context = IntPtr.Zero;
+                    MediaFoundationInterop.IMFDXGIDeviceManager? manager = null;
+                    GCHandle handle = default;
+
+                    try
+                    {
+                        var featureLevels = new[]
+                        {
+                            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_12_1,
+                            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_12_0,
+                            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_11_1,
+                            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_11_0,
+                            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_10_1,
+                            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_10_0,
+                        };
+
+                        handle = GCHandle.Alloc(featureLevels, GCHandleType.Pinned);
+                        if (!TryCreateDeviceOnPreferredAdapter(handle.AddrOfPinnedObject(), (uint)featureLevels.Length, out device, out context))
+                        {
+                            int hr = D3D11CreateDevice(
+                                IntPtr.Zero,
+                                D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_HARDWARE,
+                                IntPtr.Zero,
+                                (uint)(D3D11_CREATE_DEVICE_FLAG.D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_FLAG.D3D11_CREATE_DEVICE_VIDEO_SUPPORT),
+                                handle.AddrOfPinnedObject(),
+                                (uint)featureLevels.Length,
+                                D3D11_SDK_VERSION,
+                                out device,
+                                out _,
+                                out context);
+
+                            if (hr < 0)
+                            {
+                                throw new InvalidOperationException($"D3D11CreateDevice failed with HRESULT 0x{hr:X8}.");
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (handle.IsAllocated)
+                        {
+                            handle.Free();
+                        }
+                    }
+
+                    TryEnableMultithreadProtection(context);
+
+                    try
+                    {
+                        manager = MediaFoundationInterop.CreateDxgiDeviceManager(out var resetToken);
+                        MediaFoundationInterop.CheckHr(manager.ResetDevice(device, resetToken), "IMFDXGIDeviceManager.ResetDevice");
+
+                        var result = new HardwareDeviceContext(device, context, manager);
+                        device = IntPtr.Zero;
+                        context = IntPtr.Zero;
+                        manager = null;
+                        return result;
+                    }
+                    finally
+                    {
+                        if (manager != null)
+                        {
+                            Marshal.ReleaseComObject(manager);
+                        }
+
+                        if (context != IntPtr.Zero)
+                        {
+                            Marshal.Release(context);
+                        }
+
+                        if (device != IntPtr.Zero)
+                        {
+                            Marshal.Release(device);
+                        }
+                    }
+                }
+
+                private static bool TryCreateDeviceOnPreferredAdapter(IntPtr featureLevelPtr, uint featureLevelCount, out IntPtr device, out IntPtr context)
+                {
+                    device = IntPtr.Zero;
+                    context = IntPtr.Zero;
+
+                    IntPtr factoryPtr = IntPtr.Zero;
+                    IDXGIFactory1? factory = null;
+                    var adapters = new List<AdapterInfo>();
+
+                    try
+                    {
+                        Guid factoryGuid = typeof(IDXGIFactory1).GUID;
+                        int hr = CreateDXGIFactory1(ref factoryGuid, out factoryPtr);
+                        if (hr < 0)
+                        {
+                            return false;
+                        }
+
+                        factory = (IDXGIFactory1)Marshal.GetObjectForIUnknown(factoryPtr);
+                        Marshal.Release(factoryPtr);
+                        factoryPtr = IntPtr.Zero;
+
+                        uint index = 0;
+                        while (true)
+                        {
+                            IDXGIAdapter1? adapter = null;
+                            try
+                            {
+                                hr = factory.EnumAdapters1(index, out adapter);
+                                if (hr == DXGI_ERROR_NOT_FOUND)
+                                {
+                                    break;
+                                }
+
+                                if (hr < 0)
+                                {
+                                    return false;
+                                }
+
+                                if (adapter != null)
+                                {
+                                    adapter.GetDesc1(out var desc);
+                                    IntPtr adapterPtr = Marshal.GetIUnknownForObject(adapter);
+                                    adapters.Add(new AdapterInfo(adapterPtr, desc));
+                                }
+                            }
+                            finally
+                            {
+                                if (adapter != null)
+                                {
+                                    Marshal.ReleaseComObject(adapter);
+                                }
+
+                                index++;
+                            }
+                        }
+
+                        var hardwareAdapters = new List<AdapterInfo>();
+                        foreach (var adapter in adapters)
+                        {
+                            if (adapter.IsSoftwareAdapter)
+                            {
+                                adapter.Dispose();
+                            }
+                            else
+                            {
+                                hardwareAdapters.Add(adapter);
+                            }
+                        }
+
+                        adapters = hardwareAdapters;
+                        if (adapters.Count == 0)
+                        {
+                            return false;
+                        }
+
+                        adapters.Sort((a, b) =>
+                        {
+                            int nvidiaComparison = b.IsNvidia.CompareTo(a.IsNvidia);
+                            if (nvidiaComparison != 0)
+                            {
+                                return nvidiaComparison;
+                            }
+
+                            int memoryComparison = b.DedicatedVideoMemory.CompareTo(a.DedicatedVideoMemory);
+                            if (memoryComparison != 0)
+                            {
+                                return memoryComparison;
+                            }
+
+                            return string.Compare(b.Description, a.Description, StringComparison.OrdinalIgnoreCase);
+                        });
+
+                        foreach (var adapter in adapters)
+                        {
+                            hr = D3D11CreateDevice(
+                                adapter.AdapterPtr,
+                                D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_UNKNOWN,
+                                IntPtr.Zero,
+                                (uint)(D3D11_CREATE_DEVICE_FLAG.D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_FLAG.D3D11_CREATE_DEVICE_VIDEO_SUPPORT),
+                                featureLevelPtr,
+                                featureLevelCount,
+                                D3D11_SDK_VERSION,
+                                out device,
+                                out _,
+                                out context);
+
+                            if (hr >= 0)
+                            {
+                                return true;
+                            }
+
+                            if (device != IntPtr.Zero)
+                            {
+                                Marshal.Release(device);
+                                device = IntPtr.Zero;
+                            }
+
+                            if (context != IntPtr.Zero)
+                            {
+                                Marshal.Release(context);
+                                context = IntPtr.Zero;
+                            }
+                        }
+
+                        return false;
+                    }
+                    finally
+                    {
+                        if (factory != null)
+                        {
+                            Marshal.ReleaseComObject(factory);
+                        }
+
+                        if (factoryPtr != IntPtr.Zero)
+                        {
+                            Marshal.Release(factoryPtr);
+                        }
+
+                        foreach (var adapter in adapters)
+                        {
+                            adapter.Dispose();
+                        }
+                    }
+                }
+
+                private static void TryEnableMultithreadProtection(IntPtr context)
+                {
+                    if (context == IntPtr.Zero)
+                    {
+                        return;
+                    }
+
+                    IntPtr multithreadPtr = IntPtr.Zero;
+                    try
+                    {
+                        Guid multithreadGuid = typeof(ID3D11Multithread).GUID;
+                        int hr = Marshal.QueryInterface(context, ref multithreadGuid, out multithreadPtr);
+                        if (hr < 0)
+                        {
+                            return;
+                        }
+
+                        var multithread = (ID3D11Multithread)Marshal.GetObjectForIUnknown(multithreadPtr);
+                        try
+                        {
+                            multithread.SetMultithreadProtected(true);
+                        }
+                        finally
+                        {
+                            Marshal.ReleaseComObject(multithread);
+                        }
+                    }
+                    finally
+                    {
+                        if (multithreadPtr != IntPtr.Zero)
+                        {
+                            Marshal.Release(multithreadPtr);
+                        }
+                    }
+                }
+
+                private sealed class AdapterInfo : IDisposable
+                {
+                    public AdapterInfo(IntPtr adapterPtr, DXGI_ADAPTER_DESC1 description)
+                    {
+                        AdapterPtr = adapterPtr;
+                        DescriptionRaw = description;
+                    }
+
+                    public IntPtr AdapterPtr { get; }
+
+                    private DXGI_ADAPTER_DESC1 DescriptionRaw { get; }
+
+                    public bool IsSoftwareAdapter => (DescriptionRaw.Flags & (uint)DXGI_ADAPTER_FLAG.DXGI_ADAPTER_FLAG_SOFTWARE) != 0;
+
+                    public bool IsNvidia => DescriptionRaw.VendorId == NvidiaVendorId;
+
+                    public ulong DedicatedVideoMemory
+                    {
+                        get
+                        {
+                            return Environment.Is64BitProcess
+                                ? DescriptionRaw.DedicatedVideoMemory.ToUInt64()
+                                : DescriptionRaw.DedicatedVideoMemory.ToUInt32();
+                        }
+                    }
+
+                    public string Description => DescriptionRaw.Description ?? string.Empty;
+
+                    public void Dispose()
+                    {
+                        if (AdapterPtr != IntPtr.Zero)
+                        {
+                            Marshal.Release(AdapterPtr);
+                        }
+                    }
+                }
+
+                private const uint NvidiaVendorId = 0x10DE;
+                private const int DXGI_ERROR_NOT_FOUND = unchecked((int)0x887A0002);
+
+                public void Dispose()
+                {
+                    if (_disposed)
+                    {
+                        return;
+                    }
+
+                    _disposed = true;
+
+                    if (_deviceManager != null)
+                    {
+                        Marshal.ReleaseComObject(_deviceManager);
+                        _deviceManager = null;
+                    }
+
+                    if (_deviceContext != IntPtr.Zero)
+                    {
+                        Marshal.Release(_deviceContext);
+                        _deviceContext = IntPtr.Zero;
+                    }
+
+                    if (_device != IntPtr.Zero)
+                    {
+                        Marshal.Release(_device);
+                        _device = IntPtr.Zero;
+                    }
+                }
+            }
+
+            private enum D3D_DRIVER_TYPE : uint
+            {
+                D3D_DRIVER_TYPE_UNKNOWN = 0,
+                D3D_DRIVER_TYPE_HARDWARE = 1,
+            }
+
+            [Flags]
+            private enum D3D11_CREATE_DEVICE_FLAG : uint
+            {
+                D3D11_CREATE_DEVICE_BGRA_SUPPORT = 0x20,
+                D3D11_CREATE_DEVICE_VIDEO_SUPPORT = 0x800,
+            }
+
+            private enum D3D_FEATURE_LEVEL : uint
+            {
+                D3D_FEATURE_LEVEL_12_1 = 0x0000C100,
+                D3D_FEATURE_LEVEL_12_0 = 0x0000C000,
+                D3D_FEATURE_LEVEL_11_1 = 0x0000B100,
+                D3D_FEATURE_LEVEL_11_0 = 0x0000B000,
+                D3D_FEATURE_LEVEL_10_1 = 0x0000A100,
+                D3D_FEATURE_LEVEL_10_0 = 0x0000A000,
+            }
+
+            private const uint D3D11_SDK_VERSION = 7;
+
+            [DllImport("d3d11.dll")]
+            private static extern int D3D11CreateDevice(
+                IntPtr pAdapter,
+                D3D_DRIVER_TYPE DriverType,
+                IntPtr Software,
+                uint Flags,
+                IntPtr pFeatureLevels,
+                uint FeatureLevels,
+                uint SDKVersion,
+                out IntPtr ppDevice,
+                out D3D_FEATURE_LEVEL pFeatureLevel,
+                out IntPtr ppImmediateContext);
+
+            [DllImport("dxgi.dll")]
+            private static extern int CreateDXGIFactory1(ref Guid riid, out IntPtr ppFactory);
+
+            [ComImport]
+            [Guid("b2daad8b-03d4-4dbf-95eb-32ab4b63d0ab")]
+            [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+            private interface ID3D11Multithread
+            {
+                void Enter();
+                void Leave();
+                void SetMultithreadProtected(bool bMTProtect);
+                bool GetMultithreadProtected();
+            }
+
+            [ComImport]
+            [Guid("770aae78-f26f-4dba-a829-253c83d1b387")]
+            [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+            private interface IDXGIFactory1
+            {
+                [PreserveSig] int SetPrivateData(ref Guid name, uint dataSize, IntPtr data);
+                [PreserveSig] int SetPrivateDataInterface(ref Guid name, IntPtr unknown);
+                [PreserveSig] int GetPrivateData(ref Guid name, ref uint dataSize, IntPtr data);
+                [PreserveSig] int GetParent(ref Guid riid, out IntPtr parent);
+                [PreserveSig] int EnumAdapters(uint adapter, out IntPtr ppAdapter);
+                [PreserveSig] int MakeWindowAssociation(IntPtr hwnd, uint flags);
+                [PreserveSig] int GetWindowAssociation(out IntPtr hwnd);
+                [PreserveSig] int CreateSwapChain(IntPtr device, IntPtr desc, out IntPtr swapChain);
+                [PreserveSig] int CreateSoftwareAdapter(IntPtr module, out IntPtr adapter);
+                [PreserveSig] int EnumAdapters1(uint adapter, out IDXGIAdapter1 ppAdapter);
+                [PreserveSig] bool IsCurrent();
+            }
+
+            [ComImport]
+            [Guid("29038f61-3839-4626-91fd-086879011a05")]
+            [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+            private interface IDXGIAdapter1
+            {
+                [PreserveSig] int SetPrivateData(ref Guid name, uint dataSize, IntPtr data);
+                [PreserveSig] int SetPrivateDataInterface(ref Guid name, IntPtr unknown);
+                [PreserveSig] int GetPrivateData(ref Guid name, ref uint dataSize, IntPtr data);
+                [PreserveSig] int GetParent(ref Guid riid, out IntPtr parent);
+                [PreserveSig] int EnumOutputs(uint output, out IntPtr ppOutput);
+                [PreserveSig] int GetDesc(IntPtr desc);
+                [PreserveSig] int CheckInterfaceSupport(ref Guid guid, out long umdVersion);
+                [PreserveSig] int GetDesc1(out DXGI_ADAPTER_DESC1 desc);
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct LUID
+            {
+                public uint LowPart;
+                public int HighPart;
+            }
+
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            private struct DXGI_ADAPTER_DESC1
+            {
+                [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+                public string Description;
+                public uint VendorId;
+                public uint DeviceId;
+                public uint SubSysId;
+                public uint Revision;
+                public UIntPtr DedicatedVideoMemory;
+                public UIntPtr DedicatedSystemMemory;
+                public UIntPtr SharedSystemMemory;
+                public LUID AdapterLuid;
+                public uint Flags;
+            }
+
+            [Flags]
+            private enum DXGI_ADAPTER_FLAG : uint
+            {
+                DXGI_ADAPTER_FLAG_NONE = 0,
+                DXGI_ADAPTER_FLAG_SOFTWARE = 0x2,
             }
 
             private static int CalculateBitrate(int width, int height, int frameRate)
@@ -1360,6 +2214,9 @@ namespace ToNRoundCounter.Application
                 public static readonly Guid MFTranscodeContainerType_ASF = new Guid("430F6F6E-B6BF-4FC1-A0BD-9EE46EEE2AFB");
                 public static readonly Guid MFTranscodeContainerType_MPEG4 = new Guid("DC6CD05D-B9D0-40EF-BD35-FA622C1AB28A");
                 public static readonly Guid MFTranscodeContainerType_MPEG2 = new Guid("BFC2DBF9-7BB4-4F8F-AFDE-E112C44BA882");
+                public static readonly Guid MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS = new Guid("A634A91C-822B-41B9-A494-4DE4643612B0");
+                public static readonly Guid MF_SINK_WRITER_DISABLE_THROTTLING = new Guid("08B845D8-2B74-4AFE-9D53-BE16D2D5AE4F");
+                public static readonly Guid MF_SINK_WRITER_D3D_MANAGER = new Guid("EC82238C-1EA6-4DBF-8451-4D3EBE0B6837");
                 public static readonly Guid MF_TRANSCODE_CONTAINERTYPE = new Guid("150FF23F-4ABC-478B-AC4F-E1916FBA1CCA");
                 public static readonly Guid MF_MT_MAJOR_TYPE = new Guid("48EBA18E-F8C9-4687-BF11-0A74C9F96A8F");
                 public static readonly Guid MF_MT_SUBTYPE = new Guid("F7E34C9A-42E8-4714-B74B-CB29D72C35E5");
@@ -1445,6 +2302,12 @@ namespace ToNRoundCounter.Application
                     return buffer;
                 }
 
+                public static IMFDXGIDeviceManager CreateDxgiDeviceManager(out uint resetToken)
+                {
+                    CheckHr(MFCreateDXGIDeviceManager(out resetToken, out var manager), nameof(MFCreateDXGIDeviceManager));
+                    return manager;
+                }
+
                 public static void SetAttributeSize(IMFMediaType type, Guid key, int width, int height)
                 {
                     CheckHr(MFSetAttributeSize(type, key, (uint)width, (uint)height), nameof(MFSetAttributeSize));
@@ -1481,6 +2344,9 @@ namespace ToNRoundCounter.Application
 
                 [DllImport("mfplat.dll")]
                 private static extern int MFCreateMemoryBuffer(int cbMaxLength, out IMFMediaBuffer ppBuffer);
+
+                [DllImport("mfplat.dll")]
+                private static extern int MFCreateDXGIDeviceManager(out uint resetToken, out IMFDXGIDeviceManager? ppDeviceManager);
 
                 [ComImport]
                 [Guid("2cd2d921-c447-44a7-a13c-4adabfc247e3")]
@@ -1547,6 +2413,20 @@ namespace ToNRoundCounter.Application
                     [PreserveSig] int Finalize();
                     [PreserveSig] int GetServiceForStream(int streamIndex, ref Guid guidService, ref Guid riid, out IntPtr service);
                     [PreserveSig] int GetStatistics(int streamIndex, out MF_SINK_WRITER_STATISTICS statistics);
+                }
+
+                [ComImport]
+                [Guid("ca86aa50-c46e-429e-9866-2fc0ba7a656f")]
+                [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+                public interface IMFDXGIDeviceManager
+                {
+                    [PreserveSig] int ResetDevice(IntPtr pDevice, uint resetToken);
+                    [PreserveSig] int OpenDeviceHandle(out IntPtr phDevice);
+                    [PreserveSig] int CloseDeviceHandle(IntPtr hDevice);
+                    [PreserveSig] int TestDevice(IntPtr hDevice);
+                    [PreserveSig] int LockDevice(IntPtr hDevice, Guid riid, out IntPtr ppv, bool block);
+                    [PreserveSig] int UnlockDevice(IntPtr hDevice, bool saveState);
+                    [PreserveSig] int GetVideoService(IntPtr hDevice, Guid riid, out IntPtr ppService);
                 }
 
                 [ComImport]
@@ -1674,6 +2554,8 @@ namespace ToNRoundCounter.Application
                 _height = height;
                 _frameDelay = (ushort)Math.Max(1, Math.Round(100.0 / Math.Max(1, frameRate)));
             }
+
+            public bool IsHardwareAccelerated => false;
 
             public void WriteFrame(Bitmap frame)
             {

--- a/Application/IAppSettings.cs
+++ b/Application/IAppSettings.cs
@@ -73,6 +73,7 @@ namespace ToNRoundCounter.Application
         string AutoRecordingArguments { get; set; }
         string AutoRecordingOutputDirectory { get; set; }
         string AutoRecordingOutputExtension { get; set; }
+        bool AutoRecordingIncludeOverlay { get; set; }
         List<string> AutoRecordingRoundTypes { get; set; }
         List<string> AutoRecordingTerrors { get; set; }
         string DiscordWebhookUrl { get; set; }

--- a/Infrastructure/AppSettings.cs
+++ b/Infrastructure/AppSettings.cs
@@ -97,6 +97,7 @@ namespace ToNRoundCounter.Infrastructure
         public string AutoRecordingArguments { get; set; } = string.Empty;
         public string AutoRecordingOutputDirectory { get; set; } = "recordings";
         public string AutoRecordingOutputExtension { get; set; } = "avi";
+        public bool AutoRecordingIncludeOverlay { get; set; }
         public List<string> AutoRecordingRoundTypes { get; set; } = new List<string>();
         public List<string> AutoRecordingTerrors { get; set; } = new List<string>();
         public string DiscordWebhookUrl { get; set; } = string.Empty;
@@ -564,6 +565,7 @@ namespace ToNRoundCounter.Infrastructure
                 AutoRecordingArguments = AutoRecordingArguments,
                 AutoRecordingOutputDirectory = AutoRecordingOutputDirectory,
                 AutoRecordingOutputExtension = AutoRecordingOutputExtension,
+                AutoRecordingIncludeOverlay = AutoRecordingIncludeOverlay,
                 AutoRecordingRoundTypes = AutoRecordingRoundTypes,
                 AutoRecordingTerrors = AutoRecordingTerrors,
                 DiscordWebhookUrl = DiscordWebhookUrl,
@@ -659,6 +661,7 @@ namespace ToNRoundCounter.Infrastructure
         public string AutoRecordingArguments { get; set; } = string.Empty;
         public string AutoRecordingOutputDirectory { get; set; } = "recordings";
         public string AutoRecordingOutputExtension { get; set; } = "avi";
+        public bool AutoRecordingIncludeOverlay { get; set; }
         public List<string> AutoRecordingRoundTypes { get; set; } = new List<string>();
         public List<string> AutoRecordingTerrors { get; set; } = new List<string>();
         public string DiscordWebhookUrl { get; set; } = string.Empty;

--- a/Infrastructure/Resources/Strings.ja.resx
+++ b/Infrastructure/Resources/Strings.ja.resx
@@ -293,6 +293,9 @@ APIキーはwebサイトから取得してください。</value>
   <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
     <value>GIF（アニメーション画像）</value>
   </data>
+  <data name="AutoRecording_IncludeOverlay" xml:space="preserve">
+    <value>録画にオーバーレイを含める</value>
+  </data>
   <data name="AutoRecording_FormatHelp" xml:space="preserve">
     <value>AVIは非圧縮で高品質ですがファイルサイズが大きくなります。MP4/MOV/MKV/FLVはH.264圧縮で容量と互換性のバランスを取ります。WMV/ASFはWindows Media Videoを生成します。MPG/VOBはMPEG2のプログラムストリームです。GIFは軽量ですが色数とフレームレートに制限があるアニメーション画像です。</value>
   </data>

--- a/Infrastructure/Resources/Strings.resx
+++ b/Infrastructure/Resources/Strings.resx
@@ -293,6 +293,9 @@ Please obtain an API key from the website.</value>
   <data name="AutoRecording_FormatOption_GIF" xml:space="preserve">
     <value>GIF (animated image)</value>
   </data>
+  <data name="AutoRecording_IncludeOverlay" xml:space="preserve">
+    <value>Include overlay windows in recordings</value>
+  </data>
   <data name="AutoRecording_FormatHelp" xml:space="preserve">
     <value>AVI creates lossless recordings but results in large files. MP4, MOV, MKV, and FLV use H.264 to balance size and compatibility. WMV and ASF produce Windows Media Video files. MPG and VOB generate MPEG-2 program streams. GIF produces lightweight animated images with limited colors and frame rate.</value>
   </data>

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -662,6 +662,7 @@ namespace ToNRoundCounter.UI
                     _settings.AutoRecordingEnabled = settingsForm.SettingsPanel.AutoRecordingEnabledCheckBox.Checked;
                     _settings.AutoRecordingWindowTitle = settingsForm.SettingsPanel.AutoRecordingWindowTitleTextBox.Text?.Trim() ?? string.Empty;
                     _settings.AutoRecordingFrameRate = (int)settingsForm.SettingsPanel.AutoRecordingFrameRateNumeric.Value;
+                    _settings.AutoRecordingIncludeOverlay = settingsForm.SettingsPanel.AutoRecordingIncludeOverlayCheckBox.Checked;
                     _settings.AutoRecordingOutputDirectory = settingsForm.SettingsPanel.AutoRecordingOutputDirectoryTextBox.Text?.Trim() ?? string.Empty;
                     _settings.AutoRecordingOutputExtension = settingsForm.SettingsPanel.GetAutoRecordingOutputExtension();
                     _settings.AutoRecordingRoundTypes = settingsForm.SettingsPanel.GetAutoRecordingRoundTypes();

--- a/UI/SettingsPanel.cs
+++ b/UI/SettingsPanel.cs
@@ -115,6 +115,7 @@ namespace ToNRoundCounter.UI
         public CheckBox AutoRecordingEnabledCheckBox { get; private set; } = null!;
         public TextBox AutoRecordingWindowTitleTextBox { get; private set; } = null!;
         public NumericUpDown AutoRecordingFrameRateNumeric { get; private set; } = null!;
+        public CheckBox AutoRecordingIncludeOverlayCheckBox { get; private set; } = null!;
         public TextBox AutoRecordingOutputDirectoryTextBox { get; private set; } = null!;
         public ComboBox AutoRecordingFormatComboBox { get; private set; } = null!;
         public CheckedListBox AutoRecordingRoundTypesListBox { get; private set; } = null!;
@@ -1042,7 +1043,15 @@ namespace ToNRoundCounter.UI
             autoRecordingFpsLabel.Location = new Point(AutoRecordingFrameRateNumeric.Right + 8, AutoRecordingFrameRateNumeric.Top + 4);
             grpAutoRecording.Controls.Add(autoRecordingFpsLabel);
 
-            autoRecordingInnerY = AutoRecordingFrameRateNumeric.Bottom + 10;
+            autoRecordingInnerY = AutoRecordingFrameRateNumeric.Bottom + 8;
+
+            AutoRecordingIncludeOverlayCheckBox = new CheckBox();
+            AutoRecordingIncludeOverlayCheckBox.Text = LanguageManager.Translate("AutoRecording_IncludeOverlay");
+            AutoRecordingIncludeOverlayCheckBox.AutoSize = true;
+            AutoRecordingIncludeOverlayCheckBox.Location = new Point(innerMargin, autoRecordingInnerY);
+            grpAutoRecording.Controls.Add(AutoRecordingIncludeOverlayCheckBox);
+
+            autoRecordingInnerY = AutoRecordingIncludeOverlayCheckBox.Bottom + 10;
 
             Label autoRecordingOutputLabel = new Label();
             autoRecordingOutputLabel.Text = LanguageManager.Translate("出力フォルダー");
@@ -1133,6 +1142,7 @@ namespace ToNRoundCounter.UI
             AutoRecordingFrameRateNumeric.Value = Math.Min(Math.Max(_settings.AutoRecordingFrameRate, 5), 60);
             AutoRecordingOutputDirectoryTextBox.Text = _settings.AutoRecordingOutputDirectory;
             AutoRecordingEnabledCheckBox.Checked = _settings.AutoRecordingEnabled;
+            AutoRecordingIncludeOverlayCheckBox.Checked = _settings.AutoRecordingIncludeOverlay;
             SetAutoRecordingFormat(_settings.AutoRecordingOutputExtension);
             SetAutoRecordingRoundTypes(_settings.AutoRecordingRoundTypes);
             SetAutoRecordingTerrors(_settings.AutoRecordingTerrors);
@@ -2564,6 +2574,10 @@ namespace ToNRoundCounter.UI
             if (AutoRecordingFrameRateNumeric != null)
             {
                 AutoRecordingFrameRateNumeric.Enabled = enabled;
+            }
+            if (AutoRecordingIncludeOverlayCheckBox != null)
+            {
+                AutoRecordingIncludeOverlayCheckBox.Enabled = enabled;
             }
             if (AutoRecordingOutputDirectoryTextBox != null)
             {


### PR DESCRIPTION
## Summary
- create a DXGI factory to enumerate hardware adapters and prefer NVIDIA GPUs and higher memory devices for Media Foundation hardware encoding
- fall back to the default adapter when enumeration fails while enabling D3D11 video support flags and multithread protection
- wire DXGI device manager setup to release resources cleanly after attempting hardware initialization
- add a settings-controlled option to include overlay windows in built-in auto recordings and route the capture loop through screen grabs when requested

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c4a5d6248329aaecc92e7e7ffbe5