### PR TITLE
Fix MainForm disposal duplicate and enable nullable context

### DIFF
--- a/Application/AutoRecordingService.cs
+++ b/Application/AutoRecordingService.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/UI/MainForm.Designer.cs
+++ b/UI/MainForm.Designer.cs
@@ -7,41 +7,6 @@
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                UnsubscribeEventBus();
-                velocityTimer?.Stop();
-                velocityTimer?.Dispose();
-                oscListener?.Stop();
-                _cancellation.Cancel();
-                overlayVisibilityTimer?.Stop();
-                overlayVisibilityTimer?.Dispose();
-                foreach (var form in overlayForms.Values)
-                {
-                    if (form == null)
-                    {
-                        continue;
-                    }
-
-                    if (!form.IsDisposed)
-                    {
-                        form.Hide();
-                        form.Close();
-                    }
-                    form.Dispose();
-                }
-                overlayForms.Clear();
-                components?.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Windows Form Designer generated code
 
         /// <summary>

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1100,6 +1100,33 @@ namespace ToNRoundCounter.UI
         {
             if (disposing)
             {
+                UnsubscribeEventBus();
+                velocityTimer?.Stop();
+                velocityTimer?.Dispose();
+                oscListener?.Stop();
+                _cancellation.Cancel();
+                overlayVisibilityTimer?.Stop();
+                overlayVisibilityTimer?.Dispose();
+
+                foreach (var form in overlayForms.Values)
+                {
+                    if (form == null)
+                    {
+                        continue;
+                    }
+
+                    if (!form.IsDisposed)
+                    {
+                        form.Hide();
+                        form.Close();
+                    }
+
+                    form.Dispose();
+                }
+
+                overlayForms.Clear();
+                components?.Dispose();
+
                 try
                 {
                     _uiLogQueue.CompleteAdding();


### PR DESCRIPTION
## Summary
- consolidate MainForm disposal logic into the main partial class to avoid duplicate overrides
- remove the designer-generated Dispose override that caused CS0111
- enable nullable reference annotations in AutoRecordingService by turning on nullable context

## Testing
- not run (dotnet CLI is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e5095e9e30832983761a10b1a70902