### PR TITLE
Handle repeated terror events and delay auto suicide

### DIFF
--- a/ToNRoundCounter.Tests/AutoSuicideCancelTests.cs
+++ b/ToNRoundCounter.Tests/AutoSuicideCancelTests.cs
@@ -62,6 +62,28 @@ namespace ToNRoundCounter.Tests
             Assert.False(triggered);
             Assert.False(service.HasScheduled);
         }
+
+        [Fact]
+        public async Task TerrorRuleDelayReschedulesSuicide()
+        {
+            var service = new AutoSuicideService();
+            bool triggered = false;
+
+            service.Schedule(TimeSpan.FromMilliseconds(30), true, () => triggered = true);
+            await Task.Delay(10);
+
+            service.Schedule(TimeSpan.FromMilliseconds(80), false, () => triggered = true);
+
+            await Task.Delay(50);
+
+            Assert.False(triggered);
+            Assert.True(service.HasScheduled);
+
+            await Task.Delay(100);
+
+            Assert.True(triggered);
+            Assert.False(service.HasScheduled);
+        }
     }
 }
 

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1315,21 +1315,34 @@ namespace ToNRoundCounter.UI
                         {
                             CancelAutoSuicide();
                         }
+
                         if (issetAllSelfKillMode)
                         {
                             _ = Task.Run(() => PerformAutoSuicide());
                         }
                         else if (terrorAction == 1)
                         {
-                            _ = Task.Run(() => PerformAutoSuicide());
+                            ScheduleAutoSuicide(TimeSpan.FromSeconds(3), true, allRoundsForcedSchedule);
                         }
                         else if (terrorAction == 2)
                         {
-                            TimeSpan remaining = TimeSpan.FromSeconds(40) - (DateTime.UtcNow - autoSuicideService.RoundStartTime);
-                            if (remaining > TimeSpan.Zero)
+                            var roundStart = autoSuicideService.RoundStartTime;
+                            bool resetStartTime = roundStart == default;
+                            TimeSpan remaining;
+                            if (resetStartTime)
                             {
-                                ScheduleAutoSuicide(remaining, false, allRoundsForcedSchedule);
+                                remaining = TimeSpan.FromSeconds(40);
                             }
+                            else
+                            {
+                                remaining = TimeSpan.FromSeconds(40) - (DateTime.UtcNow - roundStart);
+                                if (remaining < TimeSpan.Zero)
+                                {
+                                    remaining = TimeSpan.Zero;
+                                }
+                            }
+
+                            ScheduleAutoSuicide(remaining, resetStartTime, allRoundsForcedSchedule);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure successive TERRORS messages can override prior auto-suicide actions by rescheduling through the service
- introduce a 3 second delay before executing a standard auto-suicide trigger
- add a regression test covering delayed rescheduling behaviour of the auto-suicide service

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4f053a6dc832987113af986188edd