### PR TITLE
Fix WASAPI capture handler signature to support ReadOnlySpan

### DIFF
--- a/Application/AutoRecordingService.cs
+++ b/Application/AutoRecordingService.cs
@@ -1928,7 +1928,9 @@ namespace ToNRoundCounter.Application
                 }
             }
 
-            public Task CaptureAsync(Action<ReadOnlySpan<byte>, int> handler, CancellationToken token)
+            public delegate void AudioBufferHandler(ReadOnlySpan<byte> buffer, int frames);
+
+            public Task CaptureAsync(AudioBufferHandler handler, CancellationToken token)
             {
                 if (handler == null)
                 {
@@ -1939,7 +1941,7 @@ namespace ToNRoundCounter.Application
                 return Task.CompletedTask;
             }
 
-            private void RunCapture(Action<ReadOnlySpan<byte>, int> handler, CancellationToken token)
+            private void RunCapture(AudioBufferHandler handler, CancellationToken token)
             {
                 if (_disposed)
                 {
@@ -1973,7 +1975,7 @@ namespace ToNRoundCounter.Application
                 }
             }
 
-            private void DrainPackets(Action<ReadOnlySpan<byte>, int> handler, CancellationToken token)
+            private void DrainPackets(AudioBufferHandler handler, CancellationToken token)
             {
                 while (!token.IsCancellationRequested)
                 {


### PR DESCRIPTION
## Summary
- introduce a dedicated AudioBufferHandler delegate for WASAPI capture callbacks
- update capture methods to use the new delegate instead of Action to support ReadOnlySpan parameters

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f089d27083298f61424d06900149