### PR TITLE
Add audio capture to auto recording

### DIFF
--- a/Infrastructure/Resources/Strings.ja.resx
+++ b/Infrastructure/Resources/Strings.ja.resx
@@ -299,6 +299,12 @@ APIキーはwebサイトから取得してください。</value>
   <data name="AutoRecording_FormatHelp" xml:space="preserve">
     <value>AVIは非圧縮で高品質ですがファイルサイズが大きくなります。MP4/MOV/MKV/FLVはH.264圧縮で容量と互換性のバランスを取ります。WMV/ASFはWindows Media Videoを生成します。MPG/VOBはMPEG2のプログラムストリームです。GIFは軽量ですが色数とフレームレートに制限があるアニメーション画像です。</value>
   </data>
+  <data name="AutoRecording_AdminElevationPrompt" xml:space="preserve">
+    <value>VRChatの音声を録音するには管理者権限が必要です。管理者権限でToNRoundCounterを再起動しますか？</value>
+  </data>
+  <data name="AutoRecording_AdminElevationTitle" xml:space="preserve">
+    <value>管理者権限の確認</value>
+  </data>
   <data name="録画開始テラー" xml:space="preserve">
     <value>録画開始テラー</value>
   </data>

--- a/Infrastructure/Resources/Strings.resx
+++ b/Infrastructure/Resources/Strings.resx
@@ -299,6 +299,12 @@ Please obtain an API key from the website.</value>
   <data name="AutoRecording_FormatHelp" xml:space="preserve">
     <value>AVI creates lossless recordings but results in large files. MP4, MOV, MKV, and FLV use H.264 to balance size and compatibility. WMV and ASF produce Windows Media Video files. MPG and VOB generate MPEG-2 program streams. GIF produces lightweight animated images with limited colors and frame rate.</value>
   </data>
+  <data name="AutoRecording_AdminElevationPrompt" xml:space="preserve">
+    <value>Capturing VRChat audio requires administrator privileges. Restart ToNRoundCounter with elevated permissions now?</value>
+  </data>
+  <data name="AutoRecording_AdminElevationTitle" xml:space="preserve">
+    <value>Administrator privileges required</value>
+  </data>
   <data name="録画開始テラー" xml:space="preserve">
     <value>Trigger terror names</value>
   </data>


### PR DESCRIPTION
## Summary
- extend the auto recording service with Media Foundation writers, WASAPI loopback capture, and Core Audio interop so window audio is captured with video
- hook auto-recording enablement to prompt for an elevated restart when admin rights are required and relaunch with runas when accepted
- localize the new elevation prompt strings in both English and Japanese resources

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e446498bc48329a87c9fc6b503b794